### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: backend/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -32,6 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: backend/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -64,6 +68,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: backend/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
- GitHub Actions CI ワークフローを追加
- lint-and-format / build / test の3ジョブを並列実行
- test ジョブは PostgreSQL 16 サービスコンテナを使用

## Test plan
- [ ] 3ジョブすべてが green であること
- [ ] pnpm store キャッシュが効いていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)