### PR TITLE
Add signup and artist registration mockups, update ADRs

### DIFF
--- a/docs/decisions/011-genre-system.md
+++ b/docs/decisions/011-genre-system.md
@@ -25,7 +25,15 @@ Artists declare their own genres. The platform normalizes input through suggesti
 
 ### Genre Input Flow
 
-1. Artist enters free text in a genre field
+Two entry points exist for genre selection:
+
+**During artist registration** (ADR 013): The artist profile step presents all existing genres as tappable chips, plus an inline text input ("Create your own genre…") with an "+ Add" button. This allows both selection from the existing palette and immediate custom genre creation in a single interface. Custom genres receive an auto-generated color via deterministic hash and appear immediately as selected chips.
+
+**Post-registration editing**: The same dual interface (existing genre chips + custom input) is available when editing the Artist Page.
+
+The underlying flow:
+
+1. Artist selects from existing genre chips, or enters free text to create a new genre
 2. The system suggests existing genres that match the input (fuzzy match, alias resolution)
 3. If a matching genre exists, the artist selects it
 4. If no match exists, the artist may propose a new genre name
@@ -85,4 +93,6 @@ New genres appear and disappear organically as artists join and evolve.
 
 - ADR 009 — Discover tab (interaction patterns)
 - ADR 012 — Track system redesign (separating personal tracks from cross-artist taxonomy)
+- ADR 013 — Profile & Artist Page (genre selection in artist registration flow)
 - ADR 001 — Project vision (self-determination, transparency principles)
+- Mockup: `docs/mockups/artist-registration-v1.html` (genre selection + custom genre creation UI)

--- a/docs/decisions/012-track-redesign.md
+++ b/docs/decisions/012-track-redesign.md
@@ -24,18 +24,40 @@ Tracks remain a per-artist organizational tool for their timeline. They are not 
 - Enabling Solo/Mute filtering on the timeline (ADR 004)
 - Providing visual identity through track colors and the constellation layout
 
-### Default Tracks: To Be Redesigned
+### Default Tracks: Template Sets (Decided)
 
-The current defaults (Play, Compose, Life, English) are retired as universal defaults. The replacement approach is to be determined, with the following candidates under consideration:
+The current defaults (Play, Compose, Life, English) are retired as universal defaults. After evaluating four candidates, the **Template sets** approach was chosen based on the artist registration mockup implementation:
 
-| Approach | Description | Pros | Cons |
-|----------|-------------|------|------|
-| **No defaults** | Artist creates all tracks from scratch on signup | Maximum freedom | High friction for new users; blank-slate paralysis |
-| **Template sets** | Choose from preset bundles (Musician, Visual Artist, Writer, Filmmaker, Custom) | Low friction; audience-appropriate | Platform decides what templates exist; may still feel limiting |
-| **Minimal universal defaults** | 1–2 genuinely universal tracks (e.g. "Work" and "Life") + custom | Balance of guidance and freedom | Hard to find tracks that are truly universal |
-| **AI-suggested** | Analyze the artist's genre selections (ADR 011) and suggest an initial track set | Personalized; low friction | Adds complexity; depends on genre system being in place |
+| Template | Default Tracks |
+|----------|---------------|
+| **Musician** | Play, Compose, Life |
+| **Visual Artist** | Works, Process, Thoughts |
+| **Writer** | Writing, Notes, Life |
+| **Filmmaker** | Films, BTS, Stills |
+| **Custom** | (empty — artist creates from scratch) |
 
-The specific approach will be decided when the genre system (ADR 011) is implemented, as the genre context may inform which template or suggestion approach works best.
+The artist registration flow presents these as a horizontal card selector. Selecting a template populates the track list, which the artist can then freely edit (rename, add, remove) before completing registration.
+
+The other candidates considered but not adopted:
+
+| Approach | Why not |
+|----------|---------|
+| **No defaults** | High friction; blank-slate paralysis for new users |
+| **Minimal universal defaults** | No truly universal track names exist across disciplines |
+| **AI-suggested** | Adds unnecessary complexity at this stage |
+
+#### Track Onboarding UX
+
+The track setup step in artist registration includes a **"What are Tracks?"** explainer at the top of the page. This is critical because users encountering Tracks for the first time have no mental model for the concept. The explainer describes Tracks as "themed channels within your Artist Page" where "fans can follow individual Tracks to only see what interests them," with a concrete example (Play / Compose / Life for a musician).
+
+#### Track Color Assignment (TBD)
+
+Track colors are currently derived from a name-based hash (via `TRACK_COLORS` palette with fallback to deterministic hash generation). This works for known track names but produces visually similar colors for similar names (e.g., "New Track 1" and "New Track 2"). The production implementation should use one of:
+
+- **Color picker**: Artist explicitly chooses a color per track
+- **Palette rotation**: Assign colors sequentially from a curated palette, regardless of name
+
+The specific approach is deferred to implementation.
 
 ### Track Configuration Rules
 
@@ -56,9 +78,11 @@ The internal concept name "Track" is retained, but fan-facing UI (e.g., artist p
 
 - Removing the musician-specific defaults eliminates a significant barrier for non-musician artists joining Gleisner
 - The track system becomes a true personal tool, not confused with platform-level taxonomy
-- The specific default approach is deferred until the genre system provides context for personalization
-- Existing mockups (timeline-v1.html, post-v1.html, post-v2.html) continue to use Play/Compose/Life/English as illustrative examples; these will be updated when the default approach is finalized
+- Template sets provide low-friction onboarding while respecting creative diversity across disciplines
+- The "What are Tracks?" explainer in artist registration ensures first-time users understand the concept before configuring
+- Existing mockups (timeline-v1.html, post-v1.html, post-v2.html) continue to use Play/Compose/Life/English as illustrative examples for a musician persona
 - Fan-facing pages show "TRACKS" with the subtext "This artist's content streams" for clarity
+- Track color assignment method is deferred to implementation (color picker or palette rotation)
 
 ## Related
 
@@ -66,3 +90,5 @@ The internal concept name "Track" is retained, but fan-facing UI (e.g., artist p
 - ADR 004 — Multitrack timeline (Solo/Mute, track-based visual layout)
 - ADR 006 — Timeline visual design (track colors, constellation layout)
 - ADR 009 — Discover tab (where genre filtering replaces track-based filtering)
+- ADR 013 — Profile & Artist Page (onboarding flow, artist registration)
+- Mockup: `docs/mockups/artist-registration-v1.html` (track template selection and setup)

--- a/docs/decisions/013-profile-and-artist-page.md
+++ b/docs/decisions/013-profile-and-artist-page.md
@@ -23,6 +23,46 @@ This ADR separates the two concepts and defines the relationship system between 
 | **Profile** | Every user | Personal identity and social connections | Bottom nav "Profile" tab |
 | **Artist Page** | Artist-registered users only | Creative identity and public-facing artist hub | Navigated from Profile, Discover, or direct link |
 
+### Onboarding: Signup & Artist Registration
+
+The two-identity model requires careful onboarding to avoid confusion. A user who intends to be an artist must first create a personal account, then upgrade — if this isn't communicated upfront, they may feel misled when they discover the personal signup wasn't for artist setup.
+
+#### Signup Flow (Personal Account)
+
+A 4-step wizard: Welcome → Profile Setup → Genre Selection → Complete.
+
+**Step 1 (Welcome)** explicitly explains the account structure with two visual cards:
+- **Personal Account**: "Discover artists, follow tracks, build your timeline. This is your personal identity on Gleisner."
+- **+ Artist Upgrade**: "Create an Artist Page, set up tracks, and broadcast your work. You can upgrade anytime after signup."
+
+This ensures users understand the two-tier structure before entering any credentials.
+
+**Step 2 (Profile Setup)** collects: display name, username (@-prefixed with URL preview), bio (optional, 160 chars), and avatar. The avatar defaults to a generative image seeded from the display name, with an option to upload a photo. This avatar is the **personal** avatar.
+
+**Step 3 (Genre Selection)** presents interest genres (skippable). These feed the auto-detected Interests on the Profile page.
+
+**Step 4 (Complete)** confirms the personal account, shows what it includes (Timeline, Discover), and presents a prominent CTA card: "Ready to share your work? Become an Artist" — with the explanation: "Your personal account stays — the artist profile is a separate creative identity."
+
+#### Artist Registration Flow (Upgrade)
+
+A 4-step wizard: Intro → Artist Profile → Track Setup → Complete. Accessible from the signup completion screen or later from Profile settings.
+
+**Step 1 (Intro)** shows feature cards (Artist Page, Tracks, Broadcasting) with a note: "Your artist profile is separate from your personal account. It has its own name, avatar, and cover image."
+
+**Step 2 (Artist Profile)** collects: cover image (generative default or upload), artist avatar (separate from personal avatar, generative default or upload), artist name, tagline (80 chars), location, and genre declarations (up to 5, with custom genre creation).
+
+**Step 3 (Track Setup)** starts with a "What are Tracks?" explainer, then presents template selection (see ADR 012) followed by editable track chips.
+
+**Step 4 (Complete)** shows a mini-preview of the Artist Page (cover + avatar + genres + tracks reflecting actual input) with navigation buttons.
+
+#### Separate Avatars
+
+The personal account and artist account each have their own avatar:
+- **Personal avatar**: Set during signup. Appears on the Profile tab, in Follow relationships, and in user-to-user contexts.
+- **Artist avatar**: Set during artist registration. Appears on the Artist Page, in Tune In contexts, on the timeline avatar rail, and in Discover cards.
+
+Both default to generative art (seeded from the respective display name) with an option to upload a photo. This separation ensures that the personal and creative identities remain visually distinct.
+
 ### Profile (Bottom Nav Tab)
 
 The Profile tab displays the user's personal identity:
@@ -82,7 +122,7 @@ The page is composed of ordered sections, designed for future plugin extensibili
 
 #### Cover Image
 
-A wide banner image at the top of the Artist Page (similar to X/YouTube headers). In the mockup, this is a generative art canvas seeded from the artist's identity; in production, artists will upload their own cover image. The avatar overlaps the bottom of the cover with a gradient fade.
+A wide banner image at the top of the Artist Page (similar to X/YouTube headers). The default is a generative art canvas seeded from the artist's name; artists can also upload their own cover image. The choice is made during artist registration and can be changed later. The avatar overlaps the bottom of the cover with a gradient fade.
 
 #### About Section
 
@@ -222,7 +262,7 @@ When the user has not Tuned In to any artist, the Timeline tab shows:
 - An empty state screen with a prompt: "Tune In to artists to see their timelines here" + a prominent link to the Discover tab
 - No default timeline content is shown (the user has no content to display until they Tune In or create their own as an artist)
 
-Future enhancement (post-MVP): A tutorial/onboarding flow that guides first-time users through Discover → first Tune In → Timeline, reducing the cold-start problem.
+Future enhancement (post-MVP): A tutorial/onboarding flow that guides first-time users through Discover → first Tune In → Timeline, reducing the cold-start problem. The signup and artist registration flows (described above) address the initial account creation onboarding.
 
 ### Navigation Flow
 
@@ -250,7 +290,9 @@ Bottom Nav: Timeline
 
 ## Consequences
 
-- Clear separation between personal and creative identity
+- Onboarding explicitly communicates the two-tier account structure before credentials are entered, preventing the "I thought this was for artist setup" surprise
+- Separate avatars for personal and artist accounts reinforce the identity separation visually
+- Cover image and artist avatar offer both generative defaults and upload options, giving artists control without requiring effort
 - "Follow" and "Tune In" are unambiguous — no user confusion about what each action does
 - The avatar rail provides a lightweight, performant alternative to tabs for timeline switching
 - Section-based Artist Page architecture supports future plugin extensibility without redesigning the page
@@ -265,5 +307,7 @@ Bottom Nav: Timeline
 
 - ADR 008 — Artist Mode & content management (mode switching, now triggered via avatar rail)
 - ADR 009 — Discover tab (artist selection now navigates to Artist Page instead of directly to Timeline)
-- ADR 011 — Genre system (genres displayed on Artist Page)
-- ADR 012 — Track system redesign (tracks displayed on Artist Page)
+- ADR 011 — Genre system (genres displayed on Artist Page; custom genre creation in artist registration)
+- ADR 012 — Track system redesign (tracks displayed on Artist Page; template sets chosen for onboarding)
+- Mockup: `docs/mockups/signup-v1.html` (personal account signup flow)
+- Mockup: `docs/mockups/artist-registration-v1.html` (artist upgrade flow)

--- a/docs/mockups/artist-registration-v1.html
+++ b/docs/mockups/artist-registration-v1.html
@@ -1,0 +1,622 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no">
+<title>Gleisner — Become an Artist</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#050509;--bg2:#0c0c12;--bg3:#151520;
+  --text:#eee;--text2:#8888a0;--text3:#444460;
+  --border:#1a1a28;
+  --c-play:#f97316;--c-compose:#a78bfa;--c-life:#22d3ee;--c-english:#84cc16;
+  --font:'Outfit',sans-serif;--mono:'JetBrains Mono',monospace;
+}
+*{margin:0;padding:0;box-sizing:border-box;-webkit-tap-highlight-color:transparent}
+body{background:var(--bg);color:var(--text);font-family:var(--font);overflow-x:hidden}
+
+/* Switcher */
+.switcher{display:flex;gap:6px;overflow-x:auto;padding:0 14px 16px;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.switcher::-webkit-scrollbar{display:none}
+.sw-chip{display:flex;align-items:center;gap:6px;padding:6px 12px;border-radius:20px;border:1px solid var(--border);background:var(--bg2);font-size:12px;font-weight:500;cursor:pointer;transition:all .15s;user-select:none;white-space:nowrap;flex-shrink:0}
+.sw-chip.a{background:var(--text);color:var(--bg);border-color:var(--text)}
+.sw-chip:active{transform:scale(.95)}
+
+/* Progress dots */
+.progress-dots{display:flex;gap:8px;justify-content:center;padding:20px 0 8px}
+.progress-dot{width:8px;height:8px;border-radius:50%;background:var(--text3);transition:all .3s}
+.progress-dot.a{background:var(--text);width:24px;border-radius:4px}
+.progress-dot.done{background:var(--c-compose)}
+
+/* Main */
+.main{min-height:100dvh;display:flex;flex-direction:column}
+.step{display:none;flex:1;flex-direction:column}
+.step.a{display:flex}
+
+/* Header */
+.hdr{position:sticky;top:0;z-index:100;background:rgba(5,5,9,.94);backdrop-filter:blur(24px) saturate(1.4);-webkit-backdrop-filter:blur(24px) saturate(1.4);border-bottom:1px solid var(--border);padding:12px 14px 10px}
+.hdr-row{display:flex;align-items:center;justify-content:space-between}
+.hdr-title{font-size:15px;font-weight:600;letter-spacing:-.01em}
+.hdr-back{font-size:13px;color:var(--text2);cursor:pointer;padding:4px 0}
+
+/* Step 1: Intro */
+.intro-wrap{flex:1;display:flex;flex-direction:column;padding:0}
+.intro-cover{width:100%;height:180px;position:relative;overflow:hidden}
+.intro-cover canvas{width:100%;height:100%;display:block}
+.intro-overlay{position:absolute;bottom:0;left:0;right:0;padding:20px;background:linear-gradient(transparent,var(--bg))}
+.intro-title{font-size:24px;font-weight:700;letter-spacing:-.02em}
+.intro-sub{font-size:13px;color:var(--text2);margin-top:4px}
+.intro-note{margin:0 20px 8px;padding:12px 16px;background:var(--bg2);border:1px solid var(--border);border-radius:10px;font-size:12px;color:var(--text2);line-height:1.5}
+.intro-note strong{color:var(--text);font-weight:600}
+.feature-cards{padding:12px 20px 20px;display:flex;flex-direction:column;gap:12px}
+.feature-card{background:var(--bg2);border:1px solid var(--border);border-radius:14px;padding:16px;display:flex;gap:14px;align-items:flex-start}
+.feature-icon{font-size:28px;flex-shrink:0;width:40px;text-align:center}
+.feature-body{}
+.feature-title{font-size:14px;font-weight:600;margin-bottom:4px}
+.feature-desc{font-size:12px;color:var(--text2);line-height:1.4}
+
+/* Step 2: Artist Profile */
+.profile-wrap{padding:24px 20px;flex:1;overflow-y:auto}
+.form-group{margin-bottom:20px}
+.form-label{font-size:12px;font-weight:600;color:var(--text2);margin-bottom:6px;display:block}
+.form-hint{font-size:11px;color:var(--text3);margin-top:4px;font-family:var(--mono)}
+.form-input{width:100%;background:var(--bg3);border:1px solid var(--border);border-radius:10px;padding:12px 14px;font-family:var(--font);font-size:14px;color:var(--text);outline:none;transition:border-color .15s}
+.form-input:focus{border-color:var(--c-compose)}
+.form-input::placeholder{color:var(--text3)}
+.char-count{font-family:var(--mono);font-size:11px;color:var(--text3);text-align:right;margin-top:2px}
+
+/* Cover & Avatar uploads */
+.visual-section{margin-bottom:24px}
+.cover-upload{width:100%;height:120px;border-radius:12px;overflow:hidden;position:relative;cursor:pointer;background:var(--bg2);border:1px solid var(--border)}
+.cover-upload canvas{width:100%;height:100%;display:block}
+.cover-upload img{width:100%;height:100%;object-fit:cover;display:none;position:absolute;inset:0}
+.cover-upload-overlay{position:absolute;inset:0;background:rgba(0,0,0,.4);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;opacity:0;transition:opacity .15s}
+.cover-upload:hover .cover-upload-overlay{opacity:1}
+.cover-upload-overlay svg{width:20px;height:20px;stroke:#fff;stroke-width:1.5;fill:none}
+.cover-upload-overlay span{font-size:10px;color:rgba(255,255,255,.7)}
+.cover-upload-hint{position:absolute;bottom:8px;right:10px;font-size:10px;color:var(--text3);font-family:var(--mono);background:rgba(5,5,9,.7);padding:2px 8px;border-radius:4px}
+
+.artist-avatar-row{display:flex;align-items:center;gap:16px;margin-top:-32px;margin-left:16px;position:relative;z-index:2;margin-bottom:16px}
+.artist-avatar-upload{width:64px;height:64px;border-radius:50%;overflow:hidden;position:relative;cursor:pointer;border:3px solid var(--bg);flex-shrink:0}
+.artist-avatar-upload canvas{width:100%;height:100%;display:block}
+.artist-avatar-upload img{width:100%;height:100%;object-fit:cover;display:none;position:absolute;inset:0}
+.artist-avatar-upload-overlay{position:absolute;inset:0;border-radius:50%;background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;opacity:0;transition:opacity .15s}
+.artist-avatar-upload:hover .artist-avatar-upload-overlay{opacity:1}
+.artist-avatar-upload-overlay svg{width:16px;height:16px;stroke:#fff;stroke-width:1.5;fill:none}
+.artist-avatar-badge{position:absolute;bottom:0;right:0;width:20px;height:20px;border-radius:50%;background:var(--c-compose);display:flex;align-items:center;justify-content:center;border:2px solid var(--bg)}
+.artist-avatar-badge svg{width:9px;height:9px;stroke:#fff;stroke-width:2;fill:none}
+.artist-avatar-hint{font-size:11px;color:var(--text3);line-height:1.4}
+input[type="file"]{display:none}
+
+/* Genre with custom add */
+.genre-section-label{font-family:var(--mono);font-size:8px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--text3);margin-bottom:8px}
+.genre-select{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:8px}
+.genre-tag{display:flex;align-items:center;gap:6px;padding:8px 14px;border-radius:20px;border:1px solid var(--border);background:var(--bg2);font-size:12px;font-weight:500;cursor:pointer;transition:all .15s;user-select:none}
+.genre-tag:active{transform:scale(.95)}
+.genre-tag.selected{border-color:currentColor;background:rgba(255,255,255,.06)}
+.genre-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.genre-count{font-family:var(--mono);font-size:11px;color:var(--text3);margin-top:4px}
+.custom-genre-row{display:flex;gap:8px;margin-top:12px}
+.custom-genre-input{flex:1;background:var(--bg3);border:1px solid var(--border);border-radius:20px;padding:8px 14px;font-family:var(--font);font-size:12px;color:var(--text);outline:none}
+.custom-genre-input:focus{border-color:var(--c-compose)}
+.custom-genre-input::placeholder{color:var(--text3)}
+.custom-genre-add{padding:8px 16px;border-radius:20px;border:1px solid var(--c-compose);background:transparent;font-family:var(--font);font-size:12px;font-weight:600;color:var(--c-compose);cursor:pointer;transition:all .15s;white-space:nowrap}
+.custom-genre-add:active{transform:scale(.95);background:rgba(167,139,250,.1)}
+
+/* Step 3: Track Setup */
+.track-wrap{padding:24px 20px;flex:1;overflow-y:auto}
+.track-explainer{background:var(--bg2);border:1px solid var(--border);border-radius:12px;padding:16px;margin-bottom:20px}
+.track-explainer-title{font-size:14px;font-weight:600;margin-bottom:6px}
+.track-explainer-desc{font-size:12px;color:var(--text2);line-height:1.5;margin-bottom:10px}
+.track-example{display:flex;gap:8px;flex-wrap:wrap}
+.track-example-chip{display:flex;align-items:center;gap:5px;padding:5px 10px;border-radius:14px;background:var(--bg3);font-size:11px;font-weight:500}
+.track-example-dot{width:5px;height:5px;border-radius:50%;flex-shrink:0}
+.template-section{margin-bottom:24px}
+.template-grid{display:flex;gap:10px;overflow-x:auto;padding-bottom:8px;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.template-grid::-webkit-scrollbar{display:none}
+.template-card{min-width:120px;background:var(--bg2);border:1px solid var(--border);border-radius:12px;padding:14px;cursor:pointer;transition:all .15s;user-select:none;flex-shrink:0;text-align:center}
+.template-card:active{transform:scale(.95)}
+.template-card.selected{border-color:var(--c-compose);background:rgba(167,139,250,.08)}
+.template-icon{font-size:24px;margin-bottom:6px}
+.template-name{font-size:12px;font-weight:600}
+.template-tracks{font-size:10px;color:var(--text3);margin-top:4px;font-family:var(--mono)}
+
+.track-list{margin-top:16px}
+.track-list-label{font-family:var(--mono);font-size:8px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--text3);margin-bottom:10px}
+.track-chips{display:flex;flex-wrap:wrap;gap:8px}
+.track-edit-chip{display:flex;align-items:center;gap:8px;padding:8px 14px;border-radius:20px;border:1px solid var(--border);background:var(--bg2);font-size:12px;font-weight:500;transition:all .15s}
+.track-edit-chip .track-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.track-edit-chip .track-name{outline:none;background:transparent;border:none;color:var(--text);font-family:var(--font);font-size:12px;font-weight:500;min-width:40px;max-width:100px}
+.track-edit-chip .track-remove{color:var(--text3);cursor:pointer;font-size:14px;line-height:1;padding:0 2px}
+.track-edit-chip .track-remove:hover{color:var(--text)}
+.add-track-btn{display:flex;align-items:center;gap:6px;padding:8px 14px;border-radius:20px;border:1px dashed var(--border);background:transparent;font-family:var(--font);font-size:12px;font-weight:500;color:var(--text3);cursor:pointer;transition:all .15s}
+.add-track-btn:active{transform:scale(.95);border-color:var(--text3)}
+.track-hint{font-family:var(--mono);font-size:11px;color:var(--text3);margin-top:12px}
+
+/* Step 4: Complete */
+.complete-wrap{flex:1;display:flex;flex-direction:column;align-items:center;padding:24px 20px}
+.preview-card{width:100%;max-width:340px;background:var(--bg2);border:1px solid var(--border);border-radius:16px;overflow:hidden;margin-bottom:24px}
+.preview-cover{width:100%;height:120px;position:relative;overflow:hidden}
+.preview-cover canvas{width:100%;height:100%;display:block}
+.preview-cover img{width:100%;height:100%;object-fit:cover;display:none}
+.preview-avatar-wrap{position:absolute;bottom:-28px;left:20px;width:56px;height:56px;border-radius:50%;overflow:hidden;border:3px solid var(--bg2)}
+.preview-avatar-wrap canvas{width:100%;height:100%;display:block}
+.preview-avatar-wrap img{width:100%;height:100%;object-fit:cover;display:none;position:absolute;inset:0}
+.preview-body{padding:36px 20px 20px}
+.preview-name{font-size:18px;font-weight:700;margin-bottom:2px}
+.preview-tagline{font-size:12px;color:var(--text2);margin-bottom:4px}
+.preview-location{font-size:11px;color:var(--text3);font-family:var(--mono);margin-bottom:12px}
+.preview-genres{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:12px}
+.preview-genre{display:flex;align-items:center;gap:4px;padding:4px 10px;border-radius:12px;border:1px solid var(--border);font-size:10px;font-weight:500}
+.preview-genre .genre-dot{width:5px;height:5px}
+.preview-tracks{display:flex;gap:6px;flex-wrap:wrap}
+.preview-track{display:flex;align-items:center;gap:4px;padding:4px 10px;border-radius:12px;background:var(--bg3);font-size:10px;font-weight:500}
+.preview-track .track-dot{width:5px;height:5px;border-radius:50%}
+.complete-title{font-size:22px;font-weight:700;margin-bottom:6px;text-align:center}
+.complete-sub{font-size:14px;color:var(--text2);margin-bottom:24px;text-align:center}
+.complete-buttons{width:100%;max-width:340px;display:flex;flex-direction:column;gap:10px}
+.btn-primary{width:100%;padding:14px;border-radius:12px;border:none;background:var(--c-compose);font-family:var(--font);font-size:14px;font-weight:600;color:#fff;cursor:pointer;transition:all .15s}
+.btn-primary:active{transform:scale(.97);opacity:.8}
+.btn-secondary{width:100%;padding:14px;border-radius:12px;border:1px solid var(--border);background:var(--bg2);font-family:var(--font);font-size:14px;font-weight:500;color:var(--text);cursor:pointer;transition:all .15s}
+.btn-secondary:active{transform:scale(.97);opacity:.8}
+
+/* Continue button — sticky footer */
+.step-footer{position:sticky;bottom:0;padding:16px 20px;padding-bottom:calc(16px + env(safe-area-inset-bottom));background:rgba(5,5,9,.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-top:1px solid var(--border);z-index:50}
+.next-btn{width:100%;padding:14px;border-radius:12px;border:none;background:var(--c-compose);font-family:var(--font);font-size:14px;font-weight:600;color:#fff;cursor:pointer;transition:all .15s}
+.next-btn:active{transform:scale(.97);opacity:.8}
+.next-btn:disabled{opacity:.3;pointer-events:none}
+
+/* Toast */
+.toast{position:fixed;bottom:100px;left:50%;transform:translateX(-50%);background:var(--bg3);border:1px solid var(--border);border-radius:10px;padding:10px 18px;font-size:12px;color:var(--text2);z-index:1000;font-family:var(--mono);box-shadow:0 4px 20px rgba(0,0,0,.5);transition:opacity .3s;pointer-events:none}
+</style>
+</head>
+<body>
+
+<div class="hdr">
+  <div class="hdr-row">
+    <div class="hdr-back" id="backBtn" style="visibility:hidden">← Back</div>
+    <div class="hdr-title">Become an Artist</div>
+    <div style="width:40px"></div>
+  </div>
+  <div class="progress-dots" id="progressDots"></div>
+  <div class="switcher" id="switcher" style="padding-top:12px"></div>
+</div>
+
+<div class="main" id="main">
+  <!-- Step 1: Intro -->
+  <div class="step a" id="step-0">
+    <div class="intro-wrap">
+      <div class="intro-cover"><canvas id="introCover"></canvas>
+        <div class="intro-overlay">
+          <div class="intro-title">Share your art with the world</div>
+          <div class="intro-sub">Set up your Artist Page in minutes</div>
+        </div>
+      </div>
+
+      <!-- Account structure note -->
+      <div class="intro-note">
+        <strong>Your artist profile is separate from your personal account.</strong>
+        It has its own name, avatar, and cover image — a dedicated creative identity that your audience sees.
+      </div>
+
+      <div class="feature-cards">
+        <div class="feature-card">
+          <div class="feature-icon">🎨</div>
+          <div class="feature-body">
+            <div class="feature-title">Artist Page</div>
+            <div class="feature-desc">Your creative home — cover art, artist avatar, bio, and genres that define your practice.</div>
+          </div>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">📡</div>
+          <div class="feature-body">
+            <div class="feature-title">Tracks</div>
+            <div class="feature-desc">Organize your work into Tracks — think of them as themed channels. Fans can follow individual Tracks, so they only see what interests them.</div>
+          </div>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">🔴</div>
+          <div class="feature-body">
+            <div class="feature-title">Broadcasting</div>
+            <div class="feature-desc">Post updates, share progress, and connect with your audience in real time.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="step-footer">
+      <button class="next-btn" onclick="goTo(1)">Get Started</button>
+    </div>
+  </div>
+
+  <!-- Step 2: Artist Profile -->
+  <div class="step" id="step-1">
+    <div class="profile-wrap">
+      <!-- Cover image upload -->
+      <div class="visual-section">
+        <label class="form-label" style="margin-bottom:8px">Cover &amp; Avatar</label>
+        <div class="cover-upload" id="coverUpload" onclick="document.getElementById('coverFile').click()">
+          <canvas id="coverCanvas"></canvas>
+          <img id="coverImg">
+          <div class="cover-upload-overlay">
+            <svg viewBox="0 0 24 24"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>
+            <span>Upload cover image</span>
+          </div>
+          <div class="cover-upload-hint">Tap to upload or keep generated</div>
+        </div>
+        <input type="file" id="coverFile" accept="image/*">
+
+        <!-- Artist avatar (overlapping cover) -->
+        <div class="artist-avatar-row">
+          <div class="artist-avatar-upload" id="artistAvatarUpload" onclick="document.getElementById('artistAvatarFile').click()">
+            <canvas id="artistAvatarCanvas"></canvas>
+            <img id="artistAvatarImg">
+            <div class="artist-avatar-upload-overlay">
+              <svg viewBox="0 0 24 24"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>
+            </div>
+            <div class="artist-avatar-badge">
+              <svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>
+            </div>
+          </div>
+          <input type="file" id="artistAvatarFile" accept="image/*">
+          <div class="artist-avatar-hint">Artist avatar — separate from your personal profile photo</div>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">Artist Name *</label>
+        <input class="form-input" id="artistName" type="text" placeholder="Your artist / creative name" maxlength="50" autocomplete="off">
+      </div>
+      <div class="form-group">
+        <label class="form-label">Tagline <span style="color:var(--text3)">(optional)</span></label>
+        <input class="form-input" id="taglineInput" type="text" placeholder="A short line about your art" maxlength="80" autocomplete="off">
+        <div class="char-count"><span id="taglineCount">0</span>/80</div>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Location <span style="color:var(--text3)">(optional)</span></label>
+        <input class="form-input" id="locationInput" type="text" placeholder="City, Country" maxlength="60" autocomplete="off" style="font-family:var(--mono);font-size:13px">
+      </div>
+      <div class="form-group">
+        <label class="form-label">Genres</label>
+        <div class="form-hint" style="margin-bottom:8px">Select up to 5 genres that describe your work</div>
+        <div class="genre-select" id="artistGenres"></div>
+        <div class="genre-count" id="artistGenreCount">0/5 selected</div>
+        <!-- Custom genre creation -->
+        <div class="custom-genre-row">
+          <input class="custom-genre-input" id="customGenreInput" type="text" placeholder="Create your own genre…" maxlength="30">
+          <button class="custom-genre-add" id="customGenreAdd">+ Add</button>
+        </div>
+      </div>
+    </div>
+    <div class="step-footer">
+      <button class="next-btn" id="profileNext" disabled>Continue</button>
+    </div>
+  </div>
+
+  <!-- Step 3: Track Setup -->
+  <div class="step" id="step-2">
+    <div class="track-wrap">
+      <!-- Track explanation -->
+      <div class="track-explainer">
+        <div class="track-explainer-title">What are Tracks?</div>
+        <div class="track-explainer-desc">Tracks are themed channels within your Artist Page. Each Track is a separate stream of posts — fans can follow individual Tracks to only see what interests them. For example, a musician might have:</div>
+        <div class="track-example">
+          <div class="track-example-chip"><span class="track-example-dot" style="background:#f97316"></span> Play</div>
+          <div class="track-example-chip"><span class="track-example-dot" style="background:#a78bfa"></span> Compose</div>
+          <div class="track-example-chip"><span class="track-example-dot" style="background:#22d3ee"></span> Life</div>
+        </div>
+        <div style="font-size:11px;color:var(--text3);margin-top:8px;line-height:1.4">
+          "Play" for performances, "Compose" for behind-the-scenes creation process, "Life" for personal updates. Pick a template below or start custom.
+        </div>
+      </div>
+
+      <div class="template-section">
+        <div class="genre-section-label" style="margin-bottom:10px">CHOOSE A TEMPLATE</div>
+        <div class="template-grid" id="templateGrid"></div>
+      </div>
+      <div class="track-list" id="trackList">
+        <div class="track-list-label">YOUR TRACKS</div>
+        <div class="track-chips" id="trackChips"></div>
+        <div class="track-hint" id="trackHint">1–10 tracks. Tap name to edit, × to remove.</div>
+      </div>
+    </div>
+    <div class="step-footer">
+      <button class="next-btn" id="trackNext">Continue</button>
+    </div>
+  </div>
+
+  <!-- Step 4: Complete -->
+  <div class="step" id="step-3">
+    <div class="complete-wrap">
+      <div class="complete-title">Your Artist Page is ready!</div>
+      <div class="complete-sub">Here's a preview of how it looks</div>
+      <div class="preview-card" id="previewCard"></div>
+      <div class="complete-buttons">
+        <button class="btn-primary" onclick="showToast('→ artist-page-v1.html')">View Artist Page →</button>
+        <button class="btn-secondary" onclick="showToast('→ timeline-v1.html')">Go to Timeline</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ── Utilities ── */
+function mkRng(s){let h=0;for(let i=0;i<s.length;i++)h=((h<<5)-h+s.charCodeAt(i))|0;return()=>{h=(h*16807)%2147483647;return(h&0x7fffffff)/0x7fffffff}}
+
+function drawAvatar(cv,seed,size,color){
+  const w=size*2;cv.width=w;cv.height=w;
+  const ctx=cv.getContext('2d'),rng=mkRng(seed);
+  const[cr,cg,cb]=color.split(',').map(Number);
+  ctx.fillStyle=`rgb(${12+rng()*8|0},${12+rng()*8|0},${16+rng()*8|0})`;ctx.fillRect(0,0,w,w);
+  for(let i=0;i<3;i++){const g=ctx.createRadialGradient(w*(.2+rng()*.6),w*(.2+rng()*.6),0,w*.5,w*.5,w*(.3+rng()*.4));g.addColorStop(0,`rgba(${cr},${cg},${cb},${.15+rng()*.25})`);g.addColorStop(1,'transparent');ctx.fillStyle=g;ctx.fillRect(0,0,w,w)}
+  for(let i=0;i<4+rng()*4;i++){ctx.save();ctx.globalAlpha=.04+rng()*.1;ctx.fillStyle=`rgb(${cr+rng()*40-20|0},${cg+rng()*40-20|0},${cb+rng()*40-20|0})`;ctx.translate(rng()*w,rng()*w);ctx.rotate(rng()*Math.PI*2);ctx.beginPath();const s=6+rng()*20;ctx.ellipse(0,0,s,s*(.4+rng()*.6),0,0,Math.PI*2);ctx.fill();ctx.restore()}
+  const id=ctx.getImageData(0,0,w,w),dd=id.data;for(let i=0;i<dd.length;i+=4){const n=(rng()-.5)*10;dd[i]+=n;dd[i+1]+=n;dd[i+2]+=n}ctx.putImageData(id,0,0);
+}
+
+function drawTrendBg(cv,seed,color,w,h){
+  cv.width=w*2;cv.height=h*2;
+  const ctx=cv.getContext('2d'),cw=cv.width,ch=cv.height,rng=mkRng(seed);
+  const[cr,cg,cb]=color.split(',').map(Number);
+  ctx.fillStyle=`rgb(${12+rng()*8|0},${12+rng()*8|0},${16+rng()*8|0})`;ctx.fillRect(0,0,cw,ch);
+  for(let i=0;i<5;i++){const g=ctx.createRadialGradient(cw*(.1+rng()*.8),ch*(.1+rng()*.8),0,cw*.5,ch*.5,cw*(.3+rng()*.5));g.addColorStop(0,`rgba(${cr},${cg},${cb},${.1+rng()*.2})`);g.addColorStop(1,'transparent');ctx.fillStyle=g;ctx.fillRect(0,0,cw,ch)}
+  for(let i=0;i<6+rng()*5;i++){ctx.save();ctx.globalAlpha=.03+rng()*.08;ctx.fillStyle=`rgb(${cr+rng()*40-20|0},${cg+rng()*40-20|0},${cb+rng()*40-20|0})`;ctx.translate(rng()*cw,rng()*ch);ctx.rotate(rng()*Math.PI*2);ctx.beginPath();const s=8+rng()*40;ctx.ellipse(0,0,s,s*(.4+rng()*.6),0,0,Math.PI*2);ctx.fill();ctx.restore()}
+  const id=ctx.getImageData(0,0,cw,ch),dd=id.data;for(let i=0;i<dd.length;i+=4){const n=(rng()-.5)*12;dd[i]+=n;dd[i+1]+=n;dd[i+2]+=n}ctx.putImageData(id,0,0);
+}
+
+function showToast(msg,duration=2000){const t=document.createElement('div');t.className='toast';t.textContent=msg;document.body.appendChild(t);setTimeout(()=>{t.style.opacity='0';setTimeout(()=>t.remove(),300)},duration)}
+
+const GENRE_PALETTE={
+  Music:{c:'#f97316',rgb:'249,115,22'},Flamenco:{c:'#ef4444',rgb:'239,68,68'},Electronic:{c:'#06b6d4',rgb:'6,182,212'},Ambient:{c:'#6366f1',rgb:'99,102,241'},'Lo-fi':{c:'#78716c',rgb:'120,113,108'},Jazz:{c:'#eab308',rgb:'234,179,8'},'Singer-Songwriter':{c:'#fb923c',rgb:'251,146,60'},'Visual Art':{c:'#a78bfa',rgb:'167,139,250'},'Digital Art':{c:'#c084fc',rgb:'192,132,252'},'Generative Art':{c:'#818cf8',rgb:'129,140,248'},Illustration:{c:'#a78bfa',rgb:'167,139,250'},Writing:{c:'#22d3ee',rgb:'34,211,238'},Poetry:{c:'#67e8f9',rgb:'103,232,249'},Essay:{c:'#2dd4bf',rgb:'45,212,191'},Film:{c:'#84cc16',rgb:'132,204,22'},'Short Film':{c:'#a3e635',rgb:'163,230,53'},Documentary:{c:'#65a30d',rgb:'101,163,13'},'Motion Graphics':{c:'#bef264',rgb:'190,242,100'},Photography:{c:'#e879f9',rgb:'232,121,249'},'Street Photography':{c:'#f0abfc',rgb:'240,171,252'},'Hardware Art':{c:'#fbbf24',rgb:'251,191,36'},DIY:{c:'#f59e0b',rgb:'245,158,11'},
+};
+function genreColor(g){if(GENRE_PALETTE[g])return GENRE_PALETTE[g];let h=0;for(let i=0;i<g.length;i++)h=((h<<5)-h+g.charCodeAt(i))|0;const hue=((h%360)+360)%360;const r=Math.round(180+50*Math.cos(hue*Math.PI/180)),gv=Math.round(180+50*Math.cos((hue-120)*Math.PI/180)),b=Math.round(180+50*Math.cos((hue+120)*Math.PI/180));return{c:`rgb(${r},${gv},${b})`,rgb:`${r},${gv},${b}`}}
+
+const TRACK_COLORS={
+  Play:{c:'#f97316',rgb:'249,115,22'},Compose:{c:'#a78bfa',rgb:'167,139,250'},Life:{c:'#22d3ee',rgb:'34,211,238'},English:{c:'#84cc16',rgb:'132,204,22'},Synth:{c:'#06b6d4',rgb:'6,182,212'},Visual:{c:'#c084fc',rgb:'192,132,252'},Journal:{c:'#818cf8',rgb:'129,140,248'},Beats:{c:'#78716c',rgb:'120,113,108'},'Field Recording':{c:'#a3e635',rgb:'163,230,53'},Works:{c:'#e879f9',rgb:'232,121,249'},Process:{c:'#fb923c',rgb:'251,146,60'},Thoughts:{c:'#67e8f9',rgb:'103,232,249'},Songs:{c:'#f97316',rgb:'249,115,22'},Writing:{c:'#22d3ee',rgb:'34,211,238'},Shots:{c:'#e879f9',rgb:'232,121,249'},Edits:{c:'#c084fc',rgb:'192,132,252'},BTS:{c:'#fbbf24',rgb:'251,191,36'},Poetry:{c:'#67e8f9',rgb:'103,232,249'},Prose:{c:'#2dd4bf',rgb:'45,212,191'},Films:{c:'#84cc16',rgb:'132,204,22'},Photos:{c:'#e879f9',rgb:'232,121,249'},Log:{c:'#78716c',rgb:'120,113,108'},Drawings:{c:'#a78bfa',rgb:'167,139,250'},Builds:{c:'#fbbf24',rgb:'251,191,36'},Sound:{c:'#f97316',rgb:'249,115,22'},Practice:{c:'#fb923c',rgb:'251,146,60'},Words:{c:'#22d3ee',rgb:'34,211,238'},Essays:{c:'#2dd4bf',rgb:'45,212,191'},Notes:{c:'#818cf8',rgb:'129,140,248'},Stills:{c:'#f0abfc',rgb:'240,171,252'},
+};
+function trackColor(t){if(TRACK_COLORS[t])return TRACK_COLORS[t];return genreColor(t)}
+
+/* ── State ── */
+const STEPS=['Intro','Profile','Tracks','Complete'];
+let currentStep=0;
+let artistData={name:'',tagline:'',location:'',genres:[]};
+let tracks=[];
+let selectedTemplate=null;
+let uploadedAvatarURL=null;
+let uploadedCoverURL=null;
+
+const TEMPLATES=[
+  {id:'musician',icon:'🎵',name:'Musician',tracks:['Play','Compose','Life']},
+  {id:'visual',icon:'🎨',name:'Visual Artist',tracks:['Works','Process','Thoughts']},
+  {id:'writer',icon:'✍️',name:'Writer',tracks:['Writing','Notes','Life']},
+  {id:'filmmaker',icon:'🎬',name:'Filmmaker',tracks:['Films','BTS','Stills']},
+  {id:'custom',icon:'⚡',name:'Custom',tracks:[]},
+];
+
+/* ── Navigation ── */
+function goTo(step){
+  currentStep=step;
+  document.querySelectorAll('.step').forEach((s,i)=>{s.classList.toggle('a',i===step)});
+  document.querySelectorAll('.sw-chip').forEach((c,i)=>{c.classList.toggle('a',i===step)});
+  renderProgress();
+  document.getElementById('backBtn').style.visibility=step>0?'visible':'hidden';
+  if(step===1)initArtistGenres();
+  if(step===2)renderTrackStep();
+  if(step===3)renderComplete();
+}
+
+function renderProgress(){
+  const dots=document.getElementById('progressDots');dots.innerHTML='';
+  STEPS.forEach((_,i)=>{const d=document.createElement('div');d.className='progress-dot'+(i===currentStep?' a':'')+(i<currentStep?' done':'');dots.appendChild(d)});
+}
+
+/* ── Switcher ── */
+function buildSwitcher(){
+  const sw=document.getElementById('switcher');
+  STEPS.forEach((label,i)=>{const chip=document.createElement('div');chip.className='sw-chip'+(i===0?' a':'');chip.textContent=label;chip.onclick=()=>goTo(i);sw.appendChild(chip)});
+}
+
+/* ── Step 1: Intro ── */
+function initIntro(){
+  drawTrendBg(document.getElementById('introCover'),'artist-intro','167,139,250',window.innerWidth,180);
+}
+
+/* ── Step 2: Artist Profile ── */
+function initProfileForm(){
+  const nameInput=document.getElementById('artistName');
+  const tagInput=document.getElementById('taglineInput');
+  const nextBtn=document.getElementById('profileNext');
+  const avatarCanvas=document.getElementById('artistAvatarCanvas');
+  const avatarImg=document.getElementById('artistAvatarImg');
+  const coverCanvas=document.getElementById('coverCanvas');
+  const coverImg=document.getElementById('coverImg');
+
+  // Initial generative art
+  drawAvatar(avatarCanvas,'artist',64,'167,139,250');
+  drawTrendBg(coverCanvas,'artist-cover','167,139,250',window.innerWidth,120);
+
+  // Avatar upload
+  document.getElementById('artistAvatarFile').addEventListener('change',e=>{
+    const file=e.target.files[0];if(!file)return;
+    const reader=new FileReader();
+    reader.onload=ev=>{
+      uploadedAvatarURL=ev.target.result;
+      avatarImg.src=uploadedAvatarURL;avatarImg.style.display='block';avatarCanvas.style.display='none';
+      showToast('Artist avatar set');
+    };
+    reader.readAsDataURL(file);
+  });
+
+  // Cover upload
+  document.getElementById('coverFile').addEventListener('change',e=>{
+    const file=e.target.files[0];if(!file)return;
+    const reader=new FileReader();
+    reader.onload=ev=>{
+      uploadedCoverURL=ev.target.result;
+      coverImg.src=uploadedCoverURL;coverImg.style.display='block';coverCanvas.style.display='none';
+      document.querySelector('.cover-upload-hint').textContent='Photo uploaded — tap to change';
+      showToast('Cover image set');
+    };
+    reader.readAsDataURL(file);
+  });
+
+  nameInput.addEventListener('input',()=>{
+    artistData.name=nameInput.value;
+    nextBtn.disabled=!nameInput.value.trim();
+    // Update generative avatar/cover if no upload
+    if(!uploadedAvatarURL){drawAvatar(avatarCanvas,nameInput.value.trim()||'artist',64,'167,139,250')}
+    if(!uploadedCoverURL){drawTrendBg(coverCanvas,nameInput.value.trim()||'artist-cover','167,139,250',window.innerWidth,120)}
+  });
+  tagInput.addEventListener('input',()=>{
+    artistData.tagline=tagInput.value;
+    document.getElementById('taglineCount').textContent=tagInput.value.length;
+  });
+  document.getElementById('locationInput').addEventListener('input',e=>{artistData.location=e.target.value});
+
+  // Custom genre creation
+  document.getElementById('customGenreAdd').addEventListener('click',addCustomGenre);
+  document.getElementById('customGenreInput').addEventListener('keydown',e=>{if(e.key==='Enter')addCustomGenre()});
+
+  nextBtn.onclick=()=>goTo(2);
+}
+
+function addCustomGenre(){
+  const input=document.getElementById('customGenreInput');
+  const name=input.value.trim();
+  if(!name){showToast('Enter a genre name');return}
+  if(artistData.genres.length>=5){showToast('Maximum 5 genres');return}
+  if(artistData.genres.includes(name)){showToast('Already selected');return}
+  // Add to palette if not present
+  if(!GENRE_PALETTE[name]){
+    const gc=genreColor(name);
+    GENRE_PALETTE[name]={c:gc.c,rgb:gc.rgb};
+  }
+  artistData.genres.push(name);
+  input.value='';
+  // Re-render genre tags
+  renderArtistGenreTags();
+  document.getElementById('artistGenreCount').textContent=`${artistData.genres.length}/5 selected`;
+  showToast(`Added "${name}"`);
+}
+
+let artistGenresInited=false;
+function initArtistGenres(){
+  if(artistGenresInited)return;artistGenresInited=true;
+  renderArtistGenreTags();
+}
+
+function renderArtistGenreTags(){
+  const wrap=document.getElementById('artistGenres');wrap.innerHTML='';
+  // Show custom (user-created) genres first if any
+  const customGenres=artistData.genres.filter(g=>!Object.keys(GENRE_PALETTE).includes(g)||artistData.genres.includes(g));
+  const allGenres=Object.keys(GENRE_PALETTE);
+  allGenres.forEach(g=>{
+    const gc=genreColor(g);
+    const tag=document.createElement('div');tag.className='genre-tag'+(artistData.genres.includes(g)?' selected':'');tag.style.color=gc.c;
+    const dot=document.createElement('span');dot.className='genre-dot';dot.style.background=gc.c;
+    tag.appendChild(dot);tag.appendChild(document.createTextNode(g));
+    tag.onclick=()=>{
+      const idx=artistData.genres.indexOf(g);
+      if(idx>=0){artistData.genres.splice(idx,1);tag.classList.remove('selected')}
+      else if(artistData.genres.length<5){artistData.genres.push(g);tag.classList.add('selected')}
+      else{showToast('Maximum 5 genres');return}
+      document.getElementById('artistGenreCount').textContent=`${artistData.genres.length}/5 selected`;
+    };
+    wrap.appendChild(tag);
+  });
+}
+
+/* ── Step 3: Track Setup ── */
+function renderTrackStep(){
+  const grid=document.getElementById('templateGrid');grid.innerHTML='';
+  TEMPLATES.forEach(tmpl=>{
+    const card=document.createElement('div');
+    card.className='template-card'+(selectedTemplate===tmpl.id?' selected':'');
+    card.innerHTML=`<div class="template-icon">${tmpl.icon}</div><div class="template-name">${tmpl.name}</div><div class="template-tracks">${tmpl.tracks.length?tmpl.tracks.join(' · '):'Start empty'}</div>`;
+    card.onclick=()=>{selectedTemplate=tmpl.id;tracks=[...tmpl.tracks];renderTrackStep()};
+    grid.appendChild(card);
+  });
+  renderTrackChips();
+}
+
+function renderTrackChips(){
+  const wrap=document.getElementById('trackChips');wrap.innerHTML='';
+  tracks.forEach((name,i)=>{
+    const tc=trackColor(name);
+    const chip=document.createElement('div');chip.className='track-edit-chip';
+    chip.innerHTML=`<span class="track-dot" style="background:${tc.c}"></span>`;
+    const nameEl=document.createElement('input');nameEl.className='track-name';nameEl.value=name;nameEl.maxLength=20;
+    nameEl.addEventListener('change',()=>{
+      const v=nameEl.value.trim();
+      if(v){tracks[i]=v;renderTrackChips()}else if(tracks.length>1){tracks.splice(i,1);renderTrackChips()}
+    });
+    chip.appendChild(nameEl);
+    if(tracks.length>1){
+      const rm=document.createElement('span');rm.className='track-remove';rm.textContent='×';
+      rm.onclick=()=>{tracks.splice(i,1);renderTrackChips()};
+      chip.appendChild(rm);
+    }
+    wrap.appendChild(chip);
+  });
+  if(tracks.length<10){
+    const addBtn=document.createElement('button');addBtn.className='add-track-btn';addBtn.textContent='+ Add Track';
+    addBtn.onclick=()=>{let n=1;while(tracks.includes(`New Track ${n}`))n++;tracks.push(`New Track ${n}`);renderTrackChips()};
+    wrap.appendChild(addBtn);
+  }
+  document.getElementById('trackHint').textContent=`${tracks.length}/10 tracks`;
+  document.getElementById('trackNext').disabled=tracks.length<1;
+  document.getElementById('trackNext').onclick=()=>{if(tracks.length>=1)goTo(3)};
+}
+
+/* ── Step 4: Complete ── */
+function renderComplete(){
+  const card=document.getElementById('previewCard');
+  const name=artistData.name||'Artist';
+  const color=artistData.genres.length?genreColor(artistData.genres[0]).rgb:'167,139,250';
+
+  let html='<div class="preview-cover">';
+  html+='<canvas id="previewCover"></canvas>';
+  html+='<img id="previewCoverImg">';
+  html+='<div class="preview-avatar-wrap"><canvas id="previewAvatar"></canvas><img id="previewAvatarImg"></div>';
+  html+='</div>';
+  html+='<div class="preview-body">';
+  html+=`<div class="preview-name">${esc(name)}</div>`;
+  if(artistData.tagline)html+=`<div class="preview-tagline">${esc(artistData.tagline)}</div>`;
+  if(artistData.location)html+=`<div class="preview-location">📍 ${esc(artistData.location)}</div>`;
+  if(artistData.genres.length){
+    html+='<div class="preview-genres">';
+    artistData.genres.forEach(g=>{const gc=genreColor(g);html+=`<div class="preview-genre" style="color:${gc.c};border-color:${gc.c}30"><span class="genre-dot" style="background:${gc.c}"></span>${esc(g)}</div>`});
+    html+='</div>';
+  }
+  if(tracks.length){
+    html+='<div class="preview-tracks">';
+    tracks.forEach(t=>{const tc=trackColor(t);html+=`<div class="preview-track"><span class="track-dot" style="background:${tc.c}"></span>${esc(t)}</div>`});
+    html+='</div>';
+  }
+  html+='</div>';
+  card.innerHTML=html;
+
+  requestAnimationFrame(()=>{
+    const coverCv=document.getElementById('previewCover');
+    const coverIm=document.getElementById('previewCoverImg');
+    if(uploadedCoverURL){coverIm.src=uploadedCoverURL;coverIm.style.display='block';coverCv.style.display='none'}
+    else if(coverCv){drawTrendBg(coverCv,name,color,340,120)}
+
+    const avatarCv=document.getElementById('previewAvatar');
+    const avatarIm=document.getElementById('previewAvatarImg');
+    if(uploadedAvatarURL){avatarIm.src=uploadedAvatarURL;avatarIm.style.display='block';avatarCv.style.display='none'}
+    else if(avatarCv){drawAvatar(avatarCv,name,56,color)}
+  });
+}
+
+function esc(s){const d=document.createElement('div');d.textContent=s;return d.innerHTML}
+
+/* ── Init ── */
+buildSwitcher();
+renderProgress();
+initIntro();
+initProfileForm();
+document.getElementById('backBtn').onclick=()=>{if(currentStep>0)goTo(currentStep-1)};
+</script>
+</body>
+</html>

--- a/docs/mockups/signup-v1.html
+++ b/docs/mockups/signup-v1.html
@@ -1,0 +1,487 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no">
+<title>Gleisner — Sign Up</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#050509;--bg2:#0c0c12;--bg3:#151520;
+  --text:#eee;--text2:#8888a0;--text3:#444460;
+  --border:#1a1a28;
+  --c-play:#f97316;--c-compose:#a78bfa;--c-life:#22d3ee;--c-english:#84cc16;
+  --font:'Outfit',sans-serif;--mono:'JetBrains Mono',monospace;
+}
+*{margin:0;padding:0;box-sizing:border-box;-webkit-tap-highlight-color:transparent}
+body{background:var(--bg);color:var(--text);font-family:var(--font);overflow-x:hidden}
+
+/* Switcher */
+.switcher{display:flex;gap:6px;overflow-x:auto;padding:0 14px 16px;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+.switcher::-webkit-scrollbar{display:none}
+.sw-chip{display:flex;align-items:center;gap:6px;padding:6px 12px;border-radius:20px;border:1px solid var(--border);background:var(--bg2);font-size:12px;font-weight:500;cursor:pointer;transition:all .15s;user-select:none;white-space:nowrap;flex-shrink:0}
+.sw-chip.a{background:var(--text);color:var(--bg);border-color:var(--text)}
+.sw-chip:active{transform:scale(.95)}
+
+/* Progress dots */
+.progress-dots{display:flex;gap:8px;justify-content:center;padding:20px 0 8px}
+.progress-dot{width:8px;height:8px;border-radius:50%;background:var(--text3);transition:all .3s}
+.progress-dot.a{background:var(--text);width:24px;border-radius:4px}
+.progress-dot.done{background:var(--c-compose)}
+
+/* Main */
+.main{min-height:100dvh;display:flex;flex-direction:column}
+.step{display:none;flex:1;flex-direction:column}
+.step.a{display:flex}
+
+/* Header */
+.hdr{position:sticky;top:0;z-index:100;background:rgba(5,5,9,.94);backdrop-filter:blur(24px) saturate(1.4);-webkit-backdrop-filter:blur(24px) saturate(1.4);border-bottom:1px solid var(--border);padding:12px 14px 10px}
+.hdr-row{display:flex;align-items:center;justify-content:space-between}
+.hdr-title{font-size:15px;font-weight:600;letter-spacing:-.01em}
+.hdr-back{font-size:13px;color:var(--text2);cursor:pointer;padding:4px 0}
+.hdr-skip{font-size:13px;color:var(--text3);cursor:pointer;padding:4px 0}
+
+/* Step 1: Welcome */
+.welcome-wrap{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:40px 24px}
+.welcome-logo{width:80px;height:80px;border-radius:50%;overflow:hidden;margin-bottom:24px}
+.welcome-logo canvas{width:100%;height:100%;display:block}
+.welcome-brand{font-size:28px;font-weight:700;letter-spacing:-.02em;margin-bottom:6px}
+.welcome-tagline{font-size:14px;color:var(--text2);margin-bottom:24px;text-align:center;line-height:1.5}
+
+/* Account structure info */
+.account-info{width:100%;max-width:320px;margin-bottom:28px}
+.account-info-card{background:var(--bg2);border:1px solid var(--border);border-radius:12px;padding:14px 16px;display:flex;gap:12px;margin-bottom:8px}
+.account-info-card:last-child{margin-bottom:0}
+.account-icon{font-size:20px;flex-shrink:0;width:28px;text-align:center;padding-top:1px}
+.account-info-body{flex:1}
+.account-info-title{font-size:13px;font-weight:600;margin-bottom:2px}
+.account-info-desc{font-size:11px;color:var(--text2);line-height:1.4}
+.account-arrow{display:flex;align-items:center;justify-content:center;color:var(--text3);font-size:16px;padding:2px 0}
+
+.auth-buttons{width:100%;max-width:320px;display:flex;flex-direction:column;gap:12px}
+.auth-btn{width:100%;padding:14px 20px;border-radius:12px;border:1px solid var(--border);background:var(--bg2);font-family:var(--font);font-size:14px;font-weight:500;color:var(--text);cursor:pointer;transition:all .15s;display:flex;align-items:center;gap:12px}
+.auth-btn:active{transform:scale(.97);opacity:.8}
+.auth-btn svg{width:20px;height:20px;flex-shrink:0}
+.auth-btn-google svg{color:#4285f4}
+.auth-btn-apple svg{color:#fff}
+.auth-btn-email svg{color:var(--text2)}
+.signin-link{margin-top:24px;font-size:13px;color:var(--text3)}
+.signin-link a{color:var(--c-compose);text-decoration:none}
+
+/* Step 2: Profile Setup */
+.profile-wrap{padding:24px 20px;flex:1;overflow-y:auto}
+.form-group{margin-bottom:20px}
+.form-label{font-size:12px;font-weight:600;color:var(--text2);margin-bottom:6px;display:block}
+.form-hint{font-size:11px;color:var(--text3);margin-top:4px;font-family:var(--mono)}
+.form-input{width:100%;background:var(--bg3);border:1px solid var(--border);border-radius:10px;padding:12px 14px;font-family:var(--font);font-size:14px;color:var(--text);outline:none;transition:border-color .15s}
+.form-input:focus{border-color:var(--c-compose)}
+.form-input::placeholder{color:var(--text3)}
+textarea.form-input{resize:vertical;min-height:60px;line-height:1.4}
+.username-preview{font-size:11px;color:var(--text3);font-family:var(--mono);margin-top:6px;padding:6px 10px;background:var(--bg2);border-radius:6px}
+.char-count{font-family:var(--mono);font-size:11px;color:var(--text3);text-align:right;margin-top:2px}
+
+/* Avatar with upload */
+.avatar-section{display:flex;align-items:center;gap:16px;margin-bottom:24px}
+.avatar-upload{position:relative;width:72px;height:72px;flex-shrink:0;cursor:pointer}
+.avatar-upload canvas{width:100%;height:100%;display:block;border-radius:50%}
+.avatar-upload-overlay{position:absolute;inset:0;border-radius:50%;background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;opacity:0;transition:opacity .15s}
+.avatar-upload:hover .avatar-upload-overlay{opacity:1}
+.avatar-upload-overlay svg{width:20px;height:20px;stroke:#fff;stroke-width:1.5;fill:none}
+.avatar-upload-badge{position:absolute;bottom:0;right:0;width:22px;height:22px;border-radius:50%;background:var(--c-compose);display:flex;align-items:center;justify-content:center;border:2px solid var(--bg)}
+.avatar-upload-badge svg{width:10px;height:10px;stroke:#fff;stroke-width:2;fill:none}
+.avatar-info{flex:1}
+.avatar-info-text{font-size:12px;color:var(--text2);line-height:1.4;margin-bottom:4px}
+.avatar-info-hint{font-size:11px;color:var(--text3);font-family:var(--mono)}
+.avatar-uploaded-img{width:100%;height:100%;border-radius:50%;object-fit:cover;display:none}
+input[type="file"]{display:none}
+
+/* Step 3: Genre Selection */
+.genre-wrap{padding:24px 20px;flex:1;overflow-y:auto}
+.genre-section-label{font-family:var(--mono);font-size:8px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--text3);margin-bottom:8px;margin-top:16px}
+.genre-section-label:first-child{margin-top:0}
+.genre-select{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:8px}
+.genre-tag{display:flex;align-items:center;gap:6px;padding:8px 14px;border-radius:20px;border:1px solid var(--border);background:var(--bg2);font-size:12px;font-weight:500;cursor:pointer;transition:all .15s;user-select:none}
+.genre-tag:active{transform:scale(.95)}
+.genre-tag.selected{border-color:currentColor;background:rgba(255,255,255,.06)}
+.genre-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.genre-count{font-family:var(--mono);font-size:11px;color:var(--text3);text-align:center;margin-top:12px}
+.skip-link{display:block;text-align:center;font-size:13px;color:var(--text3);cursor:pointer;padding:12px;margin-top:8px}
+.skip-link:active{color:var(--text2)}
+
+/* Step 4: Complete */
+.complete-wrap{flex:1;display:flex;flex-direction:column;align-items:center;padding:40px 24px}
+.complete-avatar{width:80px;height:80px;border-radius:50%;overflow:hidden;margin-bottom:16px}
+.complete-avatar canvas{width:100%;height:100%;display:block}
+.complete-avatar img{width:100%;height:100%;object-fit:cover;display:none}
+.complete-title{font-size:22px;font-weight:700;margin-bottom:6px}
+.complete-sub{font-size:14px;color:var(--text2);margin-bottom:12px;text-align:center}
+
+/* What's next info */
+.whats-next{width:100%;max-width:320px;margin-bottom:24px}
+.whats-next-label{font-family:var(--mono);font-size:8px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--text3);margin-bottom:10px;text-align:center}
+.next-option{background:var(--bg2);border:1px solid var(--border);border-radius:12px;padding:14px 16px;margin-bottom:8px;display:flex;gap:12px;align-items:flex-start}
+.next-option-icon{font-size:18px;flex-shrink:0;width:24px;text-align:center}
+.next-option-body{flex:1}
+.next-option-title{font-size:13px;font-weight:600;margin-bottom:2px}
+.next-option-desc{font-size:11px;color:var(--text2);line-height:1.4}
+
+.artist-cta-card{width:100%;max-width:320px;background:linear-gradient(135deg,rgba(167,139,250,.08),rgba(249,115,22,.06));border:1px solid rgba(167,139,250,.2);border-radius:16px;padding:20px;margin-bottom:16px;cursor:pointer;transition:all .15s}
+.artist-cta-card:active{transform:scale(.97)}
+.cta-icon{font-size:24px;margin-bottom:8px}
+.cta-title{font-size:15px;font-weight:600;margin-bottom:4px}
+.cta-desc{font-size:12px;color:var(--text2);line-height:1.4;margin-bottom:12px}
+.cta-arrow{font-size:13px;color:var(--c-compose);font-weight:600}
+.complete-btn{width:100%;max-width:320px;padding:14px;border-radius:12px;border:none;background:var(--bg3);font-family:var(--font);font-size:14px;font-weight:500;color:var(--text);cursor:pointer;transition:all .15s;margin-top:8px}
+.complete-btn:active{transform:scale(.97);opacity:.8}
+
+/* Continue button — sticky footer */
+.step-footer{position:sticky;bottom:0;padding:16px 20px;padding-bottom:calc(16px + env(safe-area-inset-bottom));background:rgba(5,5,9,.92);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-top:1px solid var(--border);z-index:50}
+.next-btn{width:100%;padding:14px;border-radius:12px;border:none;background:var(--c-compose);font-family:var(--font);font-size:14px;font-weight:600;color:#fff;cursor:pointer;transition:all .15s}
+.next-btn:active{transform:scale(.97);opacity:.8}
+.next-btn:disabled{opacity:.3;pointer-events:none}
+
+/* Toast */
+.toast{position:fixed;bottom:100px;left:50%;transform:translateX(-50%);background:var(--bg3);border:1px solid var(--border);border-radius:10px;padding:10px 18px;font-size:12px;color:var(--text2);z-index:1000;font-family:var(--mono);box-shadow:0 4px 20px rgba(0,0,0,.5);transition:opacity .3s;pointer-events:none}
+</style>
+</head>
+<body>
+
+<div class="hdr">
+  <div class="hdr-row">
+    <div class="hdr-back" id="backBtn" style="visibility:hidden">← Back</div>
+    <div class="hdr-title">Sign Up</div>
+    <div class="hdr-skip" id="skipBtn" style="visibility:hidden">Skip</div>
+  </div>
+  <div class="progress-dots" id="progressDots"></div>
+  <div class="switcher" id="switcher" style="padding-top:12px"></div>
+</div>
+
+<div class="main" id="main">
+  <!-- Step 1: Welcome -->
+  <div class="step a" id="step-0">
+    <div class="welcome-wrap">
+      <div class="welcome-logo"><canvas id="logoCanvas"></canvas></div>
+      <div class="welcome-brand">Gleisner</div>
+      <div class="welcome-tagline">Your creative identity, owned by you.<br>Share art, music, writing &amp; more.</div>
+
+      <!-- Account structure explanation -->
+      <div class="account-info">
+        <div class="account-info-card">
+          <div class="account-icon">👤</div>
+          <div class="account-info-body">
+            <div class="account-info-title">Personal Account</div>
+            <div class="account-info-desc">Discover artists, follow tracks, build your timeline. This is your personal identity on Gleisner.</div>
+          </div>
+        </div>
+        <div class="account-arrow">↓</div>
+        <div class="account-info-card" style="border-color:rgba(167,139,250,.25)">
+          <div class="account-icon">🎨</div>
+          <div class="account-info-body">
+            <div class="account-info-title" style="color:var(--c-compose)">+ Artist Upgrade</div>
+            <div class="account-info-desc">Create an Artist Page, set up tracks, and broadcast your work. You can upgrade anytime after signup.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="auth-buttons">
+        <button class="auth-btn auth-btn-google" onclick="authWith('Google')">
+          <svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34a853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#fbbc05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#ea4335"/></svg>
+          Continue with Google
+        </button>
+        <button class="auth-btn auth-btn-apple" onclick="authWith('Apple')">
+          <svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.32 2.32-2.11 4.45-3.74 4.25z"/></svg>
+          Continue with Apple
+        </button>
+        <button class="auth-btn auth-btn-email" onclick="authWith('Email')">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M22 4L12 13 2 4"/></svg>
+          Continue with Email
+        </button>
+      </div>
+      <div class="signin-link">Already have an account? <a href="#" onclick="showToast('Sign in flow — not in scope')">Sign in</a></div>
+    </div>
+  </div>
+
+  <!-- Step 2: Profile Setup -->
+  <div class="step" id="step-1">
+    <div class="profile-wrap">
+      <!-- Avatar with upload option -->
+      <div class="avatar-section">
+        <div class="avatar-upload" id="avatarUpload" onclick="document.getElementById('avatarFile').click()">
+          <canvas id="profileAvatarCanvas"></canvas>
+          <img class="avatar-uploaded-img" id="avatarImg">
+          <div class="avatar-upload-overlay">
+            <svg viewBox="0 0 24 24"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>
+          </div>
+          <div class="avatar-upload-badge">
+            <svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>
+          </div>
+        </div>
+        <input type="file" id="avatarFile" accept="image/*">
+        <div class="avatar-info">
+          <div class="avatar-info-text">Tap to upload a photo, or keep the generated avatar</div>
+          <div class="avatar-info-hint">Auto-generated from your display name</div>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">Display Name *</label>
+        <input class="form-input" id="displayName" type="text" placeholder="Your name" maxlength="50" autocomplete="off">
+      </div>
+      <div class="form-group">
+        <label class="form-label">Username *</label>
+        <input class="form-input" id="username" type="text" placeholder="username" maxlength="30" autocomplete="off" style="font-family:var(--mono)">
+        <div class="username-preview" id="usernamePreview">gleisner.app/@username</div>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Bio <span style="color:var(--text3)">(optional)</span></label>
+        <textarea class="form-input" id="bioInput" placeholder="Tell us about yourself" maxlength="160" rows="2"></textarea>
+        <div class="char-count"><span id="bioCount">0</span>/160</div>
+      </div>
+    </div>
+    <div class="step-footer">
+      <button class="next-btn" id="profileNext" disabled>Continue</button>
+    </div>
+  </div>
+
+  <!-- Step 3: Genre Selection -->
+  <div class="step" id="step-2">
+    <div class="genre-wrap" id="genreWrap"></div>
+    <div class="step-footer">
+      <button class="next-btn" id="genreNext">Continue</button>
+      <div class="skip-link" onclick="goTo(3)">Skip for now</div>
+    </div>
+  </div>
+
+  <!-- Step 4: Complete -->
+  <div class="step" id="step-3">
+    <div class="complete-wrap">
+      <div class="complete-avatar" id="completeAvatar">
+        <canvas></canvas>
+        <img id="completeAvatarImg" style="display:none">
+      </div>
+      <div class="complete-title" id="completeTitle">Welcome!</div>
+      <div class="complete-sub">Your personal account is ready.</div>
+
+      <!-- What you can do now -->
+      <div class="whats-next">
+        <div class="whats-next-label">YOUR ACCOUNT INCLUDES</div>
+        <div class="next-option">
+          <div class="next-option-icon">📡</div>
+          <div class="next-option-body">
+            <div class="next-option-title">Personalized Timeline</div>
+            <div class="next-option-desc">Follow artists and tracks to build your own feed</div>
+          </div>
+        </div>
+        <div class="next-option">
+          <div class="next-option-icon">🔍</div>
+          <div class="next-option-body">
+            <div class="next-option-title">Discover</div>
+            <div class="next-option-desc">Explore trending artists, genres, and new work</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="artist-cta-card" onclick="gotoArtistReg()">
+        <div class="cta-icon">🎨</div>
+        <div class="cta-title">Ready to share your work?</div>
+        <div class="cta-desc">Upgrade to an Artist account to get your own Artist Page, Tracks, and broadcasting tools. Your personal account stays — the artist profile is a separate creative identity.</div>
+        <div class="cta-arrow">Become an Artist →</div>
+      </div>
+      <button class="complete-btn" onclick="showToast('→ discover-v1.html')">Explore Discover first →</button>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ── Utilities ── */
+function mkRng(s){let h=0;for(let i=0;i<s.length;i++)h=((h<<5)-h+s.charCodeAt(i))|0;return()=>{h=(h*16807)%2147483647;return(h&0x7fffffff)/0x7fffffff}}
+
+function drawAvatar(cv,seed,size,color){
+  const w=size*2;cv.width=w;cv.height=w;
+  const ctx=cv.getContext('2d'),rng=mkRng(seed);
+  const[cr,cg,cb]=color.split(',').map(Number);
+  ctx.fillStyle=`rgb(${12+rng()*8|0},${12+rng()*8|0},${16+rng()*8|0})`;ctx.fillRect(0,0,w,w);
+  for(let i=0;i<3;i++){const g=ctx.createRadialGradient(w*(.2+rng()*.6),w*(.2+rng()*.6),0,w*.5,w*.5,w*(.3+rng()*.4));g.addColorStop(0,`rgba(${cr},${cg},${cb},${.15+rng()*.25})`);g.addColorStop(1,'transparent');ctx.fillStyle=g;ctx.fillRect(0,0,w,w)}
+  for(let i=0;i<4+rng()*4;i++){ctx.save();ctx.globalAlpha=.04+rng()*.1;ctx.fillStyle=`rgb(${cr+rng()*40-20|0},${cg+rng()*40-20|0},${cb+rng()*40-20|0})`;ctx.translate(rng()*w,rng()*w);ctx.rotate(rng()*Math.PI*2);ctx.beginPath();const s=6+rng()*20;ctx.ellipse(0,0,s,s*(.4+rng()*.6),0,0,Math.PI*2);ctx.fill();ctx.restore()}
+  const id=ctx.getImageData(0,0,w,w),dd=id.data;for(let i=0;i<dd.length;i+=4){const n=(rng()-.5)*10;dd[i]+=n;dd[i+1]+=n;dd[i+2]+=n}ctx.putImageData(id,0,0);
+}
+
+function showToast(msg,duration=2000){const t=document.createElement('div');t.className='toast';t.textContent=msg;document.body.appendChild(t);setTimeout(()=>{t.style.opacity='0';setTimeout(()=>t.remove(),300)},duration)}
+
+const GENRE_PALETTE={
+  Music:{c:'#f97316',rgb:'249,115,22'},Flamenco:{c:'#ef4444',rgb:'239,68,68'},Electronic:{c:'#06b6d4',rgb:'6,182,212'},Ambient:{c:'#6366f1',rgb:'99,102,241'},'Lo-fi':{c:'#78716c',rgb:'120,113,108'},Jazz:{c:'#eab308',rgb:'234,179,8'},'Singer-Songwriter':{c:'#fb923c',rgb:'251,146,60'},'Visual Art':{c:'#a78bfa',rgb:'167,139,250'},'Digital Art':{c:'#c084fc',rgb:'192,132,252'},'Generative Art':{c:'#818cf8',rgb:'129,140,248'},Illustration:{c:'#a78bfa',rgb:'167,139,250'},Writing:{c:'#22d3ee',rgb:'34,211,238'},Poetry:{c:'#67e8f9',rgb:'103,232,249'},Essay:{c:'#2dd4bf',rgb:'45,212,191'},Film:{c:'#84cc16',rgb:'132,204,22'},'Short Film':{c:'#a3e635',rgb:'163,230,53'},Documentary:{c:'#65a30d',rgb:'101,163,13'},'Motion Graphics':{c:'#bef264',rgb:'190,242,100'},Photography:{c:'#e879f9',rgb:'232,121,249'},'Street Photography':{c:'#f0abfc',rgb:'240,171,252'},'Hardware Art':{c:'#fbbf24',rgb:'251,191,36'},DIY:{c:'#f59e0b',rgb:'245,158,11'},
+};
+function genreColor(g){if(GENRE_PALETTE[g])return GENRE_PALETTE[g];let h=0;for(let i=0;i<g.length;i++)h=((h<<5)-h+g.charCodeAt(i))|0;const hue=((h%360)+360)%360;const r=Math.round(180+50*Math.cos(hue*Math.PI/180)),gv=Math.round(180+50*Math.cos((hue-120)*Math.PI/180)),b=Math.round(180+50*Math.cos((hue+120)*Math.PI/180));return{c:`rgb(${r},${gv},${b})`,rgb:`${r},${gv},${b}`}}
+
+/* ── State ── */
+const STEPS=['Welcome','Profile','Genres','Complete'];
+let currentStep=0;
+let selectedGenres=[];
+let formData={displayName:'',username:'',bio:''};
+let uploadedAvatarURL=null;
+
+/* ── Navigation ── */
+function goTo(step){
+  currentStep=step;
+  document.querySelectorAll('.step').forEach((s,i)=>{s.classList.toggle('a',i===step)});
+  document.querySelectorAll('.sw-chip').forEach((c,i)=>{c.classList.toggle('a',i===step)});
+  renderProgress();
+  document.getElementById('backBtn').style.visibility=step>0?'visible':'hidden';
+  document.getElementById('skipBtn').style.visibility=step===2?'visible':'hidden';
+  document.getElementById('skipBtn').onclick=()=>goTo(3);
+  if(step===2)renderGenres();
+  if(step===3)renderComplete();
+}
+
+function renderProgress(){
+  const dots=document.getElementById('progressDots');dots.innerHTML='';
+  STEPS.forEach((_,i)=>{const d=document.createElement('div');d.className='progress-dot'+(i===currentStep?' a':'')+(i<currentStep?' done':'');dots.appendChild(d)});
+}
+
+/* ── Switcher ── */
+function buildSwitcher(){
+  const sw=document.getElementById('switcher');
+  STEPS.forEach((label,i)=>{const chip=document.createElement('div');chip.className='sw-chip'+(i===0?' a':'');chip.textContent=label;chip.onclick=()=>goTo(i);sw.appendChild(chip)});
+}
+
+/* ── Step 1: Welcome ── */
+function initWelcome(){
+  drawAvatar(document.getElementById('logoCanvas'),'Gleisner',80,'167,139,250');
+}
+
+function authWith(provider){
+  showToast(`Auth with ${provider} — demo`);
+  setTimeout(()=>goTo(1),600);
+}
+
+/* ── Step 2: Profile ── */
+function initProfile(){
+  const nameInput=document.getElementById('displayName');
+  const userInput=document.getElementById('username');
+  const bioInput=document.getElementById('bioInput');
+  const nextBtn=document.getElementById('profileNext');
+  const avatarCanvas=document.getElementById('profileAvatarCanvas');
+  const avatarImg=document.getElementById('avatarImg');
+  const avatarFileInput=document.getElementById('avatarFile');
+
+  function updateAvatar(){
+    if(uploadedAvatarURL)return; // keep uploaded photo
+    const seed=nameInput.value.trim()||'user';
+    drawAvatar(avatarCanvas,seed,72,'167,139,250');
+  }
+  updateAvatar();
+
+  // File upload handler
+  avatarFileInput.addEventListener('change',e=>{
+    const file=e.target.files[0];
+    if(!file)return;
+    const reader=new FileReader();
+    reader.onload=ev=>{
+      uploadedAvatarURL=ev.target.result;
+      avatarImg.src=uploadedAvatarURL;
+      avatarImg.style.display='block';
+      avatarCanvas.style.display='none';
+      document.querySelector('.avatar-info-hint').textContent='Photo uploaded — tap to change';
+      showToast('Avatar photo set');
+    };
+    reader.readAsDataURL(file);
+  });
+
+  function validateProfile(){
+    const nameOk=nameInput.value.trim().length>=1;
+    const userOk=/^[a-zA-Z0-9_]{1,30}$/.test(userInput.value.trim());
+    nextBtn.disabled=!(nameOk&&userOk);
+  }
+
+  nameInput.addEventListener('input',()=>{
+    formData.displayName=nameInput.value;
+    updateAvatar();
+    if(!userInput.dataset.edited){
+      const auto=nameInput.value.trim().toLowerCase().replace(/[^a-z0-9]/g,'_').replace(/_+/g,'_').replace(/^_|_$/g,'').slice(0,30);
+      userInput.value=auto;formData.username=auto;
+      document.getElementById('usernamePreview').textContent=`gleisner.app/@${auto||'username'}`;
+    }
+    validateProfile();
+  });
+
+  userInput.addEventListener('input',()=>{
+    userInput.dataset.edited='1';
+    const v=userInput.value.replace(/[^a-zA-Z0-9_]/g,'').slice(0,30);
+    userInput.value=v;formData.username=v;
+    document.getElementById('usernamePreview').textContent=`gleisner.app/@${v||'username'}`;
+    validateProfile();
+  });
+
+  bioInput.addEventListener('input',()=>{
+    formData.bio=bioInput.value;
+    document.getElementById('bioCount').textContent=bioInput.value.length;
+  });
+
+  nextBtn.onclick=()=>goTo(2);
+}
+
+/* ── Step 3: Genre Selection ── */
+const POPULAR_GENRES=['Music','Electronic','Jazz','Visual Art','Writing','Film','Photography','Lo-fi'];
+const ALL_GENRES=Object.keys(GENRE_PALETTE).filter(g=>!POPULAR_GENRES.includes(g));
+
+function renderGenres(){
+  const wrap=document.getElementById('genreWrap');wrap.innerHTML='';
+  const popLabel=document.createElement('div');popLabel.className='genre-section-label';popLabel.textContent='POPULAR';wrap.appendChild(popLabel);
+  const popGrid=document.createElement('div');popGrid.className='genre-select';wrap.appendChild(popGrid);
+  POPULAR_GENRES.forEach(g=>popGrid.appendChild(makeGenreTag(g)));
+  const allLabel=document.createElement('div');allLabel.className='genre-section-label';allLabel.textContent='ALL GENRES';wrap.appendChild(allLabel);
+  const allGrid=document.createElement('div');allGrid.className='genre-select';wrap.appendChild(allGrid);
+  ALL_GENRES.forEach(g=>allGrid.appendChild(makeGenreTag(g)));
+  const count=document.createElement('div');count.className='genre-count';count.id='genreCount';
+  count.textContent=`${selectedGenres.length}/5 selected`;wrap.appendChild(count);
+}
+
+function makeGenreTag(genre){
+  const gc=genreColor(genre);
+  const tag=document.createElement('div');
+  tag.className='genre-tag'+(selectedGenres.includes(genre)?' selected':'');
+  tag.style.color=gc.c;
+  const dot=document.createElement('span');dot.className='genre-dot';dot.style.background=gc.c;
+  tag.appendChild(dot);tag.appendChild(document.createTextNode(genre));
+  tag.onclick=()=>toggleGenre(genre,tag);
+  return tag;
+}
+
+function toggleGenre(genre,tag){
+  const idx=selectedGenres.indexOf(genre);
+  if(idx>=0){selectedGenres.splice(idx,1);tag.classList.remove('selected')}
+  else if(selectedGenres.length<5){selectedGenres.push(genre);tag.classList.add('selected')}
+  else{showToast('Maximum 5 genres');return}
+  document.getElementById('genreCount').textContent=`${selectedGenres.length}/5 selected`;
+}
+
+document.getElementById('genreNext').onclick=()=>goTo(3);
+
+/* ── Step 4: Complete ── */
+function renderComplete(){
+  const name=formData.displayName||'Explorer';
+  const cv=document.querySelector('#completeAvatar canvas');
+  const img=document.getElementById('completeAvatarImg');
+  if(uploadedAvatarURL){
+    img.src=uploadedAvatarURL;img.style.display='block';cv.style.display='none';
+  }else{
+    drawAvatar(cv,name,80,'167,139,250');img.style.display='none';cv.style.display='block';
+  }
+  document.getElementById('completeTitle').textContent=`Welcome, ${name}!`;
+}
+
+function gotoArtistReg(){
+  showToast('→ artist-registration-v1.html');
+  setTimeout(()=>{window.location.href='artist-registration-v1.html'},800);
+}
+
+/* ── Init ── */
+buildSwitcher();
+renderProgress();
+initWelcome();
+initProfile();
+document.getElementById('backBtn').onclick=()=>{if(currentStep>0)goTo(currentStep-1)};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **signup-v1.html**: 4ステップのユーザー登録ウィザード（Welcome → Profile → Genres → Complete）
  - Welcome 画面でアカウント構造（Personal Account → Artist Upgrade）を事前説明
  - アバターはジェネラティブデフォルト + 画像アップロード選択可
  - Continue ボタンを sticky footer で常時表示
- **artist-registration-v1.html**: 4ステップのアーティスト昇格ウィザード（Intro → Profile → Tracks → Complete）
  - アーティスト専用のアバター・カバー画像（ジェネラティブ or アップロード）
  - カスタムジャンル作成 UI（インラインテキスト入力 + Add ボタン）
  - 「What are Tracks?」説明セクション付きトラックテンプレート選択
  - Complete 画面で入力内容反映のミニプレビュー
- **ADR 011**: ジャンル入力 UI の詳細追加（チップ選択 + カスタム作成）
- **ADR 012**: トラックデフォルトを Template Sets 方式に決定、色割り当て TBD を記録
- **ADR 013**: オンボーディングフロー、アバター分離、カバー画像アップロードを追加

## Test plan

- [ ] signup-v1.html: 4ステップ遷移、デモスイッチャー、フォーム入力→アバター動的更新、アバターアップロード、ジャンル選択/スキップ、Complete 画面の CTA
- [ ] artist-registration-v1.html: 4ステップ遷移、カバー/アバターアップロード、カスタムジャンル作成、テンプレート選択→トラック編集、Complete でプレビュー表示
- [ ] ADR 011/012/013 の内容がモックアップの実装と整合していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)