### PR TITLE
Add Track CRUD GraphQL API

### DIFF
--- a/backend/src/graphql/__tests__/track.test.ts
+++ b/backend/src/graphql/__tests__/track.test.ts
@@ -1,0 +1,543 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { createYoga } from "graphql-yoga";
+import { initJwtKeys } from "../../auth/jwt.js";
+import { authMiddleware, type AuthUser } from "../../auth/middleware.js";
+
+import { builder } from "../builder.js";
+import "../types/index.js";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL)
+  throw new Error("DATABASE_URL is required for integration tests");
+
+const client = postgres(DATABASE_URL);
+const db = drizzle(client);
+
+function createTestApp() {
+  const schema = builder.toSchema();
+  const yoga = createYoga<{ authUser?: AuthUser }>({
+    schema,
+    maskedErrors: false,
+  });
+
+  const app = new Hono<{ Variables: { authUser?: AuthUser } }>();
+  app.use(authMiddleware);
+  app.on(["GET", "POST"], "/graphql", async (c) => {
+    const authUser = c.get("authUser");
+    const response = await yoga.handleRequest(c.req.raw, { authUser });
+    return response;
+  });
+  return app;
+}
+
+async function gql(
+  app: ReturnType<typeof createTestApp>,
+  query: string,
+  variables?: Record<string, unknown>,
+  token?: string,
+) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await app.request("/graphql", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+  return res.json() as Promise<{
+    data?: Record<string, unknown>;
+    errors?: Array<{ message: string }>;
+  }>;
+}
+
+const SIGNUP_MUTATION = `
+  mutation Signup($email: String!, $password: String!, $username: String!) {
+    signup(email: $email, password: $password, username: $username) {
+      token
+      user { id }
+    }
+  }
+`;
+
+const REGISTER_ARTIST_MUTATION = `
+  mutation RegisterArtist($artistUsername: String!, $displayName: String!) {
+    registerArtist(artistUsername: $artistUsername, displayName: $displayName) {
+      id artistUsername
+    }
+  }
+`;
+
+const CREATE_TRACK_MUTATION = `
+  mutation CreateTrack($name: String!, $color: String!) {
+    createTrack(name: $name, color: $color) {
+      id name color createdAt updatedAt
+    }
+  }
+`;
+
+const UPDATE_TRACK_MUTATION = `
+  mutation UpdateTrack($id: String!, $name: String, $color: String) {
+    updateTrack(id: $id, name: $name, color: $color) {
+      id name color
+    }
+  }
+`;
+
+const DELETE_TRACK_MUTATION = `
+  mutation DeleteTrack($id: String!) {
+    deleteTrack(id: $id) {
+      id name color
+    }
+  }
+`;
+
+const TRACK_QUERY = `
+  query Track($id: String!) {
+    track(id: $id) {
+      id name color createdAt updatedAt
+    }
+  }
+`;
+
+const TRACKS_QUERY = `
+  query Tracks($artistUsername: String!) {
+    tracks(artistUsername: $artistUsername) {
+      id name color
+    }
+  }
+`;
+
+const ARTIST_WITH_TRACKS_QUERY = `
+  query Artist($username: String!) {
+    artist(username: $username) {
+      id artistUsername
+      tracks {
+        id name color
+      }
+    }
+  }
+`;
+
+async function signupAndGetToken(
+  app: ReturnType<typeof createTestApp>,
+  email: string,
+  username: string,
+) {
+  const result = await gql(app, SIGNUP_MUTATION, {
+    email,
+    password: "password123",
+    username,
+  });
+  return (result.data!.signup as { token: string }).token;
+}
+
+async function signupAndRegisterArtist(
+  app: ReturnType<typeof createTestApp>,
+  email: string,
+  username: string,
+  artistUsername: string,
+) {
+  const token = await signupAndGetToken(app, email, username);
+  await gql(
+    app,
+    REGISTER_ARTIST_MUTATION,
+    { artistUsername, displayName: `Artist ${artistUsername}` },
+    token,
+  );
+  return token;
+}
+
+describe("Track GraphQL integration", () => {
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeAll(async () => {
+    await initJwtKeys();
+    app = createTestApp();
+  });
+
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE users CASCADE`);
+  });
+
+  describe("createTrack", () => {
+    it("creates a track successfully", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "t1@example.com",
+        "tuser1",
+        "tartist1",
+      );
+
+      const result = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "Music", color: "#FF0000" },
+        token,
+      );
+
+      expect(result.errors).toBeUndefined();
+      const track = result.data!.createTrack as Record<string, unknown>;
+      expect(track.name).toBe("Music");
+      expect(track.color).toBe("#FF0000");
+      expect(track.id).toBeDefined();
+      expect(track.createdAt).toBeDefined();
+      expect(track.updatedAt).toBeDefined();
+    });
+
+    it("rejects unauthenticated request", async () => {
+      const result = await gql(app, CREATE_TRACK_MUTATION, {
+        name: "Music",
+        color: "#FF0000",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Authentication required");
+    });
+
+    it("rejects if user has no artist profile", async () => {
+      const token = await signupAndGetToken(app, "t2@example.com", "tuser2");
+
+      const result = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "Music", color: "#FF0000" },
+        token,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "Artist profile required to create a track",
+      );
+    });
+
+    it("rejects empty name", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "t3@example.com",
+        "tuser3",
+        "tartist3",
+      );
+
+      const result = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "", color: "#FF0000" },
+        token,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain(
+        "Track name must be between 1 and 30",
+      );
+    });
+
+    it("rejects name longer than 30 characters", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "t4@example.com",
+        "tuser4",
+        "tartist4",
+      );
+
+      const result = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "a".repeat(31), color: "#FF0000" },
+        token,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain(
+        "Track name must be between 1 and 30",
+      );
+    });
+
+    it("rejects invalid color format", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "t5@example.com",
+        "tuser5",
+        "tartist5",
+      );
+
+      const result = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "Music", color: "red" },
+        token,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("valid hex color");
+    });
+  });
+
+  describe("updateTrack", () => {
+    it("updates track fields", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "u1@example.com",
+        "uuser1",
+        "uartist1",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "Original", color: "#000000" },
+        token,
+      );
+      const trackId = (
+        createResult.data!.createTrack as Record<string, unknown>
+      ).id as string;
+
+      const result = await gql(
+        app,
+        UPDATE_TRACK_MUTATION,
+        { id: trackId, name: "Updated", color: "#FFFFFF" },
+        token,
+      );
+
+      expect(result.errors).toBeUndefined();
+      const track = result.data!.updateTrack as Record<string, unknown>;
+      expect(track.name).toBe("Updated");
+      expect(track.color).toBe("#FFFFFF");
+    });
+
+    it("rejects update by another user", async () => {
+      const token1 = await signupAndRegisterArtist(
+        app,
+        "u2@example.com",
+        "uuser2",
+        "uartist2",
+      );
+      const token2 = await signupAndRegisterArtist(
+        app,
+        "u3@example.com",
+        "uuser3",
+        "uartist3",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "Mine", color: "#000000" },
+        token1,
+      );
+      const trackId = (
+        createResult.data!.createTrack as Record<string, unknown>
+      ).id as string;
+
+      const result = await gql(
+        app,
+        UPDATE_TRACK_MUTATION,
+        { id: trackId, name: "Stolen" },
+        token2,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "Not authorized to update this track",
+      );
+    });
+
+    it("rejects unauthenticated request", async () => {
+      const result = await gql(app, UPDATE_TRACK_MUTATION, {
+        id: "00000000-0000-0000-0000-000000000000",
+        name: "No Auth",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Authentication required");
+    });
+  });
+
+  describe("deleteTrack", () => {
+    it("deletes a track successfully", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "d1@example.com",
+        "duser1",
+        "dartist1",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "ToDelete", color: "#FF0000" },
+        token,
+      );
+      const trackId = (
+        createResult.data!.createTrack as Record<string, unknown>
+      ).id as string;
+
+      const result = await gql(
+        app,
+        DELETE_TRACK_MUTATION,
+        { id: trackId },
+        token,
+      );
+
+      expect(result.errors).toBeUndefined();
+      const track = result.data!.deleteTrack as Record<string, unknown>;
+      expect(track.name).toBe("ToDelete");
+
+      // Verify it's gone
+      const queryResult = await gql(app, TRACK_QUERY, { id: trackId });
+      expect(queryResult.data!.track).toBeNull();
+    });
+
+    it("rejects delete by another user", async () => {
+      const token1 = await signupAndRegisterArtist(
+        app,
+        "d2@example.com",
+        "duser2",
+        "dartist2",
+      );
+      const token2 = await signupAndRegisterArtist(
+        app,
+        "d3@example.com",
+        "duser3",
+        "dartist3",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "NotYours", color: "#000000" },
+        token1,
+      );
+      const trackId = (
+        createResult.data!.createTrack as Record<string, unknown>
+      ).id as string;
+
+      const result = await gql(
+        app,
+        DELETE_TRACK_MUTATION,
+        { id: trackId },
+        token2,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "Not authorized to delete this track",
+      );
+    });
+  });
+
+  describe("track query", () => {
+    it("returns track by ID", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "q1@example.com",
+        "quser1",
+        "qartist1",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "QueryTrack", color: "#00FF00" },
+        token,
+      );
+      const trackId = (
+        createResult.data!.createTrack as Record<string, unknown>
+      ).id as string;
+
+      const result = await gql(app, TRACK_QUERY, { id: trackId });
+
+      expect(result.errors).toBeUndefined();
+      const track = result.data!.track as Record<string, unknown>;
+      expect(track.name).toBe("QueryTrack");
+      expect(track.color).toBe("#00FF00");
+    });
+
+    it("returns null for non-existent ID", async () => {
+      const result = await gql(app, TRACK_QUERY, {
+        id: "00000000-0000-0000-0000-000000000000",
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data!.track).toBeNull();
+    });
+  });
+
+  describe("tracks query", () => {
+    it("returns tracks for an artist", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "ql1@example.com",
+        "qluser1",
+        "qlartist1",
+      );
+
+      await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "Track A", color: "#FF0000" },
+        token,
+      );
+      await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "Track B", color: "#00FF00" },
+        token,
+      );
+
+      const result = await gql(app, TRACKS_QUERY, {
+        artistUsername: "qlartist1",
+      });
+
+      expect(result.errors).toBeUndefined();
+      const tracks = result.data!.tracks as Array<Record<string, unknown>>;
+      expect(tracks).toHaveLength(2);
+      const names = tracks.map((t) => t.name).sort();
+      expect(names).toEqual(["Track A", "Track B"]);
+    });
+
+    it("returns empty array for non-existent artist", async () => {
+      const result = await gql(app, TRACKS_QUERY, {
+        artistUsername: "nonexistent",
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data!.tracks).toEqual([]);
+    });
+  });
+
+  describe("Artist.tracks field", () => {
+    it("returns tracks via artist query", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "af1@example.com",
+        "afuser1",
+        "afartist1",
+      );
+
+      await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "Nested Track", color: "#0000FF" },
+        token,
+      );
+
+      const result = await gql(app, ARTIST_WITH_TRACKS_QUERY, {
+        username: "afartist1",
+      });
+
+      expect(result.errors).toBeUndefined();
+      const artist = result.data!.artist as Record<string, unknown>;
+      const tracks = artist.tracks as Array<Record<string, unknown>>;
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].name).toBe("Nested Track");
+      expect(tracks[0].color).toBe("#0000FF");
+    });
+  });
+});

--- a/backend/src/graphql/types/index.ts
+++ b/backend/src/graphql/types/index.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { UserType } from "./user.js";
 import "./auth.js";
 import "./artist.js";
+import "./track.js";
 
 builder.queryType({
   fields: (t) => ({

--- a/backend/src/graphql/types/track.ts
+++ b/backend/src/graphql/types/track.ts
@@ -1,0 +1,233 @@
+import { GraphQLError } from "graphql";
+import { builder } from "../builder.js";
+import { db } from "../../db/index.js";
+import { artists, tracks } from "../../db/schema/index.js";
+import { eq } from "drizzle-orm";
+import { ArtistType } from "./artist.js";
+
+const TrackType = builder.objectRef<{
+  id: string;
+  artistId: string;
+  name: string;
+  color: string;
+  createdAt: Date;
+  updatedAt: Date;
+}>("Track");
+
+TrackType.implement({
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    name: t.exposeString("name"),
+    color: t.exposeString("color"),
+    createdAt: t.string({
+      resolve: (track) => track.createdAt.toISOString(),
+    }),
+    updatedAt: t.string({
+      resolve: (track) => track.updatedAt.toISOString(),
+    }),
+  }),
+});
+
+const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/;
+
+builder.mutationFields((t) => ({
+  createTrack: t.field({
+    type: TrackType,
+    args: {
+      name: t.arg.string({ required: true }),
+      color: t.arg.string({ required: true }),
+    },
+    resolve: async (_parent, args, ctx) => {
+      if (!ctx.authUser) {
+        throw new GraphQLError("Authentication required");
+      }
+
+      // Find artist for this user
+      const [artist] = await db
+        .select({ id: artists.id })
+        .from(artists)
+        .where(eq(artists.userId, ctx.authUser.userId))
+        .limit(1);
+      if (!artist) {
+        throw new GraphQLError("Artist profile required to create a track");
+      }
+
+      // Validate name
+      if (args.name.length < 1 || args.name.length > 30) {
+        throw new GraphQLError(
+          "Track name must be between 1 and 30 characters",
+        );
+      }
+
+      // Validate color
+      if (!HEX_COLOR_RE.test(args.color)) {
+        throw new GraphQLError(
+          "Color must be a valid hex color (e.g. #FF0000)",
+        );
+      }
+
+      const [track] = await db
+        .insert(tracks)
+        .values({
+          artistId: artist.id,
+          name: args.name,
+          color: args.color,
+        })
+        .returning();
+
+      return track;
+    },
+  }),
+
+  updateTrack: t.field({
+    type: TrackType,
+    args: {
+      id: t.arg.string({ required: true }),
+      name: t.arg.string(),
+      color: t.arg.string(),
+    },
+    resolve: async (_parent, args, ctx) => {
+      if (!ctx.authUser) {
+        throw new GraphQLError("Authentication required");
+      }
+
+      // Fetch the track
+      const [track] = await db
+        .select()
+        .from(tracks)
+        .where(eq(tracks.id, args.id))
+        .limit(1);
+      if (!track) {
+        throw new GraphQLError("Track not found");
+      }
+
+      // Ownership check: track.artistId → artist.userId
+      const [artist] = await db
+        .select({ userId: artists.userId })
+        .from(artists)
+        .where(eq(artists.id, track.artistId))
+        .limit(1);
+      if (!artist || artist.userId !== ctx.authUser.userId) {
+        throw new GraphQLError("Not authorized to update this track");
+      }
+
+      // Validate provided values
+      if (
+        args.name !== undefined &&
+        args.name !== null &&
+        (args.name.length < 1 || args.name.length > 30)
+      ) {
+        throw new GraphQLError(
+          "Track name must be between 1 and 30 characters",
+        );
+      }
+      if (
+        args.color !== undefined &&
+        args.color !== null &&
+        !HEX_COLOR_RE.test(args.color)
+      ) {
+        throw new GraphQLError(
+          "Color must be a valid hex color (e.g. #FF0000)",
+        );
+      }
+
+      const updateData: Record<string, unknown> = { updatedAt: new Date() };
+      if (args.name !== undefined) updateData.name = args.name;
+      if (args.color !== undefined) updateData.color = args.color;
+
+      const [updated] = await db
+        .update(tracks)
+        .set(updateData)
+        .where(eq(tracks.id, args.id))
+        .returning();
+
+      return updated;
+    },
+  }),
+
+  deleteTrack: t.field({
+    type: TrackType,
+    args: {
+      id: t.arg.string({ required: true }),
+    },
+    resolve: async (_parent, args, ctx) => {
+      if (!ctx.authUser) {
+        throw new GraphQLError("Authentication required");
+      }
+
+      const [track] = await db
+        .select()
+        .from(tracks)
+        .where(eq(tracks.id, args.id))
+        .limit(1);
+      if (!track) {
+        throw new GraphQLError("Track not found");
+      }
+
+      // Ownership check
+      const [artist] = await db
+        .select({ userId: artists.userId })
+        .from(artists)
+        .where(eq(artists.id, track.artistId))
+        .limit(1);
+      if (!artist || artist.userId !== ctx.authUser.userId) {
+        throw new GraphQLError("Not authorized to delete this track");
+      }
+
+      const [deleted] = await db
+        .delete(tracks)
+        .where(eq(tracks.id, args.id))
+        .returning();
+
+      return deleted;
+    },
+  }),
+}));
+
+builder.queryFields((t) => ({
+  track: t.field({
+    type: TrackType,
+    nullable: true,
+    args: {
+      id: t.arg.string({ required: true }),
+    },
+    resolve: async (_parent, args) => {
+      const [track] = await db
+        .select()
+        .from(tracks)
+        .where(eq(tracks.id, args.id))
+        .limit(1);
+      return track ?? null;
+    },
+  }),
+
+  tracks: t.field({
+    type: [TrackType],
+    args: {
+      artistUsername: t.arg.string({ required: true }),
+    },
+    resolve: async (_parent, args) => {
+      // Find artist by username, then get their tracks
+      const [artist] = await db
+        .select({ id: artists.id })
+        .from(artists)
+        .where(eq(artists.artistUsername, args.artistUsername))
+        .limit(1);
+      if (!artist) {
+        return [];
+      }
+
+      return db.select().from(tracks).where(eq(tracks.artistId, artist.id));
+    },
+  }),
+}));
+
+// Add tracks field to ArtistType (avoids circular import by extending here)
+builder.objectFields(ArtistType, (t) => ({
+  tracks: t.field({
+    type: [TrackType],
+    resolve: async (artist) => {
+      return db.select().from(tracks).where(eq(tracks.artistId, artist.id));
+    },
+  }),
+}));


### PR DESCRIPTION
## Summary

- Add `TrackType` with id, name, color, createdAt, updatedAt fields
- Implement mutations: `createTrack`, `updateTrack`, `deleteTrack` with auth + ownership checks
- Implement queries: `track` (by ID), `tracks` (by artist username)
- Add `Artist.tracks` relation field via `builder.objectFields` (no circular import)
- Validation: name 1-30 chars, color `#RRGGBB` hex format
- 16 integration test cases covering all CRUD operations, auth, ownership, and validation

## Test plan

- [x] `pnpm build` — TypeScript compiles without errors
- [x] `pnpm lint` — ESLint passes
- [x] `pnpm format:check` — Prettier passes
- [x] `pnpm test` — All 104 tests pass (14 test files)
- [x] CI green on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)