### PR TITLE
Add ADR 018 (Copyright) and ADR 019 (Age Policy) with research

### DIFF
--- a/docs/decisions/018-copyright-protection.md
+++ b/docs/decisions/018-copyright-protection.md
@@ -1,0 +1,248 @@
+# ADR 018: Copyright Protection and Infringement Prevention
+
+## Status
+
+Draft — **Requires legal counsel review before implementation**
+
+## Context
+
+Gleisner is a UGC (User-Generated Content) platform where artists upload and share creative work. This creates two copyright risks:
+
+1. **Inbound infringement**: Users upload content they don't own (claiming others' work as original)
+2. **Outbound protection**: Content legitimately posted on Gleisner needs protection from unauthorized use elsewhere
+
+As a platform that stores and publicly displays user-uploaded content, Gleisner must comply with copyright safe harbor laws across multiple jurisdictions (US DMCA §512, EU Copyright Directive Art.17, Japan Information Distribution Platform Act) to avoid direct liability for user-uploaded infringing content.
+
+Gleisner's existing architecture — Ed25519 signatures, contentHash (SHA-256), and DID-compatible identities (ADR 014, ADR 017) — provides unique structural advantages for copyright protection that no existing platform offers. This ADR defines how to leverage these advantages while meeting legal requirements.
+
+### Research basis
+
+This ADR is based on comprehensive research documented in Idea 011, covering:
+- Six major platform approaches (YouTube, Instagram, TikTok, SoundCloud, Bandcamp, Bluesky/Mastodon)
+- Legal requirements across US, EU, Japan, Korea, and Australia
+- Key case law (Viacom v. YouTube, BMG v. Cox, Lenz v. Universal)
+- Gleisner-specific legal analysis (DID/IPFS/AGPL implications)
+
+## Decision
+
+### Three-layer copyright protection strategy
+
+```
+┌──────────────────────────────────────────────────┐
+│  Layer 1: Legal Compliance (MUST — Day 1)        │
+│  DMCA Safe Harbor, Notice-and-Takedown,          │
+│  Repeat Infringer Policy                         │
+├──────────────────────────────────────────────────┤
+│  Layer 2: Structural Protection (MUST — Day 1)   │
+│  Ed25519 provenance, contentHash dedup,          │
+│  DID-based infringer tracking                    │
+├──────────────────────────────────────────────────┤
+│  Layer 3: Enhanced Protection (Post-MVP)         │
+│  Perceptual hashing, external timestamping,      │
+│  creator protection tools                        │
+└──────────────────────────────────────────────────┘
+```
+
+### Layer 1: Legal Compliance (Pre-launch MUST)
+
+#### 1.1 DMCA Designated Agent
+
+- Register a Designated Agent with the U.S. Copyright Office ($6, electronic filing)
+- Publish agent contact information on a public `/dmca` page
+- Set 3-year renewal reminder (registration expires if not renewed)
+
+#### 1.2 DMCA Policy Page
+
+Public page at `/legal/copyright` containing:
+- Designated Agent name, address, email (e.g., `dmca@gleisner.app`)
+- How to submit a takedown notice (required elements per §512(c)(3))
+- How to submit a counter-notification
+- Repeat Infringer Policy summary
+- Statement that Gleisner respects copyright and will respond expeditiously
+
+#### 1.3 Notice-and-Takedown Process
+
+```
+Rights holder sends notice (email or form)
+  → Gleisner verifies notice meets §512(c)(3) requirements
+    → If valid: remove content within 24 hours (target)
+      → Notify uploader with takedown details
+        → Uploader may file counter-notification
+          → Rights holder has 10-14 business days to file suit
+            → If no suit: restore content (putback)
+    → If invalid: request correction from notifier
+```
+
+**Implementation**: Admin dashboard with takedown request queue, status tracking, and audit log. All actions timestamped and logged for legal compliance.
+
+#### 1.4 Counter-Notification Process
+
+- Uploader submits counter-notification via form
+- Must include: signature, identification of removed content, statement under penalty of perjury, consent to jurisdiction
+- Forward counter-notification to original notifier
+- If notifier does not file suit within 10-14 business days, restore content
+- Fair use consideration: provide guidance to uploaders about fair use rights (Lenz v. Universal)
+
+#### 1.5 Repeat Infringer Policy
+
+Graduated enforcement:
+
+| Strike | Action |
+|--------|--------|
+| 1st | Warning + copyright education prompt |
+| 2nd | 7-day upload restriction + warning |
+| 3rd | Account suspension (30 days) |
+| 4th+ | Permanent account termination |
+
+- Strikes expire after 12 months (no additional violations)
+- Counter-notification success removes the strike
+- **Policy must be consistently enforced** (BMG v. Cox lesson: revenue-motivated non-enforcement = Safe Harbor loss)
+- Strike count tracked via DID, not just account — prevents circumvention via new accounts
+
+#### 1.6 Terms of Service
+
+Copyright-related clauses:
+- Users represent they own or have rights to uploaded content
+- Gleisner receives limited license for display/distribution (not ownership transfer)
+- Right to remove infringing content without prior notice
+- Right to terminate accounts for repeated infringement
+- Indemnification clause for copyright claims arising from user uploads
+
+### Layer 2: Structural Protection (Pre-launch, leveraging existing architecture)
+
+#### 2.1 Cryptographic Provenance (already implemented via ADR 017)
+
+Every post on Gleisner has:
+- **contentHash** (SHA-256): deterministic hash of content fields
+- **Ed25519 signature** (optional): cryptographic proof of authorship
+- **DID**: links content to a self-sovereign identity
+- **Server timestamp**: when the content was first recorded
+
+This creates an **unforgeable chain of authorship** that no other platform provides. For indie artists who cannot access YouTube's Content ID, Gleisner's built-in provenance is a meaningful alternative.
+
+#### 2.2 Exact-Copy Detection via contentHash
+
+- On upload, compute contentHash and check against all existing hashes
+- If exact match found: block upload with message "This content already exists on Gleisner"
+- Exception: same author re-uploading (e.g., updating a post) — allowed
+- Cost: O(1) hash lookup — trivial even at scale
+
+**Limitation**: Does not detect near-copies (re-encoded, cropped, pitch-shifted). This is acceptable for MVP.
+
+#### 2.3 DMCA Takedown Blocklist
+
+- When content is removed via DMCA, record its contentHash in a blocklist
+- Prevent re-upload of blocklisted content by any user
+- Blocklist is persistent and survives account deletion
+- Future: publish blocklist as a public API for fork compatibility (see AGPL considerations)
+
+#### 2.4 DID-based Infringer Tracking
+
+- Copyright strikes are recorded against the user's DID, not just the account
+- In a future federated environment, strike history can follow the DID across instances
+- This solves the decentralized platform's biggest copyright challenge: repeat infringer tracking
+
+### Layer 3: Enhanced Protection (Post-MVP)
+
+#### 3.1 External Timestamping
+
+- Integrate OpenTimestamps (Bitcoin blockchain anchoring) for contentHash
+- Provides third-party verifiable proof that "this content existed at this time"
+- Gleisner's server timestamps are self-issued and thus weak evidence in court; blockchain-anchored timestamps are far stronger
+- Batch processing for cost efficiency (e.g., daily batch of all new content hashes)
+
+#### 3.2 Perceptual Hashing
+
+- Add perceptual hash (pHash) computation alongside contentHash
+- Detects near-copies: re-encoded audio, resized images, cropped videos
+- Two-layer defense: contentHash (exact) + pHash (fuzzy)
+- Consider existing libraries: Audible Magic (audio), pHash (images/video)
+- Trigger: when platform scale justifies the computational cost
+
+#### 3.3 Provenance Export ("Proof of Authorship" Certificate)
+
+- Allow creators to export a signed document containing:
+  - contentHash + timestamp
+  - Ed25519 signature
+  - DID
+  - Optional: OpenTimestamps proof
+- Usable as evidence in copyright disputes on other platforms
+- Differentiator: "Gleisner protects your work even outside Gleisner"
+
+#### 3.4 Rights Holder Portal (at scale)
+
+- Self-service portal for rights holders to:
+  - Submit reference hashes for proactive matching
+  - View match reports
+  - Issue takedowns directly
+- Only justified at significant scale; not needed for MVP
+
+### Multi-jurisdiction Compliance
+
+#### EU Copyright Directive Article 17
+
+Gleisner qualifies for the **small platform exemption** while:
+- Available in EU for less than 3 years, AND
+- Annual revenue under €10M, AND
+- Monthly unique visitors under 5M
+
+During exemption period: only notice-and-takedown required (same as DMCA).
+
+**Action item**: Monitor these metrics. When any threshold is approached, begin implementing "best efforts" upload prevention (Layer 3 features become legally required).
+
+#### Japan Information Distribution Platform Act (2025)
+
+"Large platform" obligations (>10M monthly senders) include:
+- Designated contact point for takedown requests
+- 14-day response deadline
+- Published takedown criteria
+- Annual transparency report
+
+**Action item**: Not immediately applicable at launch scale, but design the takedown system to meet these requirements from day one for smooth scaling.
+
+### IPFS / Decentralized Storage Considerations
+
+**⚠ LEGAL RISK — requires legal counsel**
+
+When Gleisner transitions to IPFS/distributed storage (ADR 014 Phase 1+):
+- Removing content from Gleisner's own IPFS gateway/pins is likely sufficient for DMCA "expeditious removal" (good faith effort)
+- Content may persist on other IPFS nodes — this is outside Gleisner's control
+- **Mitigation**: DMCA policy page must explain the technical limitations of distributed storage
+- **Architecture**: Maintain ability to make content inaccessible via metadata removal (even if encrypted blob persists on Arweave)
+- **No case law exists** on this topic — monitor legal developments
+
+### AGPL Fork Considerations
+
+- Gleisner bears **no liability** for copyright-infringing content on forks (forks are independent operators)
+- Publish the DMCA takedown blocklist (contentHash list) as a public resource
+- Recommend (but cannot enforce) that forks respect the blocklist
+- Include in Terms of Service: data export users must comply with copyright obligations
+
+## Consequences
+
+- DMCA Safe Harbor protection is secured from day one with minimal cost (~$6 + operational procedures)
+- Gleisner's existing contentHash + Ed25519 architecture provides structural copyright protection superior to platforms that rely on policy alone
+- Indie artists get proof-of-authorship without needing Content ID access — a meaningful differentiator
+- The three-layer approach scales from MVP (legal compliance + structural) to large-scale (enhanced detection)
+- EU small platform exemption provides a compliance grace period, but monitoring thresholds is critical
+- IPFS integration introduces legal uncertainty that must be resolved with legal counsel before Phase 1 deployment
+
+## Items Requiring Legal Counsel Review
+
+| # | Item | Priority |
+|---|------|----------|
+| LC-1 | Review DMCA policy page draft and Terms of Service copyright clauses | Pre-launch |
+| LC-2 | IPFS takedown: does removing from own gateway satisfy "expeditious removal"? | Before ADR 014 Phase 1 |
+| LC-3 | DID + Ed25519 signature as evidence of authorship: strength in US/EU/JP courts? | Pre-launch (informational) |
+| LC-4 | AGPL fork liability exposure for copyright-infringing content | Pre-launch (informational) |
+| LC-5 | Japan Information Distribution Platform Act compliance checklist | Pre-launch |
+| LC-6 | Counter-notification: handling cross-border personal data disclosure (JP privacy law) | Pre-launch |
+
+## Related
+
+- ADR 001 — Project Vision (artist ownership)
+- ADR 003 — AGPL License (fork considerations)
+- ADR 014 — Decentralization Roadmap (IPFS, DID)
+- ADR 017 — Content Hash and Signature (provenance infrastructure)
+- Idea 011 — Copyright Protection research
+- **ADR 019** — Age Policy (minors' content has additional protections)

--- a/docs/decisions/019-age-policy.md
+++ b/docs/decisions/019-age-policy.md
@@ -1,0 +1,361 @@
+# ADR 019: Age Policy — Guardian-Managed Accounts for Lifelong Creative Logging
+
+## Status
+
+Draft — **Requires legal counsel review before implementation**
+
+## Context
+
+Gleisner's vision (ADR 001) includes lifelong creative logging — an artist's journey captured from childhood practice videos to professional performances. The founder's explicit intent is to avoid arbitrary age restrictions that other platforms impose, viewing them as a pain point Gleisner was built to solve.
+
+However, multiple jurisdictions impose strict requirements on platforms that serve minors:
+- **US COPPA**: Verifiable Parental Consent (VPC) required for data collection from children under 13
+- **EU GDPR Art.8**: Parental consent required below age thresholds (13-16, varies by country)
+- **UK Children's Code**: 15 principles including privacy-by-default for services accessible by under-18s
+- **EU DSA Art.28**: Appropriate measures to ensure minors' privacy, safety, and security
+- **Australia**: Social Media Minimum Age Act 2024 bans SNS accounts for under-16 (effective 2025-12-10)
+
+Enforcement is accelerating: YouTube ($170M, 2019), Epic Games ($520M, 2022), TikTok (DOJ lawsuit, 2024), Meta (42-state AG lawsuit, 2023). The trend is toward larger penalties and broader scope (now including "addictive design", not just data collection).
+
+### Critical legal insight
+
+**COPPA does not require banning children.** It requires Verifiable Parental Consent for data collection from children under 13. A platform CAN serve children of any age with proper consent and data minimization. The founder's intent is legally achievable.
+
+### Research basis
+
+This ADR is based on comprehensive research documented in Idea 012, covering:
+- Six major platform approaches (YouTube, Instagram, TikTok, Discord, Roblox, Bluesky/Mastodon)
+- Legal requirements across US, EU, UK, Japan, Australia, Korea, China, Brazil
+- Age verification technology analysis
+- Key enforcement cases and penalties
+- Gleisner-specific legal analysis (DID-based guardian delegation)
+
+### Key lesson from existing platforms
+
+> "Protection is architecture, not a feature."
+
+Instagram, YouTube, TikTok, and Discord all retrofitted child safety features onto existing architectures — resulting in billions of dollars in fines, lawsuits, and structural conflicts between engagement metrics and safety. Gleisner has the opportunity to build protection into the protocol layer from day one.
+
+## Decision
+
+### Guardian-Managed Accounts as a First-Class Feature
+
+Gleisner will support users of all ages through a **Guardian-Managed Account** system that is designed into the architecture from day one — not added as a safety layer later.
+
+```
+┌──────────────────────────────────────────────────┐
+│  Age Tier System                                  │
+│                                                   │
+│  <13    Guardian-Managed (full control)           │
+│  13-15  Guardian-Supervised (moderate oversight)  │
+│  16-17  Guardian-Notified (light oversight)       │
+│  18+    Self-Managed (full autonomy)              │
+│                                                   │
+│  Transition: seamless, no data loss               │
+└──────────────────────────────────────────────────┘
+```
+
+### Age Tier Design
+
+#### Tier 1: Guardian-Managed (<13)
+
+**Account creation**: Guardian creates the account on behalf of the child. The child account has no independent login credentials — the child accesses their account by the guardian logging in first and switching to the child's profile (same pattern as YouTube Supervised Accounts via Google Family Link).
+
+**Authentication flow**:
+```
+Guardian logs in (email + password)
+  → Dashboard shows "Managed accounts" section
+    → Guardian selects child's account → session switches
+      → Child operates within restricted UI
+```
+
+At Tier 2 (13+), the child may optionally register their own email to enable independent login. This is a gradual autonomy transition, not a sudden switch.
+
+**Consent**: Verifiable Parental Consent (VPC) obtained via FTC-approved method at account creation.
+
+**Default settings (all locked by guardian)**:
+- Profile: **private** (not discoverable, not visible to non-followers)
+- DM: **disabled** (no messages from anyone outside guardian-approved list)
+- Public timeline: **not visible** (content stored and timestamped but not publicly accessible)
+- Search engine indexing: **off**
+- Profiling/personalization: **off**
+- Location sharing: **off**
+
+**Capabilities**:
+- Create and upload content (timestamped, content-hashed, building the lifelong log)
+- View content from guardian-approved accounts
+- Guardian can view all activity, manage settings, delete content
+
+**Data collection**: DID + content only. No email, no phone number for the child account. Guardian's identity handles legal requirements. No behavioral tracking. No personalized recommendations.
+
+#### Tier 2: Guardian-Supervised (13-15)
+
+**Transition**: Automatic when age threshold is reached (based on birth date provided at account creation).
+
+**Default settings (changeable with guardian approval)**:
+- Profile: **private** (can be switched to public with guardian approval)
+- DM: **followers only**
+- Public timeline: **visible if profile is public**
+- Search engine indexing: **off** (changeable with guardian approval)
+- Profiling/personalization: **off**
+
+**Capabilities**:
+- All Tier 1 capabilities
+- Upload without guardian pre-approval
+- Receive DMs from followers
+- Guardian receives weekly activity summary (not full content access)
+- Guardian can still approve/deny setting changes
+- **Optional**: Register own email for independent login
+
+#### Tier 3: Guardian-Notified (16-17)
+
+**Default settings (self-changeable)**:
+- Profile: **private** (user can change to public without guardian approval)
+- DM: **followers only** (user can change)
+- Full feature access except age-gated content (if applicable)
+
+**Guardian role**: Receives notification when significant settings change (e.g., profile goes public). Cannot override user's choices.
+
+#### Tier 4: Self-Managed (18+)
+
+**Transition**: Automatic at 18th birthday.
+- Full feature access, full autonomy
+- DID management authority transfers from guardian to user
+- All historical content remains intact — the "lifelong creative log" is complete and owned by the artist
+- Guardian access is revoked (unless user explicitly re-grants)
+
+**This is the "unlock your creative journey" moment** — the artist's complete history, from childhood practice sessions to adulthood, becomes fully self-sovereign.
+
+### Verifiable Parental Consent (VPC) Implementation
+
+#### MVP: Email-Plus Method
+
+The lowest-cost FTC-approved method that provides reasonable verification:
+
+1. Guardian provides their email address
+2. System sends confirmation email with unique link
+3. Guardian clicks link and completes a secondary verification step (e.g., answering a security question, or confirming a code sent to a different channel)
+4. Consent is recorded with timestamp and guardian's DID signature
+
+**Limitation**: Email-plus is only approved for "internal use only" scenarios (no third-party data sharing). Since Gleisner's data minimization approach means minimal third-party sharing, this is sufficient for MVP.
+
+#### Post-MVP: Enhanced VPC Options
+
+- Credit card micro-charge verification (stronger legal standing)
+- Government ID verification via third-party service
+- Knowledge-based authentication (KBA)
+
+#### Consent Record Architecture
+
+```
+Guardian Consent Record:
+  - guardian_did: DID of the consenting guardian
+  - child_did: DID of the child account
+  - consent_method: "email_plus" | "credit_card" | "government_id" | "kba"
+  - consent_scope: ["account_creation", "data_collection", "content_display"]
+  - consent_timestamp: ISO 8601
+  - guardian_signature: Ed25519 signature over the consent payload
+  - revocable: true (guardian can revoke at any time)
+```
+
+This provides a cryptographically verifiable, timestamped consent record — stronger than what any existing platform maintains.
+
+### DID-Based Guardian-Child Relationship
+
+#### Protocol-Level Design
+
+The guardian-child relationship is modeled in the DID layer, not just the application layer:
+
+```
+Child's DID Document:
+  - id: did:web:gleisner.app:u:{child-uuid}
+  - controller: [did:web:gleisner.app:u:{guardian-uuid}]  // Guardian has management authority
+  - authentication: [{child's Ed25519 public key}]
+  - metadata:
+      account_type: "guardian_managed"
+      tier: 1 | 2 | 3
+      birth_year_month: "YYYY-MM"  // For tier transition calculation
+```
+
+At age 18 (Tier 4 transition):
+```
+  - controller: [did:web:gleisner.app:u:{child-uuid}]  // Self-controlled
+  - metadata:
+      account_type: "self_managed"
+```
+
+This means any service reading the DID document knows whether the account is guardian-managed, enabling consistent protection across a future federated environment.
+
+#### Content Propagation for Minor Accounts
+
+- Tier 1 content: `propagation: none` — stored on Gleisner's server only, not replicated to federated nodes
+- Tier 2 content (if public): `propagation: restricted` — replicated with deletion capability
+- Tier 3+: `propagation: standard` — normal federation rules apply
+
+This ensures that minors' content can be fully deleted on guardian/parent request, even in a future federated architecture.
+
+### Privacy by Default
+
+Following the UK Children's Code principles and the universal lesson that **default settings determine real-world safety**:
+
+| Setting | <13 | 13-15 | 16-17 | 18+ |
+|---------|-----|-------|-------|-----|
+| Profile visibility | Private (locked) | Private (guardian can unlock) | Private (self-changeable) | User's choice |
+| DM | Off (locked) | Followers only | Followers only (changeable) | User's choice |
+| Search engine indexing | Off (locked) | Off (guardian can unlock) | Off (changeable) | User's choice |
+| Profiling/recommendations | Off (locked) | Off | Off (changeable) | User's choice |
+| Location sharing | Off (locked) | Off (locked) | Off (changeable) | User's choice |
+| Content filters | Strictest (locked) | Strict (guardian adjustable) | Moderate (self-adjustable) | User's choice |
+
+### Data Minimization
+
+#### What Gleisner collects for minor accounts
+
+| Data | Tier 1 (<13) | Tier 2-3 (13-17) | Purpose |
+|------|-------------|------------------|---------|
+| DID | Yes | Yes | Identity (persistent identifier — COPPA-relevant) |
+| Content (posts, media) | Yes | Yes | Core service |
+| contentHash | Yes | Yes | Integrity/provenance |
+| Birth year-month | Yes | Yes | Tier calculation |
+| Guardian DID | Yes | Yes (Tier 2-3) | Legal compliance |
+| Consent record | Yes | Yes | Legal compliance |
+| IP address | Session only (not stored) | Session only | Abuse prevention |
+| Device ID | No | No | Not needed |
+| Email | No (guardian's only) | Optional (13+) | Notifications / independent login |
+| Phone | No | No | Not needed |
+| Behavioral data | No | No | Not collected |
+| Location | No | No | Not collected |
+
+#### What Gleisner does NOT collect for minor accounts
+
+- No email or phone for <13 accounts
+- No behavioral tracking or analytics
+- No device fingerprinting
+- No location data
+- No profiling data
+- No advertising identifiers
+- No third-party tracking pixels/SDKs
+
+### Data Retention and Deletion
+
+- **Content**: Retained as long as the account exists (this IS the lifelong log)
+- **Metadata** (IP, session data): Not stored beyond the session
+- **Consent records**: Retained for legal compliance until child reaches 18 + 3 years (statute of limitations buffer)
+- **Guardian deletion right**: Guardian can request deletion of all child's data at any time. Deletion is complete and irreversible.
+- **No indefinite retention of non-essential data** (Amazon Alexa $25M lesson)
+
+### Age Verification
+
+#### Why self-declaration is legally sufficient
+
+Gleisner is a **general-audience service** (artist-focused SNS), not a service "directed to children." Under COPPA's "actual knowledge" standard for general-audience services:
+
+- COPPA obligations are only triggered when the platform **actually knows** a user is under 13
+- "Constructive knowledge" (should have known) is explicitly excluded — Congress intentionally chose this narrower standard
+- **Government ID or biometric verification is NOT legally required** for age checking
+- YouTube, Instagram, TikTok, and Discord all use birth-date self-declaration — this is industry standard and legally accepted
+
+The key obligation is: once a user declares they are under 13, the system must act on that knowledge (trigger the Guardian Account Creation flow) and must NOT allow the user to go back and change their age.
+
+**Exception**: Australia's Social Media Minimum Age Act (2025) explicitly states self-declaration alone is insufficient. See the Australia Special Case section below.
+
+#### Registration Flow
+
+```
+New user registration:
+  1. Enter birth date (year-month only — day not needed)
+  2. If age >= 18: standard registration (email + password)
+  3. If age 13-17: standard registration (email + password)
+     + notification about optional guardian features
+  4. If age < 13: redirect to Guardian Account Creation flow
+     a. Guardian creates their own account first (if not already registered)
+     b. Guardian completes VPC (email-plus for MVP)
+     c. Guardian creates child's account under their supervision
+     d. Child account has NO independent login — access via guardian's session
+     e. Consent record created and signed
+```
+
+**Important**: Once Gleisner asks for age and learns a user is <13, COPPA obligations are triggered ("actual knowledge"). The system MUST NOT allow the user to simply go back and enter a different age.
+
+#### Age Misrepresentation
+
+- If a user is discovered to be <13 without a guardian account (e.g., reported by a parent, or detected through behavior):
+  - Account is suspended (not deleted)
+  - Guardian is contacted (if identifiable) to complete VPC
+  - If VPC is completed, account is restored as Tier 1
+  - If VPC is not completed within 30 days, account and data are deleted
+
+### Multi-Jurisdiction Compliance
+
+| Jurisdiction | Requirement | Gleisner's Approach |
+|-------------|-------------|-------------------|
+| **US (COPPA)** | VPC for <13, data minimization | Guardian-managed accounts + email-plus VPC + minimal data collection |
+| **EU (GDPR Art.8)** | Parental consent below threshold (13-16) | Same guardian model, adjusted age thresholds per country |
+| **UK (Children's Code)** | 15 principles for <18 | Privacy-by-default settings, no nudging, no profiling |
+| **EU (DSA Art.28)** | Appropriate measures for minors | Tiered system + default privacy + no profiling-based ads |
+| **Japan** | No specific child data law | Baseline protections exceed requirements |
+| **Australia** | No SNS accounts <16 | **⚠ Requires special handling** — see below |
+
+#### Australia Special Case
+
+The Social Media Minimum Age Act 2024 bans SNS accounts for under-16. Options:
+
+1. **Comply**: Enforce 16+ age gate for Australian users (geo-IP based)
+2. **Argue exemption**: Gleisner may not meet the Act's definition of "age-restricted social media platform" if it can demonstrate that guardian-managed accounts provide superior protection
+3. **Delay AU market entry**: Until legal clarity emerges
+
+**Decision deferred** — requires legal counsel analysis of whether Gleisner's guardian-managed model could qualify for an exemption or alternative compliance pathway.
+
+### COPPA Safe Harbor Program
+
+**Priority: COULD (nice-to-have, not required for launch)**
+
+COPPA Safe Harbor certification (kidSAFE, PRIVO) is NOT a legal requirement. A platform can fully comply with COPPA without it — by implementing VPC, publishing a privacy policy, and practicing data minimization.
+
+The certification is an "insurance policy" that reduces FTC enforcement risk, but at a cost of $5,000-$15,000/year — which is not realistic for a solo founder / side project at launch.
+
+**When to reconsider**: If Gleisner reaches significant scale (e.g., 100K+ users) or begins processing substantial amounts of children's data, the cost-benefit ratio shifts and certification becomes a more practical investment.
+
+**For launch, the minimum viable legal compliance is**:
+1. Privacy policy published (with COPPA-required disclosures)
+2. VPC flow implemented (email-plus)
+3. Data minimization practiced
+4. Parent access/deletion rights implemented
+5. Repeat age-misrepresentation handling in place
+
+This is sufficient for a side project / indie platform. FTC enforcement historically targets platforms with millions of users and intentional violations, not small indie projects practicing good-faith compliance.
+
+## Consequences
+
+- Gleisner can serve users of **all ages** — fulfilling the founder's vision of lifelong creative logging
+- Guardian-managed accounts provide **stronger protection** than competitors' age-gating (which is trivially bypassed)
+- DID-based guardian-child relationship enables consistent protection across a future federated architecture
+- Data minimization approach dramatically reduces COPPA compliance surface — less data collected = less risk
+- The ownership transfer at age 18 is a unique differentiator: "Your creative journey is yours forever"
+- Privacy-by-default settings align with UK Children's Code, DSA, and emerging global standards
+- Email-plus VPC for MVP keeps implementation cost low while meeting legal requirements
+- Australia compliance requires special handling and may delay AU market entry
+- COPPA Safe Harbor certification is a nice-to-have at scale, not required for launch — the minimum viable compliance path (privacy policy + VPC + data minimization) is achievable at zero cost beyond development time
+- Child accounts authenticate via guardian session switch (no independent login), with optional email registration at 13+ for gradual autonomy
+
+## Items Requiring Legal Counsel Review
+
+| # | Item | Priority |
+|---|------|----------|
+| LC-1 | VPC implementation: does email-plus meet requirements given Gleisner's data minimization? | Pre-launch |
+| LC-2 | DID as "persistent identifier" under COPPA 2025 amendments: implications? | Pre-launch |
+| LC-3 | Guardian consent record architecture: legally sufficient? | Pre-launch |
+| LC-4 | Australia Social Media Minimum Age Act: does guardian-managed model qualify for exemption? | Pre-AU-launch |
+| LC-5 | Content containing minors' voices/photos: COPPA coverage even with DID-only collection? | Pre-launch |
+| LC-6 | Guardian abuse/custody dispute handling: legal obligations? | Pre-launch |
+| LC-7 | GDPR Art.8 age thresholds: must Gleisner detect user's EU country for correct threshold? | Pre-EU-launch |
+| LC-8 | Data retention for consent records: how long after child turns 18? | Pre-launch |
+
+## Related
+
+- ADR 001 — Project Vision (lifelong creative logging)
+- ADR 014 — Decentralization Roadmap (DID, content propagation)
+- ADR 016 — User Identity Privacy (PublicUserType separation)
+- ADR 017 — Content Hash and Signature (provenance for minors' content)
+- **ADR 018** — Copyright Protection (minors' content has additional protections)
+- Idea 012 — Age Policy research

--- a/docs/ideas/011-copyright-protection.md
+++ b/docs/ideas/011-copyright-protection.md
@@ -1,0 +1,128 @@
+# Idea 011: Copyright protection and infringement prevention
+
+**Status:** Exploring
+**Date:** 2026-03-21
+**Updated:** 2026-03-21
+
+## Summary
+
+Design rules and system-level safeguards for copyright on Gleisner: preventing infringement by uploaders (claiming others' work as original) and protecting the rights of content posted to the platform. Research existing SNS precedents to ensure legal compliance.
+
+## Research findings
+
+### Two sides of the copyright problem
+
+1. **Infringement risk (inbound)**: Artists may upload copyrighted content and claim it as original. Gleisner needs policies and, where possible, technical measures to mitigate this.
+2. **Content protection (outbound)**: How to protect content posted on Gleisner from unauthorized use elsewhere. The platform's decentralized aspirations (see ADR 014, DID) may offer unique approaches.
+
+### Existing SNS precedents — key findings
+
+#### YouTube (Content ID)
+- Automated audio/video fingerprinting system processing **2.2 billion claims/year** (2024)
+- **Invitation-only access** — individual artists cannot use Content ID directly; must go through distributors (TuneCore, AWAL etc.)
+- 99%+ of claims are automated; ~4.2% are fundamentally erroneous, ~28.4% questionable
+- Paid out **$12B+** to rights holders cumulatively
+- **Lesson**: Content ID is a business strategy, not a legal requirement. The DMCA Safe Harbor requirements are far simpler and cheaper
+
+#### Instagram / Meta (Rights Manager)
+- Video fingerprinting for Facebook/Instagram; Rights Manager access restricted to large rights holders
+- New Reels protection tool (2025) for individual creators
+- Comprehensive music licensing deals with major labels for Stories/Reels
+- **Lesson**: Individual creator protection tools are a growing area, but still limited
+
+#### TikTok
+- Music licensing via major labels + NMPA publishing deals
+- Personal accounts: full catalog access; Business accounts: restricted to Commercial Music Library
+- Temporary Universal license lapse (early 2024) caused mass track removal
+- **Lesson**: Music licensing fragility; modular contract structures as mitigation
+
+#### SoundCloud
+- Automated audio scanning against block-registered tracks
+- Repost Network (acquired 2019): YouTube Content ID integration for artists
+- Creative Commons license selection per track — unique feature
+- **Lesson**: CC licensing as a differentiator for creator-first platforms
+
+#### Bandcamp
+- **No automated detection system** — relies entirely on DMCA notice-and-takedown
+- Artist-first: Bandcamp claims no copyright; manual human review of takedowns
+- **Lesson**: Minimal approach works at small scale but doesn't scale for proactive protection
+
+#### Bluesky / Mastodon (decentralized)
+- DMCA Designated Agent registered but **no automated detection**
+- AT Protocol's decentralization means takedowns on Bluesky don't affect other PDS nodes
+- Mastodon: each instance admin must register their own DMCA Agent ($6/3yr); most don't
+- Federated content persists in caches across instances after deletion
+- **Lesson**: Decentralized platforms face structural challenges for effective takedowns
+
+### Legal requirements — what is MUST vs. NICE-TO-HAVE
+
+#### Legally required (DMCA Safe Harbor — loss of protection if any is missing)
+
+| Requirement | Cost/Effort | Details |
+|-------------|-------------|---------|
+| Designated Agent registration | $6/3yr | Electronic filing at copyright.gov |
+| Agent info published on site | Minimal | DMCA policy page |
+| Notice-and-takedown process | Moderate | Receive, verify, remove, notify uploader |
+| Counter-notification process | Moderate | 10-14 business day putback rule |
+| Repeat Infringer Policy | Moderate | Must be adopted AND consistently enforced (BMG v. Cox lesson) |
+| No willful blindness | Behavioral | Must not intentionally ignore specific infringement (Viacom v. YouTube) |
+
+#### Voluntary (business strategy, not legally required)
+- Automated content detection (Content ID, fingerprinting)
+- Music licensing deals
+- Revenue sharing with rights holders
+- Creator protection tools
+- Copyright education for users
+
+### Key case law
+
+| Case | Ruling | Relevance to Gleisner |
+|------|--------|----------------------|
+| **Viacom v. YouTube (2012)** | General awareness of infringement is insufficient; must be item-specific knowledge | Safe Harbor survives even if platform knows infringement exists in general |
+| **BMG v. Cox (2018)** | Repeat infringer policy must be genuinely enforced; revenue-motivated non-enforcement = Safe Harbor loss | Must actually terminate repeat infringers, not just have a policy on paper |
+| **Lenz v. Universal (2015)** | Copyright holders must consider fair use before sending DMCA takedowns | Platform should support counter-notification and fair use claims |
+
+### Multi-jurisdiction requirements
+
+| Jurisdiction | Key law | Platform obligations | Small platform exemption |
+|-------------|---------|---------------------|------------------------|
+| **US** | DMCA §512 | Notice-and-takedown, repeat infringer policy | None (applies equally) |
+| **EU** | Copyright Directive Art.17 | Best efforts to prevent unauthorized uploads (large platforms) | Yes: <3yr, <€10M revenue, <5M monthly visitors |
+| **Japan** | Information Distribution Platform Act (2025) | Takedown process, designated contact (large platforms: 14-day response) | Yes: large platform obligations only for >10M monthly senders |
+| **Korea** | Copyright Act §133-2 | Notice-and-takedown + administrative 3-strike system | Limited |
+| **Australia** | Copyright Act 1968 | Similar to DMCA (narrower scope) | Effectively none |
+
+### Gleisner's unique advantages
+
+Gleisner's architecture (Ed25519 + contentHash + DID) provides structural copyright protection that no existing platform offers:
+
+1. **Cryptographic provenance**: Every post has an unforgeable Ed25519 signature + contentHash = "who posted what, when" is tamper-proof
+2. **DID-based authorship registry**: A user's DID-linked post history functions as a decentralized "work registry" — all posts automatically have provenance proof
+3. **Exact-copy detection at O(1) cost**: contentHash enables instant detection of identical re-uploads (though not modified copies)
+4. **Consistent infringer tracking across federation**: DID enables cross-instance repeat infringer tracking
+
+**Limitations**: contentHash cannot detect near-copies (re-encoded, resized). Future enhancement: perceptual hashing as a second layer.
+
+### Founder's intent
+
+- The goal is to proactively protect artists, not just reactively handle takedowns
+- System-level protections are preferred over relying solely on policy enforcement
+- This aligns with the Egan principle of "resistance to erasure" — but for *legitimate* creators
+- DID + signature provides indie artists with proof-of-authorship that Content ID gatekeeps behind distributors
+
+## Open questions
+
+| # | Question | Status |
+|---|----------|--------|
+| OQ-1 | DMCA takedown + IPFS: does removing from own gateway/pins satisfy "expeditious removal"? No case law yet | Needs legal counsel |
+| OQ-2 | contentHash as legal evidence: needs external timestamping (OpenTimestamps) for third-party credibility | Technical decision pending |
+| OQ-3 | When to introduce perceptual hashing for near-copy detection? | Defer to post-MVP |
+| OQ-4 | AGPL fork liability: if a fork restores DMCA-removed content, what is Gleisner's liability? (Likely none, but needs legal review) | Needs legal counsel |
+| OQ-5 | EU Art.17 small platform exemption timeline: at what growth point must Gleisner fully comply? | Monitor metrics |
+
+## Related
+
+- ADR 014 (DID / identity): content ownership tied to decentralized identity
+- ADR 017 (Content hash / signature): already provides proof of authorship
+- Idea 012 (Age policy): minors' content has additional legal protections in some jurisdictions
+- **ADR 018 (Copyright Protection)**: drafted based on this research

--- a/docs/ideas/012-age-policy.md
+++ b/docs/ideas/012-age-policy.md
@@ -1,0 +1,164 @@
+# Idea 012: Age policy — enabling young artists without legal risk
+
+**Status:** Exploring
+**Date:** 2026-03-21
+**Updated:** 2026-03-21
+
+## Summary
+
+Design an age policy that allows young artists to use Gleisner as a lifelong creative log (starting from childhood) while complying with COPPA, GDPR-K, and similar regulations. The founder explicitly does *not* want arbitrary age gates, viewing them as a pain point that Gleisner was built to solve.
+
+## Research findings
+
+### The core tension
+
+- Gleisner's value proposition includes **lifelong creative logging** — an artist's journey from childhood practice videos to professional performances. Restricting access to 13+ undermines this.
+- However, COPPA (US, <13), GDPR-K (EU, varies by country 13-16), and Japanese laws impose strict rules on collecting data from minors.
+- Existing platforms' "parental consent" solutions are widely seen as theater — easy to bypass, rarely enforced, and accounts get suspended arbitrarily. **This is exactly the pain Gleisner wants to solve.**
+
+### Critical legal insight: age restriction is NOT legally required
+
+**COPPA does not require banning children under 13.** It requires Verifiable Parental Consent (VPC) for data collection from children under 13. A platform CAN serve children of any age if it properly obtains parental consent and minimizes data collection.
+
+This means the founder's intent — "no age restriction" — **is legally achievable** through a Guardian-managed account model with proper VPC.
+
+### Existing platform approaches — lessons learned
+
+#### Common failure patterns across all platforms
+
+1. **Self-declaration dependency**: Every platform initially relied on birth-date self-declaration. Bypass rate is near-100%.
+2. **Retrofitting protection**: Adding safety features after massive growth is expensive and ineffective (Instagram: 42-state lawsuit; YouTube: $170M fine)
+3. **Revenue model conflict**: Ad/engagement KPIs structurally conflict with usage limits (TikTok Lite EU withdrawal)
+4. **Third-party ecosystem gaps**: Problems emerge at platform edges (YouTube channel operators, Roblox casinos, Discord server admins)
+5. **Data collection inertia**: Changing how already-collected data is handled costs $170M-$520M in fines
+
+#### Most relevant models for Gleisner
+
+**YouTube Supervised Accounts** (best reference for Guardian-managed model):
+- Parent creates and manages child's account via Google Family Link
+- 3-tier content settings ("Explore", "Explore More", "Most of YouTube")
+- No comments, no uploads, no purchases for supervised accounts
+- No personalized ads; behavioral tracking restricted
+- **Key learning**: Graduated access levels work well
+
+**Roblox** (best reference for all-ages design):
+- Explicitly designed for all ages from day one
+- AI-based facial age estimation + ID verification (2025)
+- Age-tiered restrictions: <9 (chat off by default), <13, <16, 17+
+- **Key failure**: Monetization design (Robux) not age-appropriate — gambling lawsuit via third-party casino sites
+- **Learning**: "All ages" must extend to revenue model, not just content
+
+**Discord Teen-by-Default** (best reference for default safety):
+- All unverified users treated as teens with restricted access
+- AI Age Inference Model: metadata-based age estimation (90%+ accuracy)
+- Age verification: on-device face scan OR government ID
+- **Learning**: "Safe by default, verify to unlock" is the emerging industry standard
+
+**Instagram Teen Accounts** (best reference for what NOT to do — retrofitting):
+- Forced to add default-private, content filters, message restrictions in 2024
+- Under 42-state AG lawsuit for "addictive design"
+- **Learning**: Protection must be architecture, not a feature layer
+
+### Legal requirements by jurisdiction
+
+#### US: COPPA (2025 amended rules, compliance deadline: 2026-04-22)
+
+| Requirement | Details |
+|-------------|---------|
+| **Age gate** | Must identify users under 13 (birth date input is the minimum) |
+| **VPC (Verifiable Parental Consent)** | FTC-approved methods: credit card, government ID, video call, knowledge-based auth, text-plus, facial recognition matching |
+| **Privacy policy** | Must detail: data collected, purpose, third-party sharing, parent rights |
+| **Parent access/deletion rights** | Parents can view, delete child's data; can revoke consent |
+| **Data minimization** | Collect only what's necessary for service |
+| **Data retention limits** | No indefinite retention (Amazon Alexa $25M lesson) |
+| **Separate consent for third-party sharing** | Non-core third-party data sharing requires separate parental consent |
+| **No profiling-based ads** | For known minors |
+| **Penalties** | $51,744-$53,088 per violation per day |
+
+#### EU: GDPR Article 8 + UK Children's Code + DSA
+
+**GDPR consent ages by country:**
+- 13: Spain, Czech Republic, Denmark, Ireland, Latvia, Poland, Sweden, UK
+- 14: Austria, Italy, Bulgaria, Cyprus, Lithuania
+- 15: France, Greece
+- 16 (default): Germany, Hungary, Luxembourg, Netherlands, Slovakia
+
+**UK Age Appropriate Design Code (15 principles):**
+- Best interests of the child as primary consideration
+- Privacy by default (profiles private, location off, profiling off)
+- No nudging toward weaker privacy
+- Age-appropriate transparency
+- Data minimization
+
+**DSA Article 28**: Platforms must ensure privacy, safety, security for minors. No profiling-based ads for known minors. Self-declaration alone is insufficient for age verification.
+
+#### Japan
+- No specific child data protection statute equivalent to COPPA
+- Personal Information Protection Act: parental consent for minors' legal acts (Civil Code Art. 5)
+- Youth Internet Environment Act: filtering service obligation (mainly on ISPs/carriers)
+- **Practically lowest barrier** among major markets, but international operations trigger other jurisdictions
+
+#### Australia (most restrictive)
+- **Social Media Minimum Age Act 2024**: SNS account ban for under-16. Penalty: up to AUD 49.5M
+- Effective 2025-12-10
+- If Gleisner operates in Australia, age-16 restriction is legally mandatory
+
+### Gleisner's unique approach: Guardian-managed accounts
+
+#### Legal feasibility confirmed
+
+- COPPA allows serving children of any age with proper VPC
+- GDPR allows processing with parental consent below age threshold
+- Guardian-managed accounts are a recognized model (YouTube Supervised, Roblox Parental Controls)
+
+#### DID-based guardian delegation — hybrid approach recommended
+
+**DID signatures alone are insufficient for VPC** — initial verification must use FTC-approved methods. DID signatures are used for ongoing consent management and audit trails.
+
+#### Data minimization as competitive advantage
+
+Gleisner's architecture naturally minimizes data collection:
+- DID + content only (no email/phone for minor accounts)
+- Guardian's identity handles legal requirements
+- No personalized ads = no tracking infrastructure
+- **COPPA compliance surface is dramatically reduced**
+
+### Enforcement trends (2019-2026)
+
+| Year | Target | Fine/Status | Summary |
+|------|--------|-------------|---------|
+| 2019 | YouTube | $170M | COPPA: tracking on kids' content without consent |
+| 2019 | TikTok/Musical.ly | $5.7M | COPPA: collecting children's data without consent |
+| 2022 | Epic Games | $520M | COPPA ($275M) + dark patterns ($245M) |
+| 2023 | 42 US state AGs | Meta lawsuit | Addictive design harming children |
+| 2024 | DOJ/FTC | TikTok lawsuit (pending) | Violating 2019 consent order |
+| 2025 | FTC | Disney $10M | COPPA violation |
+| 2025 | Texas AG | Roblox lawsuit | Child safety failures |
+| 2026 | Jury trial | Meta, YouTube et al. | Addictive design causing harm to minors |
+
+**Trend**: Enforcement is accelerating dramatically. Fines are growing by orders of magnitude.
+
+## Open questions
+
+| # | Question | Status |
+|---|----------|--------|
+| OQ-1 | Which FTC-approved VPC method to implement for MVP? (email-plus is cheapest) | Decision needed |
+| OQ-2 | Australia market: accept 16+ restriction or delay AU launch? | Decision needed |
+| OQ-3 | Zero-knowledge proof for age verification: technically feasible with DID, but no legal precedent | Future research |
+| OQ-4 | How to handle edge cases: guardian abuse, custody disputes, emancipated minors? | Needs legal counsel |
+
+## Founder's intent (strong)
+
+- "I genuinely do not want age restrictions" — this is achievable through Guardian-managed accounts with proper VPC
+- This is not about ignoring safety, but about *designing safety properly* rather than applying a blanket ban
+- The lifelong creative log concept *requires* early adoption to be maximally valuable
+- The goal is to be *more* protective of young users than competitors, not less — while avoiding arbitrary exclusion
+- "Protection is architecture, not a feature" — the single most important lesson from existing platforms
+
+## Related
+
+- ADR 014 (DID): guardian-child relationship could be modeled as DID delegation
+- ADR 016 (User Identity Privacy): PublicUserType separation already protects sensitive fields
+- Idea 011 (Copyright): minors' content has additional legal protections in some jurisdictions
+- Egan principle of "self-determination": even young users should own their creative identity
+- **ADR 019 (Age Policy)**: drafted based on this research


### PR DESCRIPTION
## Summary

- **Idea 011** (Copyright Protection): Upgraded to Exploring with comprehensive research across YouTube/Instagram/TikTok/SoundCloud/Bandcamp/Bluesky, DMCA/EU Art.17/Japan law, and key case law
- **Idea 012** (Age Policy): Upgraded to Exploring with research across COPPA/GDPR-K/UK Children's Code/DSA, 6 platform precedents, and enforcement trends
- **ADR 018** (Copyright Protection): Three-layer strategy — DMCA Safe Harbor compliance ($6) + Ed25519/contentHash structural protection + post-MVP perceptual hashing
- **ADR 019** (Age Policy): Guardian-managed accounts with 4-tier system, email-plus VPC, DID-based guardian delegation, privacy-by-default, and guardian session-switch authentication for child accounts

### Key findings
- COPPA does NOT require banning children — guardian-managed accounts with VPC are legally valid
- DMCA Safe Harbor minimum cost is $6 — Content ID-like systems are business strategy, not legal requirement
- Gleisner's Ed25519 + contentHash architecture provides cryptographic provenance no other platform offers
- COPPA Safe Harbor certification ($5K-$15K/yr) is nice-to-have, not required for an indie/side project

Both ADRs are **Draft** status and marked as requiring legal counsel review before implementation.

## Test plan

- [ ] Review ADR 018 for technical accuracy against existing ADRs (014, 017)
- [ ] Review ADR 019 tier design and authentication flow
- [ ] Verify all cross-references between Ideas and ADRs are consistent
- [ ] Confirm no conflicts with existing ADR decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)