### PR TITLE
Add branch strategy, PR template, and contributing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR do? Keep it brief. -->
+
+## Motivation
+
+<!-- Why is this change needed? Link to an issue if applicable. -->
+
+## Changes
+
+-
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING guide](../CONTRIBUTING.md)
+- [ ] My changes follow the existing code style
+- [ ] I have tested my changes locally
+- [ ] I have added/updated documentation as needed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to Gleisner
+
+Thank you for your interest in contributing to Gleisner! This document explains how to get involved.
+
+## Branch Strategy
+
+We use **GitHub Flow**:
+
+1. **`main`** is always the stable, deployable branch
+2. Create a **feature branch** from `main` for your work
+3. Open a **Pull Request** to merge back into `main`
+
+Direct pushes to `main` are not allowed — all changes go through PRs.
+
+### Branch naming
+
+Use descriptive names with a prefix:
+
+- `feat/multi-track-player` — new feature
+- `fix/timeline-scroll-bug` — bug fix
+- `docs/update-adr-format` — documentation
+- `refactor/api-response-types` — refactoring
+
+## How to Contribute
+
+### Reporting Issues
+
+- Search existing issues before creating a new one
+- Include steps to reproduce for bug reports
+- For feature requests, explain the use case and motivation
+
+### Submitting a Pull Request
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes
+4. Ensure your code follows the existing style
+5. Open a PR with a clear description using the PR template
+
+### Architecture Decision Records
+
+Significant design decisions are documented in `docs/decisions/`. If your contribution involves an architectural change, please propose an ADR as part of your PR.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [AGPL v3](LICENSE).


### PR DESCRIPTION
## Summary

- Establish GitHub Flow as the branch strategy
- Add branch protection rules on `main` (require PR, no force push)
- Add PR template and CONTRIBUTING.md

## Motivation

Gleisner is open source (AGPL v3) and needs to accommodate external contributions. A clear branch strategy and contribution guide are essential from day one.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md` — PR template with summary, motivation, changes, checklist
- `CONTRIBUTING.md` — Branch naming conventions, workflow, and contribution guidelines
- Branch protection ruleset configured via GitHub API

## Checklist

- [x] I have read the [CONTRIBUTING guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] I have tested my changes locally
- [x] I have added/updated documentation as needed