### PR TITLE
Update Discover mockup for ADR 011 and add Profile/Artist Page ADR

### DIFF
--- a/docs/decisions/013-profile-and-artist-page.md
+++ b/docs/decisions/013-profile-and-artist-page.md
@@ -1,0 +1,236 @@
+# ADR 013: Profile & Artist Page — User Identity and Creative Identity Separation
+
+## Status
+
+Draft
+
+## Context
+
+The bottom navigation has three tabs: Timeline, Discover, and Profile. As we designed the Profile tab, a fundamental question emerged: an artist-registered user has two identities — a personal identity (fan/user) and a creative identity (artist). Mixing both in a single "Profile" screen creates confusion around:
+
+- What "follow" means (user-to-user vs fan-to-artist)
+- What information is displayed (personal bio vs artist portfolio)
+- How the page evolves (a user profile is relatively static; an artist page becomes a rich, customizable hub)
+
+This ADR separates the two concepts and defines the relationship system between users and artists.
+
+## Decision
+
+### Two Distinct Concepts
+
+| Concept | Who has it | Purpose | Location |
+|---------|-----------|---------|----------|
+| **Profile** | Every user | Personal identity and social connections | Bottom nav "Profile" tab |
+| **Artist Page** | Artist-registered users only | Creative identity and public-facing artist hub | Navigated from Profile, Discover, or direct link |
+
+### Profile (Bottom Nav Tab)
+
+The Profile tab displays the user's personal identity:
+
+- Avatar, display name, username
+- Bio / self-introduction
+- User-to-user follow stats (following / followers)
+- **Recent fan activity**: A chronological feed of the user's activity as a fan — comments, reactions, Tune Ins. Shows "what this person has been engaging with" publicly
+- **For artist-registered users**: A prominent link to "Your Artist Page"
+- **Self view**: Edit button (inline editing of name, bio, avatar) + Settings link
+- **Other's view**: Read-only + Follow button (user-to-user)
+
+#### Messaging
+
+Users who mutually follow each other can exchange direct messages. Messaging is available from the other user's Profile page when a mutual follow exists. This keeps messaging tied to the social (Follow) relationship, not the creative (Tune In) relationship — fans cannot DM artists simply by Tuning In.
+
+### Artist Page
+
+The Artist Page is the public-facing creative identity. The full timeline is accessed via the Timeline tab, but the Artist Page includes a **Recent Posts preview** to give visitors a taste of the artist's activity before Tuning In.
+
+#### MVP Structure (Section-Based)
+
+The page is composed of ordered sections, designed for future plugin extensibility:
+
+```
+┌─────────────────────────────┐
+│ Header                      │
+│  Avatar / Name / Username   │
+│  [Tune In] button           │
+│  Tuned In: 12.4k            │
+├─────────────────────────────┤
+│ Genres                      │
+│  [Music] [Flamenco] [Electronic] │
+├─────────────────────────────┤
+│ About                       │
+│  Artist introduction text   │
+├─────────────────────────────┤
+│ Tracks                      │
+│  ● Play  ● Compose  ● Life │
+│  (track colors + names)     │
+├─────────────────────────────┤
+│ Recent Posts                │
+│  Simplified timeline preview│
+│  (latest 3–5 posts, compact)│
+└─────────────────────────────┘
+```
+
+The Recent Posts section has two subsections:
+
+- **Latest**: The most recent 3–5 posts in chronological order — shows what the artist is currently working on
+- **Popular**: The top 3–5 posts by engagement — shows the artist's best/most resonant work
+
+Both are displayed as compact cards (not the full constellation layout). Their purpose is to increase Tune In conversion by letting visitors see both the artist's current activity and their highlights before committing.
+
+#### Future Extensibility
+
+The section-based layout allows plugin sections to be added:
+
+```
+MVP sections:
+  Header / Genres / About / Tracks / Recent Posts
+
+Future plugin sections (examples):
+  📦 Merch Store
+  🎫 Ticket Sales / Event Calendar
+  📰 Newsletter
+  🔗 External Links
+  🌐 Embedded Website (webview of artist's own HP)
+  💬 Community / Fan Wall
+  📊 Activity Stats (public)
+```
+
+Each section is an independent component. Artists can reorder, show/hide, and configure sections. Third-party plugin sections follow the same interface.
+
+- **Self view**: Edit mode for all sections + section management (reorder, show/hide, add plugins)
+- **Other's view**: Read-only
+
+### Relationship System: Follow vs Tune In
+
+Two distinct relationship types with different terminology:
+
+| Relationship | Term | Direction | Meaning |
+|-------------|------|-----------|---------|
+| User ↔ User | **Follow** | Bidirectional (each direction independent) | Social connection. "I know this person" |
+| Fan → Artist | **Tune In** | One-way (fan → artist only) | "I want to receive this artist's timeline" |
+
+#### Why "Tune In"
+
+- Aligns with Gleisner's DAW/broadcast metaphor: the artist broadcasts, the fan tunes in
+- Naturally one-directional: a radio station doesn't "tune in" to its listeners
+- No ambiguity with user-to-user "follow"
+- "Tuned In: 12.4k" reads naturally as a count
+
+#### Tune In Behavior
+
+1. User visits an Artist Page
+2. Taps "Tune In"
+3. The artist is added to the avatar rail
+4. **Automatic navigation**: The app navigates to the Timeline tab with the newly Tuned In artist selected by default — the user immediately sees their timeline
+5. Returning to the Artist Page later shows "Tuned In ✓" + a "View Timeline" link
+6. "View Timeline" navigates to the Timeline tab with that artist selected
+7. "Tune Out" reverses the action (available from Artist Page or settings)
+
+#### Artist-side: No reciprocal Tune In
+
+Artists cannot "Tune In" to fans as artists. The relationship is intentionally asymmetric. An artist who wants to follow another artist's creative work Tunes In like any other fan. An artist who wants a personal social connection with someone uses the standard Follow.
+
+### Timeline Tab: Avatar Rail
+
+When a user has Tuned In to one or more artists, the Timeline tab displays an **avatar rail** below the header — a horizontal row of circular avatars:
+
+```
+┌─────────────────────────────────────┐  ← sticky
+│ ◉ Yuta        ♪ TUNED IN     LIVE  │  ← avatar(small) + name + status badge
+│ [● Play] [● Compose] [● Life] ...  │  ← track chips (Solo/Mute)
+├─────────────────────────────────────┤  ← scrolls with content
+│ ◉ ◎ ○ ○ ○ ○ ○ →                   │  ← Avatar rail
+├─────────────────────────────────────┤
+│ Timeline content                    │
+│ ...                                 │
+```
+
+#### Timeline Header
+
+The sticky header shows context about the currently viewed artist:
+
+- **Small avatar** (24–28px circle) + **artist name**: Immediately communicates whose timeline is being viewed
+- **Status badge**: Contextual indicator next to the name
+  - "TUNED IN" — viewing another artist's timeline (Fan Mode)
+  - "ARTIST" — viewing own timeline in Artist Mode (ADR 008)
+  - No badge — when viewing own timeline in Fan Mode (default)
+- **Track chips**: Solo/Mute controls for the current artist's tracks, always accessible
+
+This ensures that even when the avatar rail has scrolled out of view, the user always knows whose timeline they are viewing and their relationship to that artist.
+
+#### Avatar Rail Position
+
+The avatar rail is placed **below the sticky header (including track chips)** and **scrolls with the timeline content**. This is a deliberate trade-off:
+
+- **Track chips must remain sticky**: Solo/Mute filtering applies to the currently viewed timeline and should always be accessible
+- **Avatar rail should not consume persistent screen space**: the rail is only needed when switching artists, not during timeline browsing. Scrolling it away preserves vertical space for the constellation layout
+- **Semantic ordering** (artist selection above track selection) would be more logical, but the sticky/scroll constraint takes priority
+
+#### Avatar Rail Behavior
+
+- Avatars are ordered by **most recent update** (artists with new posts first)
+- Avatars with **unread posts** have a colored ring (using the artist's primary genre color)
+- Tapping an avatar switches the timeline to that artist's content (header updates accordingly)
+- The currently selected avatar is highlighted (larger or different border style)
+- If the user is an artist-registered user, their own avatar appears in the rail for switching to Artist Mode (ADR 008)
+- Inspired by Instagram Stories UX but adapted for Gleisner's context: these are not ephemeral stories but persistent timeline switches
+- **Persistence**: The currently selected artist is persisted locally (ADR 009). On app restart, the Timeline tab restores the last viewed artist — the user always returns to exactly where they left off
+
+#### Rail Population
+
+- Shows all Tuned In artists + self (if artist-registered)
+- Scrollable horizontally when many artists are Tuned In
+
+#### Empty State (No Tune Ins)
+
+When the user has not Tuned In to any artist, the Timeline tab shows:
+
+- No avatar rail (nothing to show)
+- An empty state screen with a prompt: "Tune In to artists to see their timelines here" + a prominent link to the Discover tab
+- No default timeline content is shown (the user has no content to display until they Tune In or create their own as an artist)
+
+Future enhancement (post-MVP): A tutorial/onboarding flow that guides first-time users through Discover → first Tune In → Timeline, reducing the cold-start problem.
+
+### Navigation Flow
+
+```
+Bottom Nav: Profile
+  → Self Profile
+    → Recent fan activity (comments, reactions, Tune Ins)
+    → [Your Artist Page] → Self Artist Page (edit mode)
+    → [Settings] → Settings screen
+    → [Message] (on other's Profile, if mutual follow)
+  → Other's Profile (via search, follower list, etc.)
+    → [Follow] / [Unfollow]
+
+Bottom Nav: Discover
+  → Tap artist card → Artist Page (other's, read-only)
+    → [Tune In] → auto-navigate to Timeline tab (artist selected)
+    → (if already Tuned In) [View Timeline] → Timeline tab (artist selected)
+    → Also shows link to user's Profile
+
+Bottom Nav: Timeline
+  → Avatar rail → tap avatar → switch to that artist's timeline
+  → Avatar rail → tap self → Artist Mode (ADR 008)
+  → Empty state (no Tune Ins) → prompt to Discover tab
+```
+
+## Consequences
+
+- Clear separation between personal and creative identity
+- "Follow" and "Tune In" are unambiguous — no user confusion about what each action does
+- The avatar rail provides a lightweight, performant alternative to tabs for timeline switching
+- Section-based Artist Page architecture supports future plugin extensibility without redesigning the page
+- Recent Posts preview on Artist Page increases Tune In conversion without duplicating the full timeline
+- Tune In → auto-navigate to Timeline creates an immediate "reward" for the action, reinforcing the value of Tuning In
+- Artist-registered users manage two pages (Profile + Artist Page), which adds complexity but accurately reflects the dual identity
+- The asymmetric Tune In model aligns with the Egan principle of self-determination: artists broadcast, fans choose what to receive
+- Messaging tied to mutual Follow (not Tune In) protects artists from unsolicited fan DMs while enabling social connections
+- Fan activity feed on Profile adds a social layer without cluttering the creative-focused Artist Page
+
+## Related
+
+- ADR 008 — Artist Mode & content management (mode switching, now triggered via avatar rail)
+- ADR 009 — Discover tab (artist selection now navigates to Artist Page instead of directly to Timeline)
+- ADR 011 — Genre system (genres displayed on Artist Page)
+- ADR 012 — Track system redesign (tracks displayed on Artist Page)

--- a/docs/mockups/discover-v1.html
+++ b/docs/mockups/discover-v1.html
@@ -78,6 +78,22 @@
   /* Empty state */
   .empty{text-align:center;padding:40px 20px;color:var(--text3);font-size:13px}
 
+  /* Disclosure link */
+  .disclosure{text-align:center;padding:16px 14px 8px}
+  .disclosure a{font-family:var(--mono);font-size:10px;color:var(--text3);text-decoration:none;transition:color .15s}
+  .disclosure a:hover{color:var(--text2)}
+
+  /* Disclosure sheet */
+  .disc-ov{position:fixed;inset:0;background:rgba(0,0,0,.85);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);z-index:500;display:none;align-items:flex-end;justify-content:center}
+  .disc-ov.vis{display:flex}
+  .disc-sheet{background:var(--bg2);border-radius:20px 20px 0 0;width:100%;max-width:420px;max-height:70dvh;overflow-y:auto;padding:20px 20px calc(20px + env(safe-area-inset-bottom));animation:su .3s ease}
+  @keyframes su{from{transform:translateY(100%)}to{transform:translateY(0)}}
+  .disc-sheet h3{font-size:16px;font-weight:600;margin-bottom:14px}
+  .disc-sheet p{font-size:13px;color:var(--text2);line-height:1.7;margin-bottom:12px}
+  .disc-sheet .dl-label{font-family:var(--mono);font-size:9px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--text3);margin-bottom:4px}
+  .disc-close{font-family:var(--mono);font-size:12px;color:var(--text3);cursor:pointer;text-align:center;padding:12px 0 0;transition:color .15s}
+  .disc-close:hover{color:var(--text2)}
+
   /* Toast */
   .toast{position:fixed;bottom:100px;left:50%;transform:translateX(-50%);background:var(--bg3);border:1px solid var(--border);border-radius:10px;padding:10px 18px;font-size:12px;color:var(--text2);z-index:1000;font-family:var(--mono);box-shadow:0 4px 20px rgba(0,0,0,.5);transition:opacity .3s;pointer-events:none}
 
@@ -102,6 +118,24 @@
 
 <div class="main" id="main"></div>
 
+<!-- Disclosure bottom sheet (ADR 011: transparency) -->
+<div class="disc-ov" id="discOv" onclick="closeDisc()">
+  <div class="disc-sheet" onclick="event.stopPropagation()">
+    <h3>発見の仕組み</h3>
+    <div class="dl-label">ジャンルについて</div>
+    <p>ジャンルはアーティスト本人が自分で選択しています。プラットフォームやアルゴリズムによる分類ではありません。1人あたり最大5つまで設定できます。</p>
+    <div class="dl-label">Discover の表示基準</div>
+    <p>一定数以上のアーティストが選択したジャンルがフィルタチップとして表示されます。各チップの数字はそのジャンルのアーティスト数です。</p>
+    <div class="dl-label">ジャンル候補の提案</div>
+    <p>ジャンル入力時の候補は、既存ジャンルとの類似性に基づいて提案されます。最終的な選択は常にアーティスト自身が行います。</p>
+    <div class="dl-label">HIGH SIGNAL</div>
+    <p>トレンド表示はエンゲージメント量（リアクション・コメント・閲覧数）に基づいています。アルゴリズムによる推薦ではありません。</p>
+    <div class="dl-label">RECENTLY JOINED</div>
+    <p>新着アーティストは参加日の時系列順に表示されます。ランキングやスコアリングは行いません。</p>
+    <div class="disc-close" onclick="closeDisc()">閉じる</div>
+  </div>
+</div>
+
 <div class="bn">
   <a class="ni" href="timeline-v1.html"><svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>Timeline</a>
   <div class="ni a"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>Discover</div>
@@ -109,37 +143,74 @@
 </div>
 
 <script>
-// === Genre color mapping ===
-const GENRE_C={
+// === Genre color palette ===
+// Known genres get curated colors; unknown genres get a deterministic hash color
+const GENRE_PALETTE={
   Music:{c:'#f97316',rgb:'249,115,22'},
+  Flamenco:{c:'#ef4444',rgb:'239,68,68'},
+  Electronic:{c:'#06b6d4',rgb:'6,182,212'},
+  Ambient:{c:'#6366f1',rgb:'99,102,241'},
+  'Lo-fi':{c:'#78716c',rgb:'120,113,108'},
+  Jazz:{c:'#eab308',rgb:'234,179,8'},
+  'Singer-Songwriter':{c:'#fb923c',rgb:'251,146,60'},
   'Visual Art':{c:'#a78bfa',rgb:'167,139,250'},
+  'Digital Art':{c:'#c084fc',rgb:'192,132,252'},
+  'Generative Art':{c:'#818cf8',rgb:'129,140,248'},
+  Illustration:{c:'#a78bfa',rgb:'167,139,250'},
   Writing:{c:'#22d3ee',rgb:'34,211,238'},
+  Poetry:{c:'#67e8f9',rgb:'103,232,249'},
+  Essay:{c:'#2dd4bf',rgb:'45,212,191'},
   Film:{c:'#84cc16',rgb:'132,204,22'},
+  'Short Film':{c:'#a3e635',rgb:'163,230,53'},
+  Documentary:{c:'#65a30d',rgb:'101,163,13'},
+  'Motion Graphics':{c:'#bef264',rgb:'190,242,100'},
   Photography:{c:'#e879f9',rgb:'232,121,249'},
-  Multi:{c:'#fbbf24',rgb:'251,191,36'},
+  'Street Photography':{c:'#f0abfc',rgb:'240,171,252'},
+  'Hardware Art':{c:'#fbbf24',rgb:'251,191,36'},
+  DIY:{c:'#f59e0b',rgb:'245,158,11'},
 };
+function genreColor(genre){
+  if(GENRE_PALETTE[genre])return GENRE_PALETTE[genre];
+  // Deterministic hash color for unknown genres
+  let h=0;for(let i=0;i<genre.length;i++)h=((h<<5)-h+genre.charCodeAt(i))|0;
+  const hue=((h%360)+360)%360;
+  const r=Math.round(180+50*Math.cos(hue*Math.PI/180));
+  const g=Math.round(180+50*Math.cos((hue-120)*Math.PI/180));
+  const b=Math.round(180+50*Math.cos((hue+120)*Math.PI/180));
+  return{c:`rgb(${r},${g},${b})`,rgb:`${r},${g},${b}`};
+}
 
 // === Dummy data: 15 artists ===
+// genres[] = self-declared (ADR 011), max 5 per artist
+// tracks[] = personal timeline tracks (ADR 012), separate concept
 const ARTISTS=[
-  {id:'a01',name:'yuta_flamenco',displayName:'Yuta',tagline:'Flamenco × electronic. Building bridges between worlds.',tracks:['Music','Film'],genre:'Music',followers:12400,trending:true,trendingTrack:'Music',isNew:false,latestPost:'Rasgueado drill session',joinedDaysAgo:180},
-  {id:'a02',name:'luna_synth',displayName:'Luna Synth',tagline:'Ambient textures and modular synthesis. Sound as architecture.',tracks:['Music','Visual Art'],genre:'Music',followers:8700,trending:true,trendingTrack:'Music',isNew:false,latestPost:'Patch from scratch vol.12',joinedDaysAgo:95},
-  {id:'a03',name:'echo_drift',displayName:'Echo Drift',tagline:'Lo-fi beats and field recordings from Tokyo streets.',tracks:['Music'],genre:'Music',followers:5300,trending:false,trendingTrack:null,isNew:false,latestPost:'Shibuya rain loop',joinedDaysAgo:210},
-  {id:'a04',name:'neon_arc',displayName:'Neon Arc',tagline:'Digital painter. Generative art meets human emotion.',tracks:['Visual Art'],genre:'Visual Art',followers:15200,trending:true,trendingTrack:'Visual Art',isNew:false,latestPost:'Series: Polycosmos #47',joinedDaysAgo:310},
-  {id:'a05',name:'sol_wave',displayName:'Sol Wave',tagline:'Singer-songwriter. Stories from the coastline.',tracks:['Music','Writing'],genre:'Music',followers:3100,trending:false,trendingTrack:null,isNew:false,latestPost:'Acoustic demo: Tidal',joinedDaysAgo:150},
-  {id:'a06',name:'prism_lens',displayName:'Prism Lens',tagline:'Street photography. Finding beauty in the mundane.',tracks:['Photography'],genre:'Photography',followers:9800,trending:true,trendingTrack:'Photography',isNew:false,latestPost:'Golden hour series #8',joinedDaysAgo:270},
-  {id:'a07',name:'ink_flow',displayName:'Ink Flow',tagline:'Poetry and prose. Words as constellations.',tracks:['Writing'],genre:'Writing',followers:2400,trending:false,trendingTrack:null,isNew:false,latestPost:'Micro-fiction: The Last Polis',joinedDaysAgo:120},
-  {id:'a08',name:'frame_ghost',displayName:'Frame Ghost',tagline:'Experimental short films. Reality is a rough cut.',tracks:['Film','Photography'],genre:'Film',followers:6100,trending:true,trendingTrack:'Film',isNew:false,latestPost:'48hr film challenge entry',joinedDaysAgo:85},
-  {id:'a09',name:'moss_garden',displayName:'Moss Garden',tagline:'Botanical illustrations and nature journaling.',tracks:['Visual Art','Writing'],genre:'Visual Art',followers:4200,trending:false,trendingTrack:null,isNew:false,latestPost:'Fern study watercolor',joinedDaysAgo:190},
-  {id:'a10',name:'circuit_poet',displayName:'Circuit Poet',tagline:'Hardware hacking as art. Bending signals into songs.',tracks:['Music','Visual Art','Film'],genre:'Multi',followers:7600,trending:false,trendingTrack:null,isNew:false,latestPost:'DIY synth build log',joinedDaysAgo:60},
-  {id:'a11',name:'pixel_rain',displayName:'Pixel Rain',tagline:'Motion graphics and visual storytelling.',tracks:['Film','Visual Art'],genre:'Film',followers:1800,trending:false,trendingTrack:null,isNew:true,latestPost:'First upload: Glitch manifesto',joinedDaysAgo:3},
-  {id:'a12',name:'dawn_chorus',displayName:'Dawn Chorus',tagline:'Classical guitar meets jazz harmony.',tracks:['Music'],genre:'Music',followers:920,trending:false,trendingTrack:null,isNew:true,latestPost:'Chord melody: Autumn Leaves',joinedDaysAgo:5},
-  {id:'a13',name:'still_light',displayName:'Still Light',tagline:'Minimalist photography. Less is everything.',tracks:['Photography'],genre:'Photography',followers:1400,trending:false,trendingTrack:null,isNew:true,latestPost:'Series: Empty rooms',joinedDaysAgo:7},
-  {id:'a14',name:'verse_walker',displayName:'Verse Walker',tagline:'Essays on creativity, identity, and digital existence.',tracks:['Writing'],genre:'Writing',followers:650,trending:false,trendingTrack:null,isNew:true,latestPost:'On being a digital citizen',joinedDaysAgo:2},
-  {id:'a15',name:'deep_frame',displayName:'Deep Frame',tagline:'Documentary filmmaker. Stories that need to be told.',tracks:['Film','Photography','Writing'],genre:'Visual Art',followers:3800,trending:false,trendingTrack:null,isNew:false,latestPost:'Behind the scenes: Diaspora doc',joinedDaysAgo:140},
+  {id:'a01',name:'yuta_flamenco',displayName:'Yuta',tagline:'Flamenco × electronic. Building bridges between worlds.',genres:['Music','Flamenco','Electronic'],tracks:['Play','Compose','Life','English'],followers:12400,trending:true,isNew:false,latestPost:'Rasgueado drill session',joinedDaysAgo:180},
+  {id:'a02',name:'luna_synth',displayName:'Luna Synth',tagline:'Ambient textures and modular synthesis. Sound as architecture.',genres:['Music','Ambient','Generative Art'],tracks:['Synth','Visual','Journal'],followers:8700,trending:true,isNew:false,latestPost:'Patch from scratch vol.12',joinedDaysAgo:95},
+  {id:'a03',name:'echo_drift',displayName:'Echo Drift',tagline:'Lo-fi beats and field recordings from Tokyo streets.',genres:['Music','Lo-fi'],tracks:['Beats','Field Recording','Life'],followers:5300,trending:false,isNew:false,latestPost:'Shibuya rain loop',joinedDaysAgo:210},
+  {id:'a04',name:'neon_arc',displayName:'Neon Arc',tagline:'Digital painter. Generative art meets human emotion.',genres:['Digital Art','Generative Art'],tracks:['Works','Process','Thoughts'],followers:15200,trending:true,isNew:false,latestPost:'Series: Polycosmos #47',joinedDaysAgo:310},
+  {id:'a05',name:'sol_wave',displayName:'Sol Wave',tagline:'Singer-songwriter. Stories from the coastline.',genres:['Music','Singer-Songwriter','Poetry'],tracks:['Songs','Writing','Life'],followers:3100,trending:false,isNew:false,latestPost:'Acoustic demo: Tidal',joinedDaysAgo:150},
+  {id:'a06',name:'prism_lens',displayName:'Prism Lens',tagline:'Street photography. Finding beauty in the mundane.',genres:['Photography','Street Photography'],tracks:['Shots','Edits','BTS'],followers:9800,trending:true,isNew:false,latestPost:'Golden hour series #8',joinedDaysAgo:270},
+  {id:'a07',name:'ink_flow',displayName:'Ink Flow',tagline:'Poetry and prose. Words as constellations.',genres:['Writing','Poetry'],tracks:['Poetry','Prose','Thoughts'],followers:2400,trending:false,isNew:false,latestPost:'Micro-fiction: The Last Polis',joinedDaysAgo:120},
+  {id:'a08',name:'frame_ghost',displayName:'Frame Ghost',tagline:'Experimental short films. Reality is a rough cut.',genres:['Film','Short Film','Photography'],tracks:['Films','Photos','Log'],followers:6100,trending:true,isNew:false,latestPost:'48hr film challenge entry',joinedDaysAgo:85},
+  {id:'a09',name:'moss_garden',displayName:'Moss Garden',tagline:'Botanical illustrations and nature journaling.',genres:['Illustration','Writing'],tracks:['Drawings','Journal'],followers:4200,trending:false,isNew:false,latestPost:'Fern study watercolor',joinedDaysAgo:190},
+  {id:'a10',name:'circuit_poet',displayName:'Circuit Poet',tagline:'Hardware hacking as art. Bending signals into songs.',genres:['Music','Hardware Art','DIY','Visual Art'],tracks:['Builds','Sound','Visual','Log'],followers:7600,trending:false,isNew:false,latestPost:'DIY synth build log',joinedDaysAgo:60},
+  {id:'a11',name:'pixel_rain',displayName:'Pixel Rain',tagline:'Motion graphics and visual storytelling.',genres:['Motion Graphics','Digital Art'],tracks:['Works','Process'],followers:1800,trending:false,isNew:true,latestPost:'First upload: Glitch manifesto',joinedDaysAgo:3},
+  {id:'a12',name:'dawn_chorus',displayName:'Dawn Chorus',tagline:'Classical guitar meets jazz harmony.',genres:['Music','Jazz'],tracks:['Play','Practice','Life'],followers:920,trending:false,isNew:true,latestPost:'Chord melody: Autumn Leaves',joinedDaysAgo:5},
+  {id:'a13',name:'still_light',displayName:'Still Light',tagline:'Minimalist photography. Less is everything.',genres:['Photography'],tracks:['Photos','Words'],followers:1400,trending:false,isNew:true,latestPost:'Series: Empty rooms',joinedDaysAgo:7},
+  {id:'a14',name:'verse_walker',displayName:'Verse Walker',tagline:'Essays on creativity, identity, and digital existence.',genres:['Writing','Essay'],tracks:['Essays','Notes'],followers:650,trending:false,isNew:true,latestPost:'On being a digital citizen',joinedDaysAgo:2},
+  {id:'a15',name:'deep_frame',displayName:'Deep Frame',tagline:'Documentary filmmaker. Stories that need to be told.',genres:['Film','Documentary','Photography'],tracks:['Films','Stills','Writing','BTS'],followers:3800,trending:false,isNew:false,latestPost:'Behind the scenes: Diaspora doc',joinedDaysAgo:140},
 ];
 
-const CATEGORIES=['All','Music','Visual Art','Writing','Film','Photography'];
-let activeCategory='All';
+// === Dynamic genre chips from artist data (ADR 011) ===
+// Genres appearing on 1+ artists are shown (in production: threshold is N=3-5)
+function buildGenreChips(){
+  const counts={};
+  ARTISTS.forEach(a=>a.genres.forEach(g=>{counts[g]=(counts[g]||0)+1}));
+  // Sort by count desc, then alphabetical
+  return Object.entries(counts).sort((a,b)=>b[1]-a[1]||a[0].localeCompare(b[0]));
+}
+
+let activeGenre='All';
 let searchQuery='';
 
 // === Utilities (same as timeline-v1) ===
@@ -204,17 +275,17 @@ function fmtFollowers(n){
 }
 
 function getColor(artist){
-  const g=artist.trendingTrack||artist.genre;
-  return GENRE_C[g]||GENRE_C[artist.tracks[0]]||GENRE_C.Music;
+  // Use first genre for primary color
+  return genreColor(artist.genres[0]||'Music');
 }
 
 // === Filtering ===
 function filtered(){
   return ARTISTS.filter(a=>{
-    if(activeCategory!=='All'&&a.genre!==activeCategory&&!a.tracks.includes(activeCategory))return false;
+    if(activeGenre!=='All'&&!a.genres.includes(activeGenre))return false;
     if(searchQuery){
       const q=searchQuery.toLowerCase();
-      if(!a.displayName.toLowerCase().includes(q)&&!a.name.toLowerCase().includes(q)&&!a.tagline.toLowerCase().includes(q))return false;
+      if(!a.displayName.toLowerCase().includes(q)&&!a.name.toLowerCase().includes(q)&&!a.tagline.toLowerCase().includes(q)&&!a.genres.some(g=>g.toLowerCase().includes(q)))return false;
     }
     return true;
   });
@@ -251,7 +322,7 @@ function render(){
       card.appendChild(badge);
 
       const info=document.createElement('div');info.className='trend-info';
-      const dots=a.tracks.map(t=>{const gc=GENRE_C[t];return gc?`<span class="td" style="background:${gc.c}"></span>`:'';}).join('');
+      const dots=a.genres.map(g=>{const gc=genreColor(g);return`<span class="td" style="background:${gc.c}" title="${g}"></span>`;}).join('');
       info.innerHTML=`<div class="trend-name">${a.displayName}</div><div class="trend-meta"><span class="trend-dots">${dots}</span><span class="trend-followers">${fmtFollowers(a.followers)} followers</span></div>`;
       card.appendChild(info);
       scroll.appendChild(card);
@@ -259,13 +330,21 @@ function render(){
     main.appendChild(scroll);
   }
 
-  // Category chips
+  // Genre chips (dynamic, ADR 011)
+  const genreChips=buildGenreChips();
   const catWrap=document.createElement('div');catWrap.className='cats';catWrap.id='cats';
-  CATEGORIES.forEach(c=>{
+  // "All" chip
+  const allChip=document.createElement('div');
+  allChip.className='cat'+(activeGenre==='All'?' a':'');
+  allChip.textContent=`All (${ARTISTS.length})`;
+  allChip.onclick=()=>{activeGenre='All';render()};
+  catWrap.appendChild(allChip);
+  // Genre chips with counts
+  genreChips.forEach(([g,count])=>{
     const chip=document.createElement('div');
-    chip.className='cat'+(activeCategory===c?' a':'');
-    chip.textContent=c;
-    chip.onclick=()=>{activeCategory=c;render()};
+    chip.className='cat'+(activeGenre===g?' a':'');
+    chip.textContent=`${g} (${count})`;
+    chip.onclick=()=>{activeGenre=g;render()};
     catWrap.appendChild(chip);
   });
   main.appendChild(catWrap);
@@ -297,9 +376,9 @@ function render(){
       card.appendChild(name);
 
       const dots=document.createElement('div');dots.className='grid-dots';
-      a.tracks.forEach(t=>{
-        const gc=GENRE_C[t];if(!gc)return;
-        const d=document.createElement('span');d.className='td';d.style.background=gc.c;d.title=t;
+      a.genres.forEach(g=>{
+        const gc=genreColor(g);
+        const d=document.createElement('span');d.className='td';d.style.background=gc.c;d.title=g;
         dots.appendChild(d);
       });
       card.appendChild(dots);
@@ -352,6 +431,11 @@ function render(){
     empty.textContent='No artists found.';
     main.appendChild(empty);
   }
+
+  // Disclosure link (ADR 011: transparency)
+  const disc=document.createElement('div');disc.className='disclosure';
+  disc.innerHTML='<a href="#" onclick="event.preventDefault();openDisc()">How discovery works — 発見の仕組み</a>';
+  main.appendChild(disc);
 }
 
 // === Search ===
@@ -370,11 +454,15 @@ function selectArtist(a){
     setTimeout(()=>{window.location.href='timeline-v1.html'},800);
     return;
   }
-  const payload={id:a.id,name:a.name,displayName:a.displayName,genre:a.genre,tracks:a.tracks};
+  const payload={id:a.id,name:a.name,displayName:a.displayName,genres:a.genres};
   localStorage.setItem('gleisner_selected_artist',JSON.stringify(payload));
   showToast(a.displayName+' のタイムラインへ移動');
   setTimeout(()=>{window.location.href='timeline-v1.html'},800);
 }
+
+// === Disclosure sheet ===
+function openDisc(){document.getElementById('discOv').classList.add('vis')}
+function closeDisc(){document.getElementById('discOv').classList.remove('vis')}
 
 // === Toast ===
 function showToast(msg,duration=2000){


### PR DESCRIPTION
## Summary
- **discover-v1.html**: ADR 011 反映 — 固定カテゴリを自己申告ジャンル（動的生成・件数表示）に変更、「発見の仕組み」開示シート追加、検索対象にジャンル追加
- **ADR 013**: Profile & Artist Page の分離設計 — Tune In 関係システム、アバターレールによるタイムライン切り替え、セクションベース拡張可能 Artist Page、相互 Follow メッセージング、ファン活動フィード

## Test plan
- [ ] discover-v1.html: ジャンルチップが動的生成され件数が表示されること
- [ ] discover-v1.html: 「How discovery works」リンクタップで開示シートが表示されること
- [ ] discover-v1.html: 検索でジャンル名（例: "Flamenco"）がヒットすること
- [ ] ADR 013: 内容と ADR 008/009/011/012 との整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)