### PR TITLE
Add idea 007: live streaming as premium plugin

### DIFF
--- a/docs/ideas/007-live-streaming.md
+++ b/docs/ideas/007-live-streaming.md
@@ -1,0 +1,17 @@
+# Idea 007: Live Streaming as a Premium Plugin
+
+**Status:** Raw idea
+**Date:** 2026-03-16
+
+## Summary
+
+Add live streaming as a paid plugin feature, separate from the core posting flow. Streams would have a prominent, dedicated tab for fans, and automatically post the recording to the timeline when ended.
+
+## Notes
+
+- **Positioning as paid feature**: Live streaming should be a premium plugin, not part of the base feature set — development and maintenance cost is high
+- **UX differentiation**: Since it's a paid feature, the UI should give it a sense of "special" presence — more prominent than free media types, with its own dedicated navigation (e.g., a "Live" tab that stands out)
+- **Fan-side experience**: When a stream starts, fans see the streaming tab highlighted; opening it shows the live stream with comments and tipping (super chat style) — standard live streaming interactions
+- **Auto-post recording**: When the stream ends, the recording is automatically posted to the creator's timeline — no extra steps needed
+- **Routing decision (open)**: Whether to integrate streaming as a media type within the existing post model or treat it as a completely separate route is still undecided
+- **Development strategy**: Should be developed later as a standalone paid plugin, not bundled into the initial release — allows focused, quality development without delaying core features


### PR DESCRIPTION
## Summary
- ライブストリーミングを有料プラグインとして提供するアイデアを記録
- 配信終了後にタイムラインへ自動投稿、ファン側のライブタブ等の構想

🤖 Generated with [Claude Code](https://claude.com/claude-code)