### PR TITLE
Add Post CRUD GraphQL API with integration tests

### DIFF
--- a/backend/src/graphql/__tests__/post.test.ts
+++ b/backend/src/graphql/__tests__/post.test.ts
@@ -1,0 +1,713 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { createYoga } from "graphql-yoga";
+import { initJwtKeys } from "../../auth/jwt.js";
+import { authMiddleware, type AuthUser } from "../../auth/middleware.js";
+
+import { builder } from "../builder.js";
+import "../types/index.js";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL)
+  throw new Error("DATABASE_URL is required for integration tests");
+
+const client = postgres(DATABASE_URL);
+const db = drizzle(client);
+
+function createTestApp() {
+  const schema = builder.toSchema();
+  const yoga = createYoga<{ authUser?: AuthUser }>({
+    schema,
+    maskedErrors: false,
+  });
+
+  const app = new Hono<{ Variables: { authUser?: AuthUser } }>();
+  app.use(authMiddleware);
+  app.on(["GET", "POST"], "/graphql", async (c) => {
+    const authUser = c.get("authUser");
+    const response = await yoga.handleRequest(c.req.raw, { authUser });
+    return response;
+  });
+  return app;
+}
+
+async function gql(
+  app: ReturnType<typeof createTestApp>,
+  query: string,
+  variables?: Record<string, unknown>,
+  token?: string,
+) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await app.request("/graphql", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+  return res.json() as Promise<{
+    data?: Record<string, unknown>;
+    errors?: Array<{ message: string }>;
+  }>;
+}
+
+const SIGNUP_MUTATION = `
+  mutation Signup($email: String!, $password: String!, $username: String!) {
+    signup(email: $email, password: $password, username: $username) {
+      token
+      user { id }
+    }
+  }
+`;
+
+const REGISTER_ARTIST_MUTATION = `
+  mutation RegisterArtist($artistUsername: String!, $displayName: String!) {
+    registerArtist(artistUsername: $artistUsername, displayName: $displayName) {
+      id artistUsername
+    }
+  }
+`;
+
+const CREATE_TRACK_MUTATION = `
+  mutation CreateTrack($name: String!, $color: String!) {
+    createTrack(name: $name, color: $color) {
+      id name color
+    }
+  }
+`;
+
+const CREATE_POST_MUTATION = `
+  mutation CreatePost(
+    $trackId: String!,
+    $mediaType: MediaType!,
+    $title: String,
+    $body: String,
+    $mediaUrl: String,
+    $importance: Float,
+    $layoutX: Int,
+    $layoutY: Int
+  ) {
+    createPost(
+      trackId: $trackId,
+      mediaType: $mediaType,
+      title: $title,
+      body: $body,
+      mediaUrl: $mediaUrl,
+      importance: $importance,
+      layoutX: $layoutX,
+      layoutY: $layoutY
+    ) {
+      id mediaType title body mediaUrl importance layoutX layoutY createdAt updatedAt
+    }
+  }
+`;
+
+const UPDATE_POST_MUTATION = `
+  mutation UpdatePost(
+    $id: String!,
+    $mediaType: MediaType,
+    $title: String,
+    $body: String,
+    $mediaUrl: String,
+    $importance: Float,
+    $layoutX: Int,
+    $layoutY: Int
+  ) {
+    updatePost(
+      id: $id,
+      mediaType: $mediaType,
+      title: $title,
+      body: $body,
+      mediaUrl: $mediaUrl,
+      importance: $importance,
+      layoutX: $layoutX,
+      layoutY: $layoutY
+    ) {
+      id mediaType title body mediaUrl importance layoutX layoutY
+    }
+  }
+`;
+
+const DELETE_POST_MUTATION = `
+  mutation DeletePost($id: String!) {
+    deletePost(id: $id) {
+      id mediaType title
+    }
+  }
+`;
+
+const POST_QUERY = `
+  query Post($id: String!) {
+    post(id: $id) {
+      id mediaType title body mediaUrl importance layoutX layoutY createdAt updatedAt
+      author { id username }
+      track { id name }
+    }
+  }
+`;
+
+const POSTS_QUERY = `
+  query Posts($trackId: String!) {
+    posts(trackId: $trackId) {
+      id mediaType title
+    }
+  }
+`;
+
+const TRACK_WITH_POSTS_QUERY = `
+  query Track($id: String!) {
+    track(id: $id) {
+      id name
+      posts {
+        id mediaType title
+      }
+    }
+  }
+`;
+
+async function signupAndGetToken(
+  app: ReturnType<typeof createTestApp>,
+  email: string,
+  username: string,
+) {
+  const result = await gql(app, SIGNUP_MUTATION, {
+    email,
+    password: "password123",
+    username,
+  });
+  return (result.data!.signup as { token: string }).token;
+}
+
+async function signupAndRegisterArtist(
+  app: ReturnType<typeof createTestApp>,
+  email: string,
+  username: string,
+  artistUsername: string,
+) {
+  const token = await signupAndGetToken(app, email, username);
+  await gql(
+    app,
+    REGISTER_ARTIST_MUTATION,
+    { artistUsername, displayName: `Artist ${artistUsername}` },
+    token,
+  );
+  return token;
+}
+
+async function signupRegisterArtistAndCreateTrack(
+  app: ReturnType<typeof createTestApp>,
+  email: string,
+  username: string,
+  artistUsername: string,
+  trackName: string = "TestTrack",
+) {
+  const token = await signupAndRegisterArtist(
+    app,
+    email,
+    username,
+    artistUsername,
+  );
+  const result = await gql(
+    app,
+    CREATE_TRACK_MUTATION,
+    { name: trackName, color: "#FF0000" },
+    token,
+  );
+  const trackId = (result.data!.createTrack as { id: string }).id;
+  return { token, trackId };
+}
+
+describe("Post GraphQL integration", () => {
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeAll(async () => {
+    await initJwtKeys();
+    app = createTestApp();
+  });
+
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE users CASCADE`);
+  });
+
+  describe("createPost", () => {
+    it("creates a post with all fields", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "p1@example.com",
+        "puser1",
+        "partist1",
+      );
+
+      const result = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        {
+          trackId,
+          mediaType: "image",
+          title: "My Photo",
+          body: "A beautiful sunset",
+          mediaUrl: "https://example.com/photo.jpg",
+          importance: 0.8,
+          layoutX: 10,
+          layoutY: 20,
+        },
+        token,
+      );
+
+      expect(result.errors).toBeUndefined();
+      const post = result.data!.createPost as Record<string, unknown>;
+      expect(post.id).toBeDefined();
+      expect(post.mediaType).toBe("image");
+      expect(post.title).toBe("My Photo");
+      expect(post.body).toBe("A beautiful sunset");
+      expect(post.mediaUrl).toBe("https://example.com/photo.jpg");
+      expect(post.importance).toBe(0.8);
+      expect(post.layoutX).toBe(10);
+      expect(post.layoutY).toBe(20);
+      expect(post.createdAt).toBeDefined();
+      expect(post.updatedAt).toBeDefined();
+    });
+
+    it("creates a post with minimal fields (defaults apply)", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "p2@example.com",
+        "puser2",
+        "partist2",
+      );
+
+      const result = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text" },
+        token,
+      );
+
+      expect(result.errors).toBeUndefined();
+      const post = result.data!.createPost as Record<string, unknown>;
+      expect(post.mediaType).toBe("text");
+      expect(post.title).toBeNull();
+      expect(post.body).toBeNull();
+      expect(post.mediaUrl).toBeNull();
+      expect(post.importance).toBe(0.5);
+      expect(post.layoutX).toBe(0);
+      expect(post.layoutY).toBe(0);
+    });
+
+    it("rejects unauthenticated request", async () => {
+      const result = await gql(app, CREATE_POST_MUTATION, {
+        trackId: "00000000-0000-0000-0000-000000000000",
+        mediaType: "text",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Authentication required");
+    });
+
+    it("rejects if user has no artist profile", async () => {
+      const token = await signupAndGetToken(app, "p3@example.com", "puser3");
+
+      const result = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        {
+          trackId: "00000000-0000-0000-0000-000000000000",
+          mediaType: "text",
+        },
+        token,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "Artist profile required to create a post",
+      );
+    });
+
+    it("rejects posting to another user's track", async () => {
+      const { trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "p4a@example.com",
+        "puser4a",
+        "partist4a",
+      );
+      const otherToken = await signupAndRegisterArtist(
+        app,
+        "p4b@example.com",
+        "puser4b",
+        "partist4b",
+      );
+
+      const result = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text" },
+        otherToken,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "Not authorized to post to this track",
+      );
+    });
+
+    it("rejects title longer than 100 characters", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "p5@example.com",
+        "puser5",
+        "partist5",
+      );
+
+      const result = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text", title: "a".repeat(101) },
+        token,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain(
+        "Title must be 100 characters or less",
+      );
+    });
+
+    it("rejects importance out of range", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "p6@example.com",
+        "puser6",
+        "partist6",
+      );
+
+      const result = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text", importance: 1.5 },
+        token,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain(
+        "Importance must be between 0.0 and 1.0",
+      );
+    });
+  });
+
+  describe("updatePost", () => {
+    it("updates post fields", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "u1@example.com",
+        "uuser1",
+        "uartist1",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text", title: "Original" },
+        token,
+      );
+      const postId = (createResult.data!.createPost as { id: string }).id;
+
+      const result = await gql(
+        app,
+        UPDATE_POST_MUTATION,
+        {
+          id: postId,
+          mediaType: "image",
+          title: "Updated",
+          body: "New body",
+          importance: 0.9,
+        },
+        token,
+      );
+
+      expect(result.errors).toBeUndefined();
+      const post = result.data!.updatePost as Record<string, unknown>;
+      expect(post.mediaType).toBe("image");
+      expect(post.title).toBe("Updated");
+      expect(post.body).toBe("New body");
+      expect(post.importance).toBe(0.9);
+    });
+
+    it("rejects update by another user", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "u2a@example.com",
+        "uuser2a",
+        "uartist2a",
+      );
+      const otherToken = await signupAndRegisterArtist(
+        app,
+        "u2b@example.com",
+        "uuser2b",
+        "uartist2b",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text", title: "Mine" },
+        token,
+      );
+      const postId = (createResult.data!.createPost as { id: string }).id;
+
+      const result = await gql(
+        app,
+        UPDATE_POST_MUTATION,
+        { id: postId, title: "Stolen" },
+        otherToken,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "Not authorized to update this post",
+      );
+    });
+
+    it("rejects unauthenticated request", async () => {
+      const result = await gql(app, UPDATE_POST_MUTATION, {
+        id: "00000000-0000-0000-0000-000000000000",
+        title: "No Auth",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Authentication required");
+    });
+
+    it("rejects title longer than 100 characters", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "u3@example.com",
+        "uuser3",
+        "uartist3",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text", title: "Original" },
+        token,
+      );
+      const postId = (createResult.data!.createPost as { id: string }).id;
+
+      const result = await gql(
+        app,
+        UPDATE_POST_MUTATION,
+        { id: postId, title: "a".repeat(101) },
+        token,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain(
+        "Title must be 100 characters or less",
+      );
+    });
+  });
+
+  describe("deletePost", () => {
+    it("deletes a post successfully", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "d1@example.com",
+        "duser1",
+        "dartist1",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text", title: "ToDelete" },
+        token,
+      );
+      const postId = (createResult.data!.createPost as { id: string }).id;
+
+      const result = await gql(
+        app,
+        DELETE_POST_MUTATION,
+        { id: postId },
+        token,
+      );
+
+      expect(result.errors).toBeUndefined();
+      const post = result.data!.deletePost as Record<string, unknown>;
+      expect(post.title).toBe("ToDelete");
+
+      // Verify it's gone
+      const queryResult = await gql(app, POST_QUERY, { id: postId });
+      expect(queryResult.data!.post).toBeNull();
+    });
+
+    it("rejects delete by another user", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "d2a@example.com",
+        "duser2a",
+        "dartist2a",
+      );
+      const otherToken = await signupAndRegisterArtist(
+        app,
+        "d2b@example.com",
+        "duser2b",
+        "dartist2b",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text", title: "NotYours" },
+        token,
+      );
+      const postId = (createResult.data!.createPost as { id: string }).id;
+
+      const result = await gql(
+        app,
+        DELETE_POST_MUTATION,
+        { id: postId },
+        otherToken,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "Not authorized to delete this post",
+      );
+    });
+  });
+
+  describe("post query", () => {
+    it("returns post by ID", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "q1@example.com",
+        "quser1",
+        "qartist1",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "image", title: "QueryPost" },
+        token,
+      );
+      const postId = (createResult.data!.createPost as { id: string }).id;
+
+      const result = await gql(app, POST_QUERY, { id: postId });
+
+      expect(result.errors).toBeUndefined();
+      const post = result.data!.post as Record<string, unknown>;
+      expect(post.mediaType).toBe("image");
+      expect(post.title).toBe("QueryPost");
+    });
+
+    it("returns null for non-existent ID", async () => {
+      const result = await gql(app, POST_QUERY, {
+        id: "00000000-0000-0000-0000-000000000000",
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data!.post).toBeNull();
+    });
+  });
+
+  describe("posts query", () => {
+    it("returns posts for a track", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "ql1@example.com",
+        "qluser1",
+        "qlartist1",
+      );
+
+      await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text", title: "Post A" },
+        token,
+      );
+      await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "image", title: "Post B" },
+        token,
+      );
+
+      const result = await gql(app, POSTS_QUERY, { trackId });
+
+      expect(result.errors).toBeUndefined();
+      const posts = result.data!.posts as Array<Record<string, unknown>>;
+      expect(posts).toHaveLength(2);
+      const titles = posts.map((p) => p.title).sort();
+      expect(titles).toEqual(["Post A", "Post B"]);
+    });
+
+    it("returns empty array for non-existent trackId", async () => {
+      const result = await gql(app, POSTS_QUERY, {
+        trackId: "00000000-0000-0000-0000-000000000000",
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data!.posts).toEqual([]);
+    });
+  });
+
+  describe("Track.posts field", () => {
+    it("returns posts via track query", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "tf1@example.com",
+        "tfuser1",
+        "tfartist1",
+      );
+
+      await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text", title: "Nested Post" },
+        token,
+      );
+
+      const result = await gql(app, TRACK_WITH_POSTS_QUERY, { id: trackId });
+
+      expect(result.errors).toBeUndefined();
+      const track = result.data!.track as Record<string, unknown>;
+      const posts = track.posts as Array<Record<string, unknown>>;
+      expect(posts).toHaveLength(1);
+      expect(posts[0].title).toBe("Nested Post");
+    });
+  });
+
+  describe("Post.author and Post.track fields", () => {
+    it("returns author and track via post query", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "rel1@example.com",
+        "reluser1",
+        "relartist1",
+      );
+
+      const createResult = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "text", title: "With Relations" },
+        token,
+      );
+      const postId = (createResult.data!.createPost as { id: string }).id;
+
+      const result = await gql(app, POST_QUERY, { id: postId });
+
+      expect(result.errors).toBeUndefined();
+      const post = result.data!.post as Record<string, unknown>;
+      const author = post.author as Record<string, unknown>;
+      const track = post.track as Record<string, unknown>;
+      expect(author.username).toBe("reluser1");
+      expect(track.name).toBe("TestTrack");
+    });
+  });
+});

--- a/backend/src/graphql/types/index.ts
+++ b/backend/src/graphql/types/index.ts
@@ -6,6 +6,7 @@ import { UserType } from "./user.js";
 import "./auth.js";
 import "./artist.js";
 import "./track.js";
+import "./post.js";
 
 builder.queryType({
   fields: (t) => ({

--- a/backend/src/graphql/types/post.ts
+++ b/backend/src/graphql/types/post.ts
@@ -1,0 +1,277 @@
+import { GraphQLError } from "graphql";
+import { builder } from "../builder.js";
+import { db } from "../../db/index.js";
+import { artists, posts, tracks, users } from "../../db/schema/index.js";
+import { eq } from "drizzle-orm";
+import { TrackType } from "./track.js";
+import { UserType } from "./user.js";
+
+const MediaTypeEnum = builder.enumType("MediaType", {
+  values: ["text", "image", "video", "audio", "link"] as const,
+});
+
+const PostType = builder.objectRef<{
+  id: string;
+  trackId: string;
+  authorId: string;
+  mediaType: "text" | "image" | "video" | "audio" | "link";
+  title: string | null;
+  body: string | null;
+  mediaUrl: string | null;
+  importance: number;
+  layoutX: number;
+  layoutY: number;
+  createdAt: Date;
+  updatedAt: Date;
+}>("Post");
+
+PostType.implement({
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    mediaType: t.field({
+      type: MediaTypeEnum,
+      resolve: (post) => post.mediaType,
+    }),
+    title: t.exposeString("title", { nullable: true }),
+    body: t.exposeString("body", { nullable: true }),
+    mediaUrl: t.exposeString("mediaUrl", { nullable: true }),
+    importance: t.exposeFloat("importance"),
+    layoutX: t.exposeInt("layoutX"),
+    layoutY: t.exposeInt("layoutY"),
+    createdAt: t.string({
+      resolve: (post) => post.createdAt.toISOString(),
+    }),
+    updatedAt: t.string({
+      resolve: (post) => post.updatedAt.toISOString(),
+    }),
+    author: t.field({
+      type: UserType,
+      resolve: async (post) => {
+        const [user] = await db
+          .select()
+          .from(users)
+          .where(eq(users.id, post.authorId))
+          .limit(1);
+        return user;
+      },
+    }),
+    track: t.field({
+      type: TrackType,
+      resolve: async (post) => {
+        const [track] = await db
+          .select()
+          .from(tracks)
+          .where(eq(tracks.id, post.trackId))
+          .limit(1);
+        return track;
+      },
+    }),
+  }),
+});
+
+builder.mutationFields((t) => ({
+  createPost: t.field({
+    type: PostType,
+    args: {
+      trackId: t.arg.string({ required: true }),
+      mediaType: t.arg({ type: MediaTypeEnum, required: true }),
+      title: t.arg.string(),
+      body: t.arg.string(),
+      mediaUrl: t.arg.string(),
+      importance: t.arg.float(),
+      layoutX: t.arg.int(),
+      layoutY: t.arg.int(),
+    },
+    resolve: async (_parent, args, ctx) => {
+      if (!ctx.authUser) {
+        throw new GraphQLError("Authentication required");
+      }
+
+      // Find artist for this user
+      const [artist] = await db
+        .select({ id: artists.id })
+        .from(artists)
+        .where(eq(artists.userId, ctx.authUser.userId))
+        .limit(1);
+      if (!artist) {
+        throw new GraphQLError("Artist profile required to create a post");
+      }
+
+      // Fetch the track and verify ownership
+      const [track] = await db
+        .select({ id: tracks.id, artistId: tracks.artistId })
+        .from(tracks)
+        .where(eq(tracks.id, args.trackId))
+        .limit(1);
+      if (!track) {
+        throw new GraphQLError("Track not found");
+      }
+      if (track.artistId !== artist.id) {
+        throw new GraphQLError("Not authorized to post to this track");
+      }
+
+      // Validate title
+      if (args.title != null && args.title.length > 100) {
+        throw new GraphQLError("Title must be 100 characters or less");
+      }
+
+      // Validate importance
+      if (
+        args.importance != null &&
+        (args.importance < 0.0 || args.importance > 1.0)
+      ) {
+        throw new GraphQLError("Importance must be between 0.0 and 1.0");
+      }
+
+      const [post] = await db
+        .insert(posts)
+        .values({
+          trackId: args.trackId,
+          authorId: ctx.authUser.userId,
+          mediaType: args.mediaType,
+          title: args.title ?? null,
+          body: args.body ?? null,
+          mediaUrl: args.mediaUrl ?? null,
+          ...(args.importance != null ? { importance: args.importance } : {}),
+          ...(args.layoutX != null ? { layoutX: args.layoutX } : {}),
+          ...(args.layoutY != null ? { layoutY: args.layoutY } : {}),
+        })
+        .returning();
+
+      return post;
+    },
+  }),
+
+  updatePost: t.field({
+    type: PostType,
+    args: {
+      id: t.arg.string({ required: true }),
+      mediaType: t.arg({ type: MediaTypeEnum }),
+      title: t.arg.string(),
+      body: t.arg.string(),
+      mediaUrl: t.arg.string(),
+      importance: t.arg.float(),
+      layoutX: t.arg.int(),
+      layoutY: t.arg.int(),
+    },
+    resolve: async (_parent, args, ctx) => {
+      if (!ctx.authUser) {
+        throw new GraphQLError("Authentication required");
+      }
+
+      const [post] = await db
+        .select()
+        .from(posts)
+        .where(eq(posts.id, args.id))
+        .limit(1);
+      if (!post) {
+        throw new GraphQLError("Post not found");
+      }
+
+      if (post.authorId !== ctx.authUser.userId) {
+        throw new GraphQLError("Not authorized to update this post");
+      }
+
+      // Validate title
+      if (args.title != null && args.title.length > 100) {
+        throw new GraphQLError("Title must be 100 characters or less");
+      }
+
+      // Validate importance
+      if (
+        args.importance != null &&
+        (args.importance < 0.0 || args.importance > 1.0)
+      ) {
+        throw new GraphQLError("Importance must be between 0.0 and 1.0");
+      }
+
+      const updateData: Record<string, unknown> = { updatedAt: new Date() };
+      if (args.mediaType !== undefined) updateData.mediaType = args.mediaType;
+      if (args.title !== undefined) updateData.title = args.title;
+      if (args.body !== undefined) updateData.body = args.body;
+      if (args.mediaUrl !== undefined) updateData.mediaUrl = args.mediaUrl;
+      if (args.importance !== undefined)
+        updateData.importance = args.importance;
+      if (args.layoutX !== undefined) updateData.layoutX = args.layoutX;
+      if (args.layoutY !== undefined) updateData.layoutY = args.layoutY;
+
+      const [updated] = await db
+        .update(posts)
+        .set(updateData)
+        .where(eq(posts.id, args.id))
+        .returning();
+
+      return updated;
+    },
+  }),
+
+  deletePost: t.field({
+    type: PostType,
+    args: {
+      id: t.arg.string({ required: true }),
+    },
+    resolve: async (_parent, args, ctx) => {
+      if (!ctx.authUser) {
+        throw new GraphQLError("Authentication required");
+      }
+
+      const [post] = await db
+        .select()
+        .from(posts)
+        .where(eq(posts.id, args.id))
+        .limit(1);
+      if (!post) {
+        throw new GraphQLError("Post not found");
+      }
+
+      if (post.authorId !== ctx.authUser.userId) {
+        throw new GraphQLError("Not authorized to delete this post");
+      }
+
+      const [deleted] = await db
+        .delete(posts)
+        .where(eq(posts.id, args.id))
+        .returning();
+
+      return deleted;
+    },
+  }),
+}));
+
+builder.queryFields((t) => ({
+  post: t.field({
+    type: PostType,
+    nullable: true,
+    args: {
+      id: t.arg.string({ required: true }),
+    },
+    resolve: async (_parent, args) => {
+      const [post] = await db
+        .select()
+        .from(posts)
+        .where(eq(posts.id, args.id))
+        .limit(1);
+      return post ?? null;
+    },
+  }),
+
+  posts: t.field({
+    type: [PostType],
+    args: {
+      trackId: t.arg.string({ required: true }),
+    },
+    resolve: async (_parent, args) => {
+      return db.select().from(posts).where(eq(posts.trackId, args.trackId));
+    },
+  }),
+}));
+
+// Add posts field to TrackType (avoids circular import by extending here)
+builder.objectFields(TrackType, (t) => ({
+  posts: t.field({
+    type: [PostType],
+    resolve: async (track) => {
+      return db.select().from(posts).where(eq(posts.trackId, track.id));
+    },
+  }),
+}));

--- a/backend/src/graphql/types/track.ts
+++ b/backend/src/graphql/types/track.ts
@@ -5,7 +5,7 @@ import { artists, tracks } from "../../db/schema/index.js";
 import { eq } from "drizzle-orm";
 import { ArtistType } from "./artist.js";
 
-const TrackType = builder.objectRef<{
+export const TrackType = builder.objectRef<{
   id: string;
   artistId: string;
   name: string;


### PR DESCRIPTION
## Summary

- Add `createPost`, `updatePost`, `deletePost` mutations with authorization (track ownership check) and validation (title length, importance range)
- Add `post` (by ID) and `posts` (by trackId) queries
- Add `Track.posts` relation field and `Post.author` / `Post.track` relation fields
- Add `MediaType` enum (text, image, video, audio, link)
- 18 integration tests covering all CRUD operations, auth checks, validation, and relation queries

## Scope decisions

- `layoutX`/`layoutY` included (low cost, needed for frontend)
- `contentHash`/`signature` deferred (separate concern)
- Relations limited to `author` + `track` (reactions/comments/connections added in their own PRs)

## Test plan

- [x] `pnpm build` — type check passes
- [x] `pnpm lint` — no ESLint errors
- [x] `pnpm format:check` — Prettier clean
- [x] `pnpm test` — all 142 tests pass (16 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)