### PR TITLE
Add auth system with Ed25519/JWT and test suite

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,10 +9,13 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "packageManager": "pnpm@10.32.1",
   "dependencies": {
+    "@graphql-yoga/plugin-disable-introspection": "^2.19.1",
     "@hono/node-server": "^1.19.11",
     "@pothos/core": "^4.12.0",
     "dotenv": "^17.3.1",
@@ -20,12 +23,14 @@
     "graphql": "^16.13.1",
     "graphql-yoga": "^5.18.1",
     "hono": "^4.12.8",
+    "jose": "^6.2.1",
     "postgres": "^3.4.8"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "drizzle-kit": "^0.31.10",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
   }
 }

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@graphql-yoga/plugin-disable-introspection':
+        specifier: ^2.19.1
+        version: 2.19.1(graphql-yoga@5.18.1(graphql@16.13.1))(graphql@16.13.1)
       '@hono/node-server':
         specifier: ^1.19.11
         version: 1.19.11(hono@4.12.8)
@@ -29,6 +32,9 @@ importers:
       hono:
         specifier: ^4.12.8
         version: 4.12.8
+      jose:
+        specifier: ^6.2.1
+        version: 6.2.1
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
@@ -45,11 +51,23 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))
 
 packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@emnapi/core@1.9.0':
+    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+
+  '@emnapi/runtime@1.9.0':
+    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@envelop/core@5.5.1':
     resolution: {integrity: sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw==}
@@ -557,6 +575,13 @@ packages:
     resolution: {integrity: sha512-Nv0BoDGLMg9QBKy9cIswQ3/6aKaKjlTh87x3GiBg2Z4RrjyrM48DvOOK0pJh1C1At+b0mUIM67cwZcFTDLN4sA==}
     engines: {node: '>=18.0.0'}
 
+  '@graphql-yoga/plugin-disable-introspection@2.19.1':
+    resolution: {integrity: sha512-AjnWg2/XTyCr1bHL1v3AZhjRPKK0qxHx9QMjI1p0dvPZnwhGy/hpKOYZBN2hN1EpOmbjnu5hlpineKWmcE4+Rw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^15.2.0 || ^16.0.0
+      graphql-yoga: ^5.18.1
+
   '@graphql-yoga/subscription@5.0.5':
     resolution: {integrity: sha512-oCMWOqFs6QV96/NZRt/ZhTQvzjkGB4YohBOpKM4jH/lDT4qb7Lex/aGCxpi/JD9njw3zBBtMqxbaC22+tFHVvw==}
     engines: {node: '>=18.0.0'}
@@ -571,6 +596,19 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@oxc-project/runtime@0.115.0':
+    resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.115.0':
+    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
   '@pothos/core@4.12.0':
     resolution: {integrity: sha512-PeiODrj3GjQ7Nbs/5p65DEyBWZTSGGjgGO/BgaMEqS1jBNX/2zJTEQJA9zM5uPmCHUCDjE7Qn2U7lOi0ALp/8A==}
     peerDependencies:
@@ -579,8 +617,150 @@ packages:
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.9':
+    resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   '@whatwg-node/disposablestack@0.0.6':
     resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
@@ -606,12 +786,27 @@ packages:
     resolution: {integrity: sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==}
     engines: {node: '>=18.0.0'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-inspect@1.0.1:
     resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
     engines: {node: '>=16.0.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -713,6 +908,9 @@ packages:
       sqlite3:
         optional: true
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
@@ -727,6 +925,22 @@ packages:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -750,8 +964,110 @@ packages:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
 
+  jose@6.2.1:
+    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.8:
     resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
@@ -760,12 +1076,45 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  rolldown@1.0.0-rc.9:
+    resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -786,9 +1135,108 @@ packages:
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
 
+  vite@8.0.0:
+    resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.0.0-alpha.31
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
 snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@emnapi/core@1.9.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@envelop/core@5.5.1':
     dependencies:
@@ -1088,6 +1536,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@graphql-yoga/plugin-disable-introspection@2.19.1(graphql-yoga@5.18.1(graphql@16.13.1))(graphql@16.13.1)':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.13.1
+      graphql-yoga: 5.18.1(graphql@16.13.1)
+
   '@graphql-yoga/subscription@5.0.5':
     dependencies:
       '@graphql-yoga/typed-event-target': 3.0.2
@@ -1104,15 +1558,134 @@ snapshots:
     dependencies:
       hono: 4.12.8
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.9.0
+      '@emnapi/runtime': 1.9.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/runtime@0.115.0': {}
+
+  '@oxc-project/types@0.115.0': {}
+
   '@pothos/core@4.12.0(graphql@16.13.1)':
     dependencies:
       graphql: 16.13.1
 
   '@repeaterjs/repeater@3.0.6': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.9': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:
@@ -1147,11 +1720,19 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   buffer-from@1.1.2: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
 
   cross-inspect@1.0.1:
     dependencies:
       tslib: 2.8.1
+
+  detect-libc@2.1.2: {}
 
   dotenv@17.3.1: {}
 
@@ -1165,6 +1746,8 @@ snapshots:
   drizzle-orm@0.45.1(postgres@3.4.8):
     optionalDependencies:
       postgres: 3.4.8
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -1249,6 +1832,16 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
   fsevents@2.3.3:
     optional: true
 
@@ -1276,11 +1869,107 @@ snapshots:
 
   hono@4.12.8: {}
 
+  jose@6.2.1: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lru-cache@10.4.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.11: {}
+
+  obug@2.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postgres@3.4.8: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  rolldown@1.0.0-rc.9:
+    dependencies:
+      '@oxc-project/types': 0.115.0
+      '@rolldown/pluginutils': 1.0.0-rc.9
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.9
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.9
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -1288,6 +1977,21 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   tslib@2.8.1: {}
 
@@ -1303,3 +2007,49 @@ snapshots:
   undici-types@7.18.2: {}
 
   urlpattern-polyfill@10.1.0: {}
+
+  vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0):
+    dependencies:
+      '@oxc-project/runtime': 0.115.0
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.9
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.5.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/backend/src/auth/__tests__/crypto.test.ts
+++ b/backend/src/auth/__tests__/crypto.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateEdKeyPair,
+  generateSalt,
+  hashPassword,
+  verifyPassword,
+  encryptPrivateKey,
+  decryptPrivateKey,
+} from "../crypto.js";
+
+describe("generateEdKeyPair", () => {
+  it("returns valid PEM-format key pair", () => {
+    const { publicKey, privateKey } = generateEdKeyPair();
+    expect(publicKey).toContain("-----BEGIN PUBLIC KEY-----");
+    expect(publicKey).toContain("-----END PUBLIC KEY-----");
+    expect(privateKey).toContain("-----BEGIN PRIVATE KEY-----");
+    expect(privateKey).toContain("-----END PRIVATE KEY-----");
+  });
+});
+
+describe("generateSalt", () => {
+  it("returns a 64-character hex string", () => {
+    const salt = generateSalt();
+    expect(salt).toHaveLength(64);
+    expect(salt).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("hashPassword / verifyPassword", () => {
+  it("verifies correct password", () => {
+    const salt = generateSalt();
+    const hash = hashPassword("testpassword", salt);
+    expect(verifyPassword("testpassword", salt, hash)).toBe(true);
+  });
+
+  it("rejects wrong password", () => {
+    const salt = generateSalt();
+    const hash = hashPassword("testpassword", salt);
+    expect(verifyPassword("wrongpassword", salt, hash)).toBe(false);
+  });
+});
+
+describe("encryptPrivateKey / decryptPrivateKey", () => {
+  it("round-trips successfully", () => {
+    const { privateKey } = generateEdKeyPair();
+    const salt = generateSalt();
+    const encrypted = encryptPrivateKey(privateKey, "mypassword", salt);
+    const decrypted = decryptPrivateKey(encrypted, "mypassword", salt);
+    expect(decrypted).toBe(privateKey);
+  });
+
+  it("throws on wrong password", () => {
+    const { privateKey } = generateEdKeyPair();
+    const salt = generateSalt();
+    const encrypted = encryptPrivateKey(privateKey, "mypassword", salt);
+    expect(() => decryptPrivateKey(encrypted, "wrongpassword", salt)).toThrow();
+  });
+});

--- a/backend/src/auth/__tests__/did.test.ts
+++ b/backend/src/auth/__tests__/did.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { generateDid } from "../did.js";
+
+describe("generateDid", () => {
+  it("returns correct DID format", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    const did = generateDid(uuid);
+    expect(did).toBe(`did:web:gleisner.app:u:${uuid}`);
+  });
+});

--- a/backend/src/auth/__tests__/jwt.test.ts
+++ b/backend/src/auth/__tests__/jwt.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { initJwtKeys, signToken, verifyToken } from "../jwt.js";
+
+describe("JWT", () => {
+  beforeAll(async () => {
+    await initJwtKeys();
+  });
+
+  it("signs and verifies a token (round-trip)", async () => {
+    const userId = "test-user-id";
+    const token = await signToken(userId);
+    const result = await verifyToken(token);
+    expect(result.userId).toBe(userId);
+  });
+
+  it("rejects an invalid token", async () => {
+    await expect(verifyToken("invalid.token.here")).rejects.toThrow();
+  });
+});

--- a/backend/src/auth/__tests__/middleware.test.ts
+++ b/backend/src/auth/__tests__/middleware.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Hono } from "hono";
+import { initJwtKeys, signToken } from "../jwt.js";
+import { authMiddleware, type AuthUser } from "../middleware.js";
+
+describe("authMiddleware", () => {
+  let app: Hono<{ Variables: { authUser?: AuthUser } }>;
+
+  beforeAll(async () => {
+    await initJwtKeys();
+
+    app = new Hono<{ Variables: { authUser?: AuthUser } }>();
+    app.use(authMiddleware);
+    app.get("/test", (c) => {
+      const authUser = c.get("authUser");
+      return c.json({ authUser: authUser ?? null });
+    });
+  });
+
+  it("sets authUser with valid Bearer token", async () => {
+    const token = await signToken("user-123");
+    const res = await app.request("/test", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = await res.json();
+    expect(body.authUser).toEqual({ userId: "user-123" });
+  });
+
+  it("leaves authUser undefined without token", async () => {
+    const res = await app.request("/test");
+    const body = await res.json();
+    expect(body.authUser).toBeNull();
+  });
+
+  it("leaves authUser undefined with invalid token", async () => {
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer invalid.token.here" },
+    });
+    const body = await res.json();
+    expect(body.authUser).toBeNull();
+  });
+});

--- a/backend/src/auth/crypto.ts
+++ b/backend/src/auth/crypto.ts
@@ -1,0 +1,63 @@
+import { generateKeyPairSync, scryptSync, randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
+
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 } as const;
+const SCRYPT_KEYLEN = 64;
+const AES_KEYLEN = 32;
+
+export interface KeyPair {
+  publicKey: string;
+  privateKey: string;
+}
+
+export function generateEdKeyPair(): KeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { publicKey, privateKey };
+}
+
+export function generateSalt(): string {
+  return randomBytes(32).toString("hex");
+}
+
+export function hashPassword(password: string, salt: string): string {
+  const saltBuf = Buffer.from(salt, "hex");
+  const hash = scryptSync(password, saltBuf, SCRYPT_KEYLEN, SCRYPT_PARAMS);
+  return hash.toString("hex");
+}
+
+export function verifyPassword(password: string, salt: string, hash: string): boolean {
+  const computed = hashPassword(password, salt);
+  // Constant-time comparison
+  if (computed.length !== hash.length) return false;
+  let diff = 0;
+  for (let i = 0; i < computed.length; i++) {
+    diff |= computed.charCodeAt(i) ^ hash.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function deriveEncryptionKey(password: string, salt: string): Buffer {
+  const saltBuf = Buffer.from(salt, "hex");
+  return scryptSync(password, saltBuf, AES_KEYLEN, SCRYPT_PARAMS);
+}
+
+export function encryptPrivateKey(privateKeyPem: string, password: string, encryptionSalt: string): string {
+  const key = deriveEncryptionKey(password, encryptionSalt);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(privateKeyPem, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  // Format: iv:authTag:encrypted (all hex)
+  return `${iv.toString("hex")}:${authTag.toString("hex")}:${encrypted.toString("hex")}`;
+}
+
+export function decryptPrivateKey(encrypted: string, password: string, encryptionSalt: string): string {
+  const [ivHex, authTagHex, dataHex] = encrypted.split(":");
+  const key = deriveEncryptionKey(password, encryptionSalt);
+  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(ivHex, "hex"));
+  decipher.setAuthTag(Buffer.from(authTagHex, "hex"));
+  const decrypted = Buffer.concat([decipher.update(Buffer.from(dataHex, "hex")), decipher.final()]);
+  return decrypted.toString("utf8");
+}

--- a/backend/src/auth/did.ts
+++ b/backend/src/auth/did.ts
@@ -1,0 +1,3 @@
+export function generateDid(userId: string): string {
+  return `did:web:gleisner.app:u:${userId}`;
+}

--- a/backend/src/auth/jwt.ts
+++ b/backend/src/auth/jwt.ts
@@ -1,0 +1,44 @@
+import { SignJWT, jwtVerify, importPKCS8, importSPKI, exportPKCS8, exportSPKI, generateKeyPair } from "jose";
+
+const ALG = "EdDSA";
+const TOKEN_EXPIRY = "24h";
+
+let privateKey: CryptoKey;
+let publicKey: CryptoKey;
+
+export async function initJwtKeys(privateKeyPem?: string, publicKeyPem?: string): Promise<void> {
+  if (privateKeyPem && publicKeyPem) {
+    privateKey = await importPKCS8(privateKeyPem, ALG);
+    publicKey = await importSPKI(publicKeyPem, ALG);
+  } else {
+    // Auto-generate for development
+    const keyPair = await generateKeyPair(ALG, { extractable: true });
+    privateKey = keyPair.privateKey;
+    publicKey = keyPair.publicKey;
+    const privPem = await exportPKCS8(keyPair.privateKey);
+    const pubPem = await exportSPKI(keyPair.publicKey);
+    console.log("JWT keys auto-generated (development mode)");
+    console.log("Set JWT_PRIVATE_KEY and JWT_PUBLIC_KEY env vars for production");
+    console.log(`JWT_PRIVATE_KEY=${JSON.stringify(privPem)}`);
+    console.log(`JWT_PUBLIC_KEY=${JSON.stringify(pubPem)}`);
+  }
+}
+
+export async function signToken(userId: string): Promise<string> {
+  return new SignJWT({ sub: userId })
+    .setProtectedHeader({ alg: ALG })
+    .setIssuedAt()
+    .setExpirationTime(TOKEN_EXPIRY)
+    .setIssuer("gleisner")
+    .sign(privateKey);
+}
+
+export async function verifyToken(token: string): Promise<{ userId: string }> {
+  const { payload } = await jwtVerify(token, publicKey, {
+    issuer: "gleisner",
+  });
+  if (!payload.sub) {
+    throw new Error("Invalid token: missing sub");
+  }
+  return { userId: payload.sub };
+}

--- a/backend/src/auth/middleware.ts
+++ b/backend/src/auth/middleware.ts
@@ -1,0 +1,21 @@
+import type { Context, Next } from "hono";
+import { verifyToken } from "./jwt.js";
+
+export interface AuthUser {
+  userId: string;
+}
+
+// Store auth user in Hono context variables
+export async function authMiddleware(c: Context, next: Next): Promise<void | Response> {
+  const header = c.req.header("Authorization");
+  if (header?.startsWith("Bearer ")) {
+    try {
+      const token = header.slice(7);
+      const { userId } = await verifyToken(token);
+      c.set("authUser", { userId } satisfies AuthUser);
+    } catch {
+      // Invalid token — continue as unauthenticated
+    }
+  }
+  await next();
+}

--- a/backend/src/db/schema/user.ts
+++ b/backend/src/db/schema/user.ts
@@ -8,8 +8,11 @@ export const users = pgTable("users", {
   displayName: varchar("display_name", { length: 50 }),
   bio: text("bio"),
   avatarUrl: text("avatar_url"),
+  passwordHash: text("password_hash").notNull(),
+  passwordSalt: text("password_salt").notNull(),
   publicKey: text("public_key").notNull(),
   encryptedPrivateKey: text("encrypted_private_key").notNull(),
+  encryptionSalt: text("encryption_salt").notNull(),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -11,5 +11,8 @@ function requireEnv(key: string): string {
 export const env = {
   DATABASE_URL: requireEnv("DATABASE_URL"),
   PORT: parseInt(process.env.PORT ?? "4000", 10),
-  JWT_SECRET: requireEnv("JWT_SECRET"),
+  NODE_ENV: process.env.NODE_ENV ?? "development",
+  // JWT EdDSA keys — optional in development (auto-generated), required in production
+  JWT_PRIVATE_KEY: process.env.JWT_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+  JWT_PUBLIC_KEY: process.env.JWT_PUBLIC_KEY?.replace(/\\n/g, "\n"),
 } as const;

--- a/backend/src/graphql/__tests__/auth.test.ts
+++ b/backend/src/graphql/__tests__/auth.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { createYoga } from "graphql-yoga";
+import { initJwtKeys, signToken } from "../../auth/jwt.js";
+import { authMiddleware, type AuthUser } from "../../auth/middleware.js";
+
+// Import GraphQL schema setup
+import { builder } from "../builder.js";
+import "../types/index.js";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) throw new Error("DATABASE_URL is required for integration tests");
+
+const client = postgres(DATABASE_URL);
+const db = drizzle(client);
+
+// Build the Hono app with GraphQL for testing
+function createTestApp() {
+  const schema = builder.toSchema();
+  const yoga = createYoga<{ authUser?: AuthUser }>({ schema, maskedErrors: false });
+
+  const app = new Hono<{ Variables: { authUser?: AuthUser } }>();
+  app.use(authMiddleware);
+  app.on(["GET", "POST"], "/graphql", async (c) => {
+    const authUser = c.get("authUser");
+    const response = await yoga.handleRequest(c.req.raw, { authUser });
+    return response;
+  });
+  return app;
+}
+
+async function gql(
+  app: ReturnType<typeof createTestApp>,
+  query: string,
+  variables?: Record<string, unknown>,
+  token?: string,
+) {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await app.request("/graphql", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+  return res.json() as Promise<{ data?: Record<string, unknown>; errors?: Array<{ message: string }> }>;
+}
+
+describe("Auth GraphQL integration", () => {
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeAll(async () => {
+    await initJwtKeys();
+    app = createTestApp();
+  });
+
+  beforeEach(async () => {
+    // Clean up users table before each test
+    await db.execute(sql`DELETE FROM users`);
+  });
+
+  const SIGNUP_MUTATION = `
+    mutation Signup($email: String!, $password: String!, $username: String!) {
+      signup(email: $email, password: $password, username: $username) {
+        token
+        user { id did email username publicKey }
+      }
+    }
+  `;
+
+  const LOGIN_MUTATION = `
+    mutation Login($email: String!, $password: String!) {
+      login(email: $email, password: $password) {
+        token
+        user { id email username }
+      }
+    }
+  `;
+
+  const ME_QUERY = `
+    query { me { id email username did } }
+  `;
+
+  describe("signup", () => {
+    it("creates a user and returns token + user", async () => {
+      const result = await gql(app, SIGNUP_MUTATION, {
+        email: "test@example.com",
+        password: "password123",
+        username: "testuser",
+      });
+
+      expect(result.errors).toBeUndefined();
+      const { token, user } = result.data!.signup as { token: string; user: Record<string, string> };
+      expect(token).toBeTruthy();
+      expect(user.email).toBe("test@example.com");
+      expect(user.username).toBe("testuser");
+      expect(user.did).toMatch(/^did:web:gleisner\.app:u:.+$/);
+      expect(user.publicKey).toContain("-----BEGIN PUBLIC KEY-----");
+    });
+
+    it("rejects password shorter than 8 characters", async () => {
+      const result = await gql(app, SIGNUP_MUTATION, {
+        email: "test@example.com",
+        password: "short",
+        username: "testuser",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("Password must be at least 8 characters");
+    });
+
+    it("rejects username shorter than 2 characters", async () => {
+      const result = await gql(app, SIGNUP_MUTATION, {
+        email: "test@example.com",
+        password: "password123",
+        username: "a",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("Username must be between 2 and 30 characters");
+    });
+
+    it("rejects username with invalid characters", async () => {
+      const result = await gql(app, SIGNUP_MUTATION, {
+        email: "test@example.com",
+        password: "password123",
+        username: "bad user!",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("Username can only contain letters, numbers, and underscores");
+    });
+
+    it("rejects duplicate email", async () => {
+      await gql(app, SIGNUP_MUTATION, {
+        email: "dup@example.com",
+        password: "password123",
+        username: "user1",
+      });
+
+      const result = await gql(app, SIGNUP_MUTATION, {
+        email: "dup@example.com",
+        password: "password123",
+        username: "user2",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("Email already registered");
+    });
+
+    it("rejects duplicate username", async () => {
+      await gql(app, SIGNUP_MUTATION, {
+        email: "user1@example.com",
+        password: "password123",
+        username: "sameuser",
+      });
+
+      const result = await gql(app, SIGNUP_MUTATION, {
+        email: "user2@example.com",
+        password: "password123",
+        username: "sameuser",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("Username already taken");
+    });
+  });
+
+  describe("login", () => {
+    beforeEach(async () => {
+      // Create a user for login tests
+      await gql(app, SIGNUP_MUTATION, {
+        email: "login@example.com",
+        password: "password123",
+        username: "loginuser",
+      });
+    });
+
+    it("returns token + user with valid credentials", async () => {
+      const result = await gql(app, LOGIN_MUTATION, {
+        email: "login@example.com",
+        password: "password123",
+      });
+
+      expect(result.errors).toBeUndefined();
+      const { token, user } = result.data!.login as { token: string; user: Record<string, string> };
+      expect(token).toBeTruthy();
+      expect(user.email).toBe("login@example.com");
+      expect(user.username).toBe("loginuser");
+    });
+
+    it("rejects wrong password", async () => {
+      const result = await gql(app, LOGIN_MUTATION, {
+        email: "login@example.com",
+        password: "wrongpassword",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("Invalid credentials");
+    });
+
+    it("rejects non-existent email", async () => {
+      const result = await gql(app, LOGIN_MUTATION, {
+        email: "nobody@example.com",
+        password: "password123",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("Invalid credentials");
+    });
+  });
+
+  describe("me", () => {
+    it("returns user info when authenticated", async () => {
+      const signupResult = await gql(app, SIGNUP_MUTATION, {
+        email: "me@example.com",
+        password: "password123",
+        username: "meuser",
+      });
+      const { token } = signupResult.data!.signup as { token: string };
+
+      const result = await gql(app, ME_QUERY, undefined, token);
+
+      expect(result.errors).toBeUndefined();
+      const me = result.data!.me as Record<string, string>;
+      expect(me.email).toBe("me@example.com");
+      expect(me.username).toBe("meuser");
+      expect(me.did).toMatch(/^did:web:gleisner\.app:u:.+$/);
+    });
+
+    it("returns null when not authenticated", async () => {
+      const result = await gql(app, ME_QUERY);
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data!.me).toBeNull();
+    });
+  });
+});

--- a/backend/src/graphql/builder.ts
+++ b/backend/src/graphql/builder.ts
@@ -1,3 +1,8 @@
 import SchemaBuilder from "@pothos/core";
+import type { AuthUser } from "../auth/middleware.js";
 
-export const builder = new SchemaBuilder({});
+export interface GraphQLContext {
+  authUser?: AuthUser;
+}
+
+export const builder = new SchemaBuilder<{ Context: GraphQLContext }>({});

--- a/backend/src/graphql/index.ts
+++ b/backend/src/graphql/index.ts
@@ -1,7 +1,17 @@
 import { createYoga } from "graphql-yoga";
+import { useDisableIntrospection } from "@graphql-yoga/plugin-disable-introspection";
 import { builder } from "./builder.js";
+import { env } from "../env.js";
+import type { AuthUser } from "../auth/middleware.js";
 import "./types/index.js";
 
 const schema = builder.toSchema();
 
-export const yoga = createYoga({ schema });
+const isProduction = env.NODE_ENV === "production";
+
+export const yoga = createYoga<{ authUser?: AuthUser }>({
+  schema,
+  graphiql: !isProduction,
+  maskedErrors: isProduction,
+  plugins: isProduction ? [useDisableIntrospection()] : [],
+});

--- a/backend/src/graphql/types/auth.ts
+++ b/backend/src/graphql/types/auth.ts
@@ -1,0 +1,110 @@
+import { GraphQLError } from "graphql";
+import { builder } from "../builder.js";
+import { UserType } from "./user.js";
+import { db } from "../../db/index.js";
+import { users } from "../../db/schema/index.js";
+import { eq } from "drizzle-orm";
+import { generateEdKeyPair, generateSalt, hashPassword, verifyPassword, encryptPrivateKey } from "../../auth/crypto.js";
+import { generateDid } from "../../auth/did.js";
+import { signToken } from "../../auth/jwt.js";
+
+const AuthPayload = builder.objectRef<{ token: string; user: typeof users.$inferSelect }>("AuthPayload");
+
+AuthPayload.implement({
+  fields: (t) => ({
+    token: t.exposeString("token"),
+    user: t.field({ type: UserType, resolve: (parent) => parent.user }),
+  }),
+});
+
+builder.mutationType({
+  fields: (t) => ({
+    signup: t.field({
+      type: AuthPayload,
+      args: {
+        email: t.arg.string({ required: true }),
+        password: t.arg.string({ required: true }),
+        username: t.arg.string({ required: true }),
+      },
+      resolve: async (_parent, args) => {
+        // Validate
+        if (args.password.length < 8) {
+          throw new GraphQLError("Password must be at least 8 characters");
+        }
+        if (args.username.length < 2 || args.username.length > 30) {
+          throw new GraphQLError("Username must be between 2 and 30 characters");
+        }
+        if (!/^[a-zA-Z0-9_]+$/.test(args.username)) {
+          throw new GraphQLError("Username can only contain letters, numbers, and underscores");
+        }
+
+        // Check uniqueness
+        const existing = await db.select({ id: users.id })
+          .from(users)
+          .where(eq(users.email, args.email))
+          .limit(1);
+        if (existing.length > 0) {
+          throw new GraphQLError("Email already registered");
+        }
+
+        const existingUsername = await db.select({ id: users.id })
+          .from(users)
+          .where(eq(users.username, args.username))
+          .limit(1);
+        if (existingUsername.length > 0) {
+          throw new GraphQLError("Username already taken");
+        }
+
+        // Generate keys and credentials
+        const { publicKey, privateKey } = generateEdKeyPair();
+        const passwordSalt = generateSalt();
+        const encryptionSalt = generateSalt();
+        const passwordHashValue = hashPassword(args.password, passwordSalt);
+        const encryptedPrivateKey = encryptPrivateKey(privateKey, args.password, encryptionSalt);
+
+        // Insert user — DID uses the generated UUID
+        const [user] = await db.insert(users).values({
+          email: args.email,
+          username: args.username,
+          passwordHash: passwordHashValue,
+          passwordSalt,
+          publicKey,
+          encryptedPrivateKey,
+          encryptionSalt,
+          did: "pending", // Temporary, updated after we have the ID
+        }).returning();
+
+        // Update DID with actual user ID
+        const did = generateDid(user.id);
+        const [updatedUser] = await db.update(users)
+          .set({ did })
+          .where(eq(users.id, user.id))
+          .returning();
+
+        const token = await signToken(updatedUser.id);
+        return { token, user: updatedUser };
+      },
+    }),
+
+    login: t.field({
+      type: AuthPayload,
+      args: {
+        email: t.arg.string({ required: true }),
+        password: t.arg.string({ required: true }),
+      },
+      resolve: async (_parent, args) => {
+        const [user] = await db.select()
+          .from(users)
+          .where(eq(users.email, args.email))
+          .limit(1);
+
+        if (!user || !verifyPassword(args.password, user.passwordSalt, user.passwordHash)) {
+          throw new GraphQLError("Invalid credentials");
+        }
+
+        const token = await signToken(user.id);
+        return { token, user };
+      },
+    }),
+  }),
+});

--- a/backend/src/graphql/types/index.ts
+++ b/backend/src/graphql/types/index.ts
@@ -1,9 +1,27 @@
+import { GraphQLError } from "graphql";
 import { builder } from "../builder.js";
+import { db } from "../../db/index.js";
+import { users } from "../../db/schema/index.js";
+import { eq } from "drizzle-orm";
+import { UserType } from "./user.js";
+import "./auth.js";
 
 builder.queryType({
   fields: (t) => ({
     hello: t.string({
       resolve: () => "Gleisner API is running",
+    }),
+    me: t.field({
+      type: UserType,
+      nullable: true,
+      resolve: async (_parent, _args, ctx) => {
+        if (!ctx.authUser) return null;
+        const [user] = await db.select()
+          .from(users)
+          .where(eq(users.id, ctx.authUser.userId))
+          .limit(1);
+        return user ?? null;
+      },
     }),
   }),
 });

--- a/backend/src/graphql/types/user.ts
+++ b/backend/src/graphql/types/user.ts
@@ -1,0 +1,29 @@
+import { builder } from "../builder.js";
+
+export const UserType = builder.objectRef<{
+  id: string;
+  did: string;
+  email: string;
+  username: string;
+  displayName: string | null;
+  bio: string | null;
+  avatarUrl: string | null;
+  publicKey: string;
+  createdAt: Date;
+  updatedAt: Date;
+}>("User");
+
+UserType.implement({
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    did: t.exposeString("did"),
+    email: t.exposeString("email"),
+    username: t.exposeString("username"),
+    displayName: t.exposeString("displayName", { nullable: true }),
+    bio: t.exposeString("bio", { nullable: true }),
+    avatarUrl: t.exposeString("avatarUrl", { nullable: true }),
+    publicKey: t.exposeString("publicKey"),
+    createdAt: t.string({ resolve: (user) => user.createdAt.toISOString() }),
+    updatedAt: t.string({ resolve: (user) => user.updatedAt.toISOString() }),
+  }),
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,19 +4,29 @@ import { serve } from "@hono/node-server";
 import { env } from "./env.js";
 import { health } from "./routes/health.js";
 import { yoga } from "./graphql/index.js";
+import { authMiddleware, type AuthUser } from "./auth/middleware.js";
+import { initJwtKeys } from "./auth/jwt.js";
 
-const app = new Hono();
+type HonoEnv = { Variables: { authUser?: AuthUser } };
+
+const app = new Hono<HonoEnv>();
 
 app.use(logger());
+app.use(authMiddleware);
 app.route("/", health);
 app.on(["GET", "POST"], "/graphql", async (c) => {
-  const response = await yoga.handleRequest(c.req.raw, {});
+  const authUser = c.get("authUser");
+  const response = await yoga.handleRequest(c.req.raw, { authUser });
   return response;
 });
 
-console.log(`Gleisner API listening on port ${env.PORT}`);
+async function start() {
+  await initJwtKeys(env.JWT_PRIVATE_KEY, env.JWT_PUBLIC_KEY);
+  console.log(`Gleisner API listening on port ${env.PORT}`);
+  serve({
+    fetch: app.fetch,
+    port: env.PORT,
+  });
+}
 
-serve({
-  fetch: app.fetch,
-  port: env.PORT,
-});
+start();

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

- Implement authentication layer: Ed25519 key pair generation, scrypt password hashing, AES-256-GCM private key encryption, JWT EdDSA signing/verification, Hono auth middleware
- Add GraphQL mutations (`signup`, `login`) and query (`me`) with input validation and error handling
- Add comprehensive test suite (23 tests) covering unit tests (crypto, DID, JWT, middleware) and integration tests (signup/login/me against real PostgreSQL)

## Test plan

- [x] `pnpm test` — all 23 tests pass (unit + integration)
- [x] Manual verification: signup → login → me flow via GraphiQL
- [ ] Verify DB schema migration (`pnpm db:push`) on fresh database

🤖 Generated with [Claude Code](https://claude.com/claude-code)