### PR TITLE
Add Artist CRUD with schema updates and tests

### DIFF
--- a/backend/drizzle/0000_sturdy_johnny_blaze.sql
+++ b/backend/drizzle/0000_sturdy_johnny_blaze.sql
@@ -1,0 +1,154 @@
+CREATE TYPE "public"."connection_type" AS ENUM('reply', 'remix', 'reference', 'evolution');--> statement-breakpoint
+CREATE TYPE "public"."link_category" AS ENUM('social', 'music', 'video', 'website', 'store', 'other');--> statement-breakpoint
+CREATE TYPE "public"."media_type" AS ENUM('text', 'image', 'video', 'audio', 'link');--> statement-breakpoint
+CREATE TABLE "artist_genres" (
+	"artist_id" uuid NOT NULL,
+	"genre_id" uuid NOT NULL,
+	"position" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "artist_genres_artist_id_genre_id_pk" PRIMARY KEY("artist_id","genre_id")
+);
+--> statement-breakpoint
+CREATE TABLE "artist_links" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"artist_id" uuid NOT NULL,
+	"link_category" "link_category" NOT NULL,
+	"platform" varchar(50) NOT NULL,
+	"url" text NOT NULL,
+	"position" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "artists" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"artist_username" varchar(30) NOT NULL,
+	"display_name" varchar(50),
+	"bio" text,
+	"tagline" varchar(80),
+	"location" varchar(100),
+	"active_since" integer,
+	"avatar_url" text,
+	"cover_image_url" text,
+	"tuned_in_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "artists_user_id_unique" UNIQUE("user_id"),
+	CONSTRAINT "artists_artist_username_unique" UNIQUE("artist_username")
+);
+--> statement-breakpoint
+CREATE TABLE "comments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"body" varchar(500) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "connections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"source_id" uuid NOT NULL,
+	"target_id" uuid NOT NULL,
+	"connection_type" "connection_type" NOT NULL,
+	"group_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "source_neq_target" CHECK ("connections"."source_id" != "connections"."target_id")
+);
+--> statement-breakpoint
+CREATE TABLE "follows" (
+	"follower_id" uuid NOT NULL,
+	"following_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "follows_follower_id_following_id_pk" PRIMARY KEY("follower_id","following_id"),
+	CONSTRAINT "follower_neq_following" CHECK ("follows"."follower_id" != "follows"."following_id")
+);
+--> statement-breakpoint
+CREATE TABLE "genres" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(50) NOT NULL,
+	"normalized_name" varchar(50) NOT NULL,
+	"is_promoted" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "genres_name_unique" UNIQUE("name"),
+	CONSTRAINT "genres_normalized_name_unique" UNIQUE("normalized_name")
+);
+--> statement-breakpoint
+CREATE TABLE "posts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"track_id" uuid NOT NULL,
+	"author_id" uuid NOT NULL,
+	"media_type" "media_type" NOT NULL,
+	"title" varchar(100),
+	"body" text,
+	"media_url" text,
+	"importance" real DEFAULT 0.5 NOT NULL,
+	"content_hash" varchar(64),
+	"signature" text,
+	"layout_x" integer DEFAULT 0 NOT NULL,
+	"layout_y" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "reactions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"emoji" varchar(10) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "reactions_post_id_user_id_emoji_unique" UNIQUE("post_id","user_id","emoji")
+);
+--> statement-breakpoint
+CREATE TABLE "tracks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"artist_id" uuid NOT NULL,
+	"name" varchar(30) NOT NULL,
+	"color" varchar(7) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "tune_ins" (
+	"user_id" uuid NOT NULL,
+	"artist_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tune_ins_user_id_artist_id_pk" PRIMARY KEY("user_id","artist_id")
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"did" varchar(255) NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"username" varchar(30) NOT NULL,
+	"display_name" varchar(50),
+	"bio" text,
+	"avatar_url" text,
+	"password_hash" text NOT NULL,
+	"password_salt" text NOT NULL,
+	"public_key" text NOT NULL,
+	"encrypted_private_key" text NOT NULL,
+	"encryption_salt" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "users_did_unique" UNIQUE("did"),
+	CONSTRAINT "users_email_unique" UNIQUE("email"),
+	CONSTRAINT "users_username_unique" UNIQUE("username")
+);
+--> statement-breakpoint
+ALTER TABLE "artist_genres" ADD CONSTRAINT "artist_genres_artist_id_artists_id_fk" FOREIGN KEY ("artist_id") REFERENCES "public"."artists"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "artist_genres" ADD CONSTRAINT "artist_genres_genre_id_genres_id_fk" FOREIGN KEY ("genre_id") REFERENCES "public"."genres"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "artist_links" ADD CONSTRAINT "artist_links_artist_id_artists_id_fk" FOREIGN KEY ("artist_id") REFERENCES "public"."artists"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "artists" ADD CONSTRAINT "artists_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_post_id_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."posts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "connections" ADD CONSTRAINT "connections_source_id_posts_id_fk" FOREIGN KEY ("source_id") REFERENCES "public"."posts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "connections" ADD CONSTRAINT "connections_target_id_posts_id_fk" FOREIGN KEY ("target_id") REFERENCES "public"."posts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "follows" ADD CONSTRAINT "follows_follower_id_users_id_fk" FOREIGN KEY ("follower_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "follows" ADD CONSTRAINT "follows_following_id_users_id_fk" FOREIGN KEY ("following_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "posts" ADD CONSTRAINT "posts_track_id_tracks_id_fk" FOREIGN KEY ("track_id") REFERENCES "public"."tracks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "posts" ADD CONSTRAINT "posts_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reactions" ADD CONSTRAINT "reactions_post_id_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."posts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reactions" ADD CONSTRAINT "reactions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tracks" ADD CONSTRAINT "tracks_artist_id_artists_id_fk" FOREIGN KEY ("artist_id") REFERENCES "public"."artists"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tune_ins" ADD CONSTRAINT "tune_ins_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tune_ins" ADD CONSTRAINT "tune_ins_artist_id_artists_id_fk" FOREIGN KEY ("artist_id") REFERENCES "public"."artists"("id") ON DELETE cascade ON UPDATE no action;

--- a/backend/drizzle/meta/0000_snapshot.json
+++ b/backend/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,1081 @@
+{
+  "id": "aedab057-3da5-4d9b-b972-c42b282c0b02",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.artist_genres": {
+      "name": "artist_genres",
+      "schema": "",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_genres_artist_id_artists_id_fk": {
+          "name": "artist_genres_artist_id_artists_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_genres_genre_id_genres_id_fk": {
+          "name": "artist_genres_genre_id_genres_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_genres_artist_id_genre_id_pk": {
+          "name": "artist_genres_artist_id_genre_id_pk",
+          "columns": [
+            "artist_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_links": {
+      "name": "artist_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_category": {
+          "name": "link_category",
+          "type": "link_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_links_artist_id_artists_id_fk": {
+          "name": "artist_links_artist_id_artists_id_fk",
+          "tableFrom": "artist_links",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_username": {
+          "name": "artist_username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_since": {
+          "name": "active_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tuned_in_count": {
+          "name": "tuned_in_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artists_user_id_users_id_fk": {
+          "name": "artists_user_id_users_id_fk",
+          "tableFrom": "artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artists_user_id_unique": {
+          "name": "artists_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "artists_artist_username_unique": {
+          "name": "artists_artist_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_post_id_posts_id_fk": {
+          "name": "comments_post_id_posts_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "connection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connections_source_id_posts_id_fk": {
+          "name": "connections_source_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_target_id_posts_id_fk": {
+          "name": "connections_target_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_neq_target": {
+          "name": "source_neq_target",
+          "value": "\"connections\".\"source_id\" != \"connections\".\"target_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "name": "follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "follower_neq_following": {
+          "name": "follower_neq_following",
+          "value": "\"follows\".\"follower_id\" != \"follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_promoted": {
+          "name": "is_promoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "genres_normalized_name_unique": {
+          "name": "genres_normalized_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "normalized_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importance": {
+          "name": "importance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_x": {
+          "name": "layout_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "layout_y": {
+          "name": "layout_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_track_id_tracks_id_fk": {
+          "name": "posts_track_id_tracks_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reactions_post_id_posts_id_fk": {
+          "name": "reactions_post_id_posts_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_user_id_users_id_fk": {
+          "name": "reactions_user_id_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_post_id_user_id_emoji_unique": {
+          "name": "reactions_post_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracks": {
+      "name": "tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_artist_id_artists_id_fk": {
+          "name": "tracks_artist_id_artists_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tune_ins": {
+      "name": "tune_ins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tune_ins_user_id_users_id_fk": {
+          "name": "tune_ins_user_id_users_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tune_ins_artist_id_artists_id_fk": {
+          "name": "tune_ins_artist_id_artists_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tune_ins_user_id_artist_id_pk": {
+          "name": "tune_ins_user_id_artist_id_pk",
+          "columns": [
+            "user_id",
+            "artist_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "did": {
+          "name": "did",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_salt": {
+          "name": "password_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_private_key": {
+          "name": "encrypted_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_salt": {
+          "name": "encryption_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_did_unique": {
+          "name": "users_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_type": {
+      "name": "connection_type",
+      "schema": "public",
+      "values": [
+        "reply",
+        "remix",
+        "reference",
+        "evolution"
+      ]
+    },
+    "public.link_category": {
+      "name": "link_category",
+      "schema": "public",
+      "values": [
+        "social",
+        "music",
+        "video",
+        "website",
+        "store",
+        "other"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "link"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1773852087051,
+      "tag": "0000_sturdy_johnny_blaze",
+      "breakpoints": true
+    }
+  ]
+}

--- a/backend/src/db/schema/artist.ts
+++ b/backend/src/db/schema/artist.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, uuid, varchar, text, integer, timestamp } from "drizzle-orm/pg-core";
 import { users } from "./user.js";
 
 export const artists = pgTable("artists", {
@@ -10,7 +10,12 @@ export const artists = pgTable("artists", {
   artistUsername: varchar("artist_username", { length: 30 }).unique().notNull(),
   displayName: varchar("display_name", { length: 50 }),
   bio: text("bio"),
-  headerImageUrl: text("header_image_url"),
+  tagline: varchar("tagline", { length: 80 }),
+  location: varchar("location", { length: 100 }),
+  activeSince: integer("active_since"),
+  avatarUrl: text("avatar_url"),
+  coverImageUrl: text("cover_image_url"),
+  tunedInCount: integer("tuned_in_count").default(0).notNull(),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });

--- a/backend/src/graphql/__tests__/artist.test.ts
+++ b/backend/src/graphql/__tests__/artist.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { createYoga } from "graphql-yoga";
+import { initJwtKeys } from "../../auth/jwt.js";
+import { authMiddleware, type AuthUser } from "../../auth/middleware.js";
+
+import { builder } from "../builder.js";
+import "../types/index.js";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) throw new Error("DATABASE_URL is required for integration tests");
+
+const client = postgres(DATABASE_URL);
+const db = drizzle(client);
+
+function createTestApp() {
+  const schema = builder.toSchema();
+  const yoga = createYoga<{ authUser?: AuthUser }>({ schema, maskedErrors: false });
+
+  const app = new Hono<{ Variables: { authUser?: AuthUser } }>();
+  app.use(authMiddleware);
+  app.on(["GET", "POST"], "/graphql", async (c) => {
+    const authUser = c.get("authUser");
+    const response = await yoga.handleRequest(c.req.raw, { authUser });
+    return response;
+  });
+  return app;
+}
+
+async function gql(
+  app: ReturnType<typeof createTestApp>,
+  query: string,
+  variables?: Record<string, unknown>,
+  token?: string,
+) {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await app.request("/graphql", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+  return res.json() as Promise<{ data?: Record<string, unknown>; errors?: Array<{ message: string }> }>;
+}
+
+const SIGNUP_MUTATION = `
+  mutation Signup($email: String!, $password: String!, $username: String!) {
+    signup(email: $email, password: $password, username: $username) {
+      token
+      user { id }
+    }
+  }
+`;
+
+const REGISTER_ARTIST_MUTATION = `
+  mutation RegisterArtist(
+    $artistUsername: String!,
+    $displayName: String!,
+    $tagline: String,
+    $location: String,
+    $activeSince: Int,
+    $avatarUrl: String,
+    $coverImageUrl: String
+  ) {
+    registerArtist(
+      artistUsername: $artistUsername,
+      displayName: $displayName,
+      tagline: $tagline,
+      location: $location,
+      activeSince: $activeSince,
+      avatarUrl: $avatarUrl,
+      coverImageUrl: $coverImageUrl
+    ) {
+      id artistUsername displayName bio tagline location activeSince avatarUrl coverImageUrl tunedInCount createdAt updatedAt
+    }
+  }
+`;
+
+const UPDATE_ARTIST_MUTATION = `
+  mutation UpdateArtist(
+    $displayName: String,
+    $bio: String,
+    $tagline: String,
+    $location: String,
+    $activeSince: Int,
+    $avatarUrl: String,
+    $coverImageUrl: String
+  ) {
+    updateArtist(
+      displayName: $displayName,
+      bio: $bio,
+      tagline: $tagline,
+      location: $location,
+      activeSince: $activeSince,
+      avatarUrl: $avatarUrl,
+      coverImageUrl: $coverImageUrl
+    ) {
+      id artistUsername displayName bio tagline location activeSince avatarUrl coverImageUrl tunedInCount
+    }
+  }
+`;
+
+const ARTIST_QUERY = `
+  query Artist($username: String!) {
+    artist(username: $username) {
+      id artistUsername displayName bio tagline location activeSince avatarUrl coverImageUrl tunedInCount
+    }
+  }
+`;
+
+async function signupAndGetToken(app: ReturnType<typeof createTestApp>, email: string, username: string) {
+  const result = await gql(app, SIGNUP_MUTATION, { email, password: "password123", username });
+  return (result.data!.signup as { token: string }).token;
+}
+
+describe("Artist GraphQL integration", () => {
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeAll(async () => {
+    await initJwtKeys();
+    app = createTestApp();
+  });
+
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE users CASCADE`);
+  });
+
+  describe("registerArtist", () => {
+    it("registers with required fields only", async () => {
+      const token = await signupAndGetToken(app, "artist1@example.com", "user1");
+
+      const result = await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "myartist",
+        displayName: "My Artist",
+      }, token);
+
+      expect(result.errors).toBeUndefined();
+      const artist = result.data!.registerArtist as Record<string, unknown>;
+      expect(artist.artistUsername).toBe("myartist");
+      expect(artist.displayName).toBe("My Artist");
+      expect(artist.bio).toBeNull();
+      expect(artist.tagline).toBeNull();
+      expect(artist.location).toBeNull();
+      expect(artist.activeSince).toBeNull();
+      expect(artist.avatarUrl).toBeNull();
+      expect(artist.coverImageUrl).toBeNull();
+      expect(artist.tunedInCount).toBe(0);
+    });
+
+    it("registers with all fields", async () => {
+      const token = await signupAndGetToken(app, "artist2@example.com", "user2");
+
+      const result = await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "fullartist",
+        displayName: "Full Artist",
+        tagline: "Making music since forever",
+        location: "Tokyo, Japan",
+        activeSince: 2010,
+        avatarUrl: "https://example.com/avatar.jpg",
+        coverImageUrl: "https://example.com/cover.jpg",
+      }, token);
+
+      expect(result.errors).toBeUndefined();
+      const artist = result.data!.registerArtist as Record<string, unknown>;
+      expect(artist.artistUsername).toBe("fullartist");
+      expect(artist.displayName).toBe("Full Artist");
+      expect(artist.tagline).toBe("Making music since forever");
+      expect(artist.location).toBe("Tokyo, Japan");
+      expect(artist.activeSince).toBe(2010);
+      expect(artist.avatarUrl).toBe("https://example.com/avatar.jpg");
+      expect(artist.coverImageUrl).toBe("https://example.com/cover.jpg");
+      expect(artist.tunedInCount).toBe(0);
+    });
+
+    it("rejects if user is already an artist", async () => {
+      const token = await signupAndGetToken(app, "artist3@example.com", "user3");
+      await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "first_artist",
+        displayName: "First",
+      }, token);
+
+      const result = await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "second_artist",
+        displayName: "Second",
+      }, token);
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("User is already registered as an artist");
+    });
+
+    it("rejects duplicate artist username", async () => {
+      const token1 = await signupAndGetToken(app, "a4@example.com", "user4");
+      await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "taken_name",
+        displayName: "First",
+      }, token1);
+
+      const token2 = await signupAndGetToken(app, "a5@example.com", "user5");
+      const result = await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "taken_name",
+        displayName: "Second",
+      }, token2);
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Artist username already taken");
+    });
+
+    it("rejects unauthenticated request", async () => {
+      const result = await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "noauth",
+        displayName: "No Auth",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Authentication required");
+    });
+
+    it("rejects invalid characters in username", async () => {
+      const token = await signupAndGetToken(app, "a6@example.com", "user6");
+
+      const result = await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "bad user!",
+        displayName: "Bad",
+      }, token);
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("Artist username can only contain");
+    });
+
+    it("rejects too short username", async () => {
+      const token = await signupAndGetToken(app, "a7@example.com", "user7");
+
+      const result = await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "a",
+        displayName: "Short",
+      }, token);
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("Artist username must be between 2 and 30");
+    });
+  });
+
+  describe("updateArtist", () => {
+    it("updates artist fields", async () => {
+      const token = await signupAndGetToken(app, "upd@example.com", "upduser");
+      await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "updartist",
+        displayName: "Original",
+      }, token);
+
+      const result = await gql(app, UPDATE_ARTIST_MUTATION, {
+        displayName: "Updated Name",
+        bio: "My bio",
+        tagline: "New tagline",
+        location: "Osaka, Japan",
+      }, token);
+
+      expect(result.errors).toBeUndefined();
+      const artist = result.data!.updateArtist as Record<string, unknown>;
+      expect(artist.displayName).toBe("Updated Name");
+      expect(artist.bio).toBe("My bio");
+      expect(artist.tagline).toBe("New tagline");
+      expect(artist.location).toBe("Osaka, Japan");
+      expect(artist.artistUsername).toBe("updartist");
+    });
+
+    it("clears fields when null is passed", async () => {
+      const token = await signupAndGetToken(app, "clr@example.com", "clruser");
+      await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "clrartist",
+        displayName: "Original",
+        tagline: "Will be cleared",
+        location: "Will be cleared",
+      }, token);
+
+      const result = await gql(app, UPDATE_ARTIST_MUTATION, {
+        tagline: null,
+        location: null,
+      }, token);
+
+      expect(result.errors).toBeUndefined();
+      const artist = result.data!.updateArtist as Record<string, unknown>;
+      expect(artist.tagline).toBeNull();
+      expect(artist.location).toBeNull();
+      expect(artist.displayName).toBe("Original");
+    });
+
+    it("rejects if artist profile not found", async () => {
+      const token = await signupAndGetToken(app, "noprof@example.com", "noprof");
+
+      const result = await gql(app, UPDATE_ARTIST_MUTATION, {
+        displayName: "No Profile",
+      }, token);
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Artist profile not found");
+    });
+
+    it("rejects unauthenticated request", async () => {
+      const result = await gql(app, UPDATE_ARTIST_MUTATION, {
+        displayName: "No Auth",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Authentication required");
+    });
+  });
+
+  describe("artist query", () => {
+    it("returns artist by username", async () => {
+      const token = await signupAndGetToken(app, "q1@example.com", "quser1");
+      await gql(app, REGISTER_ARTIST_MUTATION, {
+        artistUsername: "queryartist",
+        displayName: "Query Artist",
+        tagline: "Hello world",
+      }, token);
+
+      const result = await gql(app, ARTIST_QUERY, { username: "queryartist" });
+
+      expect(result.errors).toBeUndefined();
+      const artist = result.data!.artist as Record<string, unknown>;
+      expect(artist.artistUsername).toBe("queryartist");
+      expect(artist.displayName).toBe("Query Artist");
+      expect(artist.tagline).toBe("Hello world");
+    });
+
+    it("returns null for non-existent username", async () => {
+      const result = await gql(app, ARTIST_QUERY, { username: "nonexistent" });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data!.artist).toBeNull();
+    });
+  });
+});

--- a/backend/src/graphql/__tests__/auth.test.ts
+++ b/backend/src/graphql/__tests__/auth.test.ts
@@ -59,8 +59,7 @@ describe("Auth GraphQL integration", () => {
   });
 
   beforeEach(async () => {
-    // Clean up users table before each test
-    await db.execute(sql`DELETE FROM users`);
+    await db.execute(sql`TRUNCATE users CASCADE`);
   });
 
   const SIGNUP_MUTATION = `

--- a/backend/src/graphql/types/artist.ts
+++ b/backend/src/graphql/types/artist.ts
@@ -1,0 +1,193 @@
+import { GraphQLError } from "graphql";
+import { builder } from "../builder.js";
+import { db } from "../../db/index.js";
+import { artists } from "../../db/schema/index.js";
+import { eq } from "drizzle-orm";
+
+export const ArtistType = builder.objectRef<{
+  id: string;
+  userId: string;
+  artistUsername: string;
+  displayName: string | null;
+  bio: string | null;
+  tagline: string | null;
+  location: string | null;
+  activeSince: number | null;
+  avatarUrl: string | null;
+  coverImageUrl: string | null;
+  tunedInCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}>("Artist");
+
+ArtistType.implement({
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    artistUsername: t.exposeString("artistUsername"),
+    displayName: t.exposeString("displayName", { nullable: true }),
+    bio: t.exposeString("bio", { nullable: true }),
+    tagline: t.exposeString("tagline", { nullable: true }),
+    location: t.exposeString("location", { nullable: true }),
+    activeSince: t.exposeInt("activeSince", { nullable: true }),
+    avatarUrl: t.exposeString("avatarUrl", { nullable: true }),
+    coverImageUrl: t.exposeString("coverImageUrl", { nullable: true }),
+    tunedInCount: t.exposeInt("tunedInCount"),
+    createdAt: t.string({ resolve: (artist) => artist.createdAt.toISOString() }),
+    updatedAt: t.string({ resolve: (artist) => artist.updatedAt.toISOString() }),
+  }),
+});
+
+builder.mutationFields((t) => ({
+  registerArtist: t.field({
+    type: ArtistType,
+    args: {
+      artistUsername: t.arg.string({ required: true }),
+      displayName: t.arg.string({ required: true }),
+      tagline: t.arg.string(),
+      location: t.arg.string(),
+      activeSince: t.arg.int(),
+      avatarUrl: t.arg.string(),
+      coverImageUrl: t.arg.string(),
+    },
+    resolve: async (_parent, args, ctx) => {
+      if (!ctx.authUser) {
+        throw new GraphQLError("Authentication required");
+      }
+
+      // Validate artistUsername
+      if (args.artistUsername.length < 2 || args.artistUsername.length > 30) {
+        throw new GraphQLError("Artist username must be between 2 and 30 characters");
+      }
+      if (!/^[a-zA-Z0-9_]+$/.test(args.artistUsername)) {
+        throw new GraphQLError("Artist username can only contain letters, numbers, and underscores");
+      }
+
+      // Validate displayName
+      if (args.displayName.length < 1 || args.displayName.length > 50) {
+        throw new GraphQLError("Display name must be between 1 and 50 characters");
+      }
+
+      // Validate optional fields
+      if (args.tagline && args.tagline.length > 80) {
+        throw new GraphQLError("Tagline must be 80 characters or less");
+      }
+      if (args.location && args.location.length > 100) {
+        throw new GraphQLError("Location must be 100 characters or less");
+      }
+      if (args.activeSince != null) {
+        const currentYear = new Date().getFullYear();
+        if (args.activeSince < 1900 || args.activeSince > currentYear) {
+          throw new GraphQLError(`Active since must be between 1900 and ${currentYear}`);
+        }
+      }
+
+      // Check if user is already an artist
+      const existingArtist = await db.select({ id: artists.id })
+        .from(artists)
+        .where(eq(artists.userId, ctx.authUser.userId))
+        .limit(1);
+      if (existingArtist.length > 0) {
+        throw new GraphQLError("User is already registered as an artist");
+      }
+
+      // Check username uniqueness
+      const existingUsername = await db.select({ id: artists.id })
+        .from(artists)
+        .where(eq(artists.artistUsername, args.artistUsername))
+        .limit(1);
+      if (existingUsername.length > 0) {
+        throw new GraphQLError("Artist username already taken");
+      }
+
+      const [artist] = await db.insert(artists).values({
+        userId: ctx.authUser.userId,
+        artistUsername: args.artistUsername,
+        displayName: args.displayName,
+        tagline: args.tagline ?? null,
+        location: args.location ?? null,
+        activeSince: args.activeSince ?? null,
+        avatarUrl: args.avatarUrl ?? null,
+        coverImageUrl: args.coverImageUrl ?? null,
+      }).returning();
+
+      return artist;
+    },
+  }),
+
+  updateArtist: t.field({
+    type: ArtistType,
+    args: {
+      displayName: t.arg.string(),
+      bio: t.arg.string(),
+      tagline: t.arg.string(),
+      location: t.arg.string(),
+      activeSince: t.arg.int(),
+      avatarUrl: t.arg.string(),
+      coverImageUrl: t.arg.string(),
+    },
+    resolve: async (_parent, args, ctx) => {
+      if (!ctx.authUser) {
+        throw new GraphQLError("Authentication required");
+      }
+
+      const [existing] = await db.select()
+        .from(artists)
+        .where(eq(artists.userId, ctx.authUser.userId))
+        .limit(1);
+      if (!existing) {
+        throw new GraphQLError("Artist profile not found");
+      }
+
+      // Validate provided values (null = clear, so skip validation for null)
+      if (args.displayName && (args.displayName.length < 1 || args.displayName.length > 50)) {
+        throw new GraphQLError("Display name must be between 1 and 50 characters");
+      }
+      if (args.tagline && args.tagline.length > 80) {
+        throw new GraphQLError("Tagline must be 80 characters or less");
+      }
+      if (args.location && args.location.length > 100) {
+        throw new GraphQLError("Location must be 100 characters or less");
+      }
+      if (args.activeSince != null) {
+        const currentYear = new Date().getFullYear();
+        if (args.activeSince < 1900 || args.activeSince > currentYear) {
+          throw new GraphQLError(`Active since must be between 1900 and ${currentYear}`);
+        }
+      }
+
+      // undefined = not provided (skip), null = clear field, value = update
+      const updateData: Record<string, unknown> = { updatedAt: new Date() };
+      if (args.displayName !== undefined) updateData.displayName = args.displayName;
+      if (args.bio !== undefined) updateData.bio = args.bio;
+      if (args.tagline !== undefined) updateData.tagline = args.tagline;
+      if (args.location !== undefined) updateData.location = args.location;
+      if (args.activeSince !== undefined) updateData.activeSince = args.activeSince;
+      if (args.avatarUrl !== undefined) updateData.avatarUrl = args.avatarUrl;
+      if (args.coverImageUrl !== undefined) updateData.coverImageUrl = args.coverImageUrl;
+
+      const [updated] = await db.update(artists)
+        .set(updateData)
+        .where(eq(artists.id, existing.id))
+        .returning();
+
+      return updated;
+    },
+  }),
+}));
+
+builder.queryFields((t) => ({
+  artist: t.field({
+    type: ArtistType,
+    nullable: true,
+    args: {
+      username: t.arg.string({ required: true }),
+    },
+    resolve: async (_parent, args) => {
+      const [artist] = await db.select()
+        .from(artists)
+        .where(eq(artists.artistUsername, args.username))
+        .limit(1);
+      return artist ?? null;
+    },
+  }),
+}));

--- a/backend/src/graphql/types/index.ts
+++ b/backend/src/graphql/types/index.ts
@@ -5,6 +5,7 @@ import { users } from "../../db/schema/index.js";
 import { eq } from "drizzle-orm";
 import { UserType } from "./user.js";
 import "./auth.js";
+import "./artist.js";
 
 builder.queryType({
   fields: (t) => ({

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -4,5 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    // Integration tests share a single DB — parallel execution causes race conditions
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Summary

- Artist エンティティの CRUD 実装（Artist → Track → Post 依存チェーンの起点）
- `registerArtist` / `updateArtist` mutation + `artist` public query
- スキーマに tagline, location, activeSince, avatarUrl, coverImageUrl(リネーム), tunedInCount を追加
- updateArtist は undefined(未指定) と null(クリア) を区別するセマンティクス
- 全12テーブルの初回 Drizzle マイグレーション生成
- テスト基盤改善: `fileParallelism: false` + `TRUNCATE CASCADE` cleanup

## Test plan

- [x] 既存 auth テスト 23件パス
- [x] 新規 artist テスト 13件パス（計36件）
  - registerArtist: 必須のみ / 全フィールド / 既にアーティスト / username重複 / 未認証 / 不正文字 / 短すぎ
  - updateArtist: 正常更新 / nullクリア / 未登録 / 未認証
  - artist query: 存在する / 存在しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)