### PR TITLE
chore: add mise (プロジェクト環境管理ツール)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ build/
 *.iml
 .flutter-plugins
 .flutter-plugins-dependencies
+
+# mise
+.mise/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,41 @@ Discover/Tune In のテストには追加 seed も投入：
 
 **⚠ `pnpm test` 実行後は seed データが消える。** テストの `beforeEach` で `TRUNCATE users CASCADE` が実行されるため、テスト後に実機確認する場合は seed スクリプトを再実行すること。
 
+### mise tasks（代替コマンド）
+
+[mise](https://mise.jdx.dev/) がインストール済みであれば、上記の手動コマンドの代わりにタスクを使用できる。タスクは依存関係を自動解決する（例: `mise run test` は自動的に `build` を先行実行）。
+
+```bash
+mise run <タスク名>    # プロジェクトルートまたは backend/frontend ディレクトリから実行
+mise tasks             # 利用可能なタスク一覧を表示
+```
+
+#### バックエンドタスク（`cd backend` で実行）
+
+| タスク | 実行内容 | 自動依存 |
+|--------|----------|---------|
+| `start_dev` | 開発サーバー起動（`pnpm dev`） | `start_db` |
+| `start_db` | PostgreSQL 起動（`docker compose up -d --wait`） | — |
+| `stop_db` | PostgreSQL 停止 | — |
+| `build` | TypeScript ビルド | — |
+| `lint` | ESLint + Prettier チェック | — |
+| `test` | インテグレーションテスト | `build` |
+| `seed_dev` | スキーマを DB に反映（`db:push`） | `build` |
+| `seed_init_dev` | Discover 用データ投入（4アーティスト・20ジャンル） | — |
+| `setup_new_local` | 初回セットアップ: `.env` コピー → DB 起動 → seed | — |
+| `clean_cache_build` | `node_modules` / `dist` を削除 | — |
+| `clean_docker` | Docker コンテナ・イメージ・ボリュームを全削除 | — |
+
+#### フロントエンドタスク（`cd frontend` で実行）
+
+| タスク | 実行内容 | 自動依存 |
+|--------|----------|---------|
+| `pub_get` | `flutter pub get` | — |
+| `lint` | フォーマット + 静的解析 | `pub_get` |
+| `run_web` | `flutter run` | — |
+| `build` | `flutter build web` | — |
+| `test` | `flutter test` | — |
+
 ### ⚠ `db:push` の注意事項
 
 `db:push` はカラム追加時にテーブルを再作成する場合があり、**既存データが消失する**。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,8 @@ pnpm db:studio        # Drizzle Studio（DB GUI）
 
 ```bash
 cd frontend
-dart analyze           # 静的解析（flutter_lints）
-dart format .          # Dart フォーマッタ
+flutter analyze       # 静的解析（flutter_lints）
+dart format lib test  # Dart フォーマッタ
 ```
 
 ### テストデータ投入
@@ -127,6 +127,8 @@ mise run <タスク名>    # プロジェクトルートまたは backend/fronte
 mise tasks             # 利用可能なタスク一覧を表示
 ```
 
+[mise monorepo](https://mise.jdx.dev/tasks/monorepo.html#monorepo-tasks) を有効化しているため、下記のコマンドは [monorepo task syntax](https://mise.jdx.dev/tasks/monorepo.html#task-path-syntax) 指定も可能
+
 #### バックエンドタスク（`cd backend` で実行）
 
 | タスク | 実行内容 | 自動依存 |
@@ -135,7 +137,7 @@ mise tasks             # 利用可能なタスク一覧を表示
 | `start_db` | PostgreSQL 起動（`docker compose up -d --wait`） | — |
 | `stop_db` | PostgreSQL 停止 | — |
 | `build` | TypeScript ビルド | — |
-| `lint` | ESLint + Prettier チェック | — |
+| `lint` | ESLint + Prettier 自動修正（`pnpm format` + `pnpm lint:fix`） | — |
 | `test` | インテグレーションテスト | `build` |
 | `seed_dev` | スキーマを DB に反映（`db:push`） | `build` |
 | `seed_init_dev` | Discover 用データ投入（4アーティスト・20ジャンル） | — |
@@ -150,8 +152,9 @@ mise tasks             # 利用可能なタスク一覧を表示
 | `pub_get` | `flutter pub get` | — |
 | `lint` | フォーマット + 静的解析 | `pub_get` |
 | `run_web` | `flutter run` | — |
-| `build` | `flutter build web` | — |
+| `build` | `flutter build web` | `clean` |
 | `test` | `flutter test` | — |
+| `clean` | `flutter clean` | — |
 
 ### ⚠ `db:push` の注意事項
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,41 @@ docker compose up -d   # Start PostgreSQL
 docker compose down    # Stop PostgreSQL
 ```
 
+### Using mise (optional)
+
+If you have [mise](https://mise.jdx.dev/) installed, you can use the defined tasks instead of running commands manually. Tasks handle dependencies automatically (e.g., `mise run test` builds first).
+
+```bash
+mise run <task>        # run from project root or backend/frontend directory
+mise tasks             # list all available tasks
+```
+
+#### Backend tasks (`cd backend`)
+
+| Task | What it does | Auto-runs |
+|------|-------------|-----------|
+| `start_dev` | Start dev server (`pnpm dev`) | `start_db` |
+| `start_db` | Start PostgreSQL (`docker compose up -d --wait`) | — |
+| `stop_db` | Stop PostgreSQL | — |
+| `build` | TypeScript build | — |
+| `lint` | ESLint + Prettier check | — |
+| `test` | Integration tests | `build` |
+| `seed_dev` | Push schema to DB (`db:push`) | `build` |
+| `seed_init_dev` | Seed discover data (4 artists, 20 genres) | — |
+| `setup_new_local` | First-time setup: copy `.env`, start DB, seed | — |
+| `clean_cache_build` | Remove `node_modules` and `dist` | — |
+| `clean_docker` | Remove all Docker containers/images/volumes | — |
+
+#### Frontend tasks (`cd frontend`)
+
+| Task | What it does | Auto-runs |
+|------|-------------|-----------|
+| `pub_get` | `flutter pub get` | — |
+| `lint` | Format + static analysis | `pub_get` |
+| `run_web` | `flutter run` | — |
+| `build` | `flutter build web` | — |
+| `test` | `flutter test` | — |
+
 ### Important notes
 
 - **After `pnpm test`**: Seed data is truncated. Re-run seed scripts before manual testing.

--- a/backend/mise.toml
+++ b/backend/mise.toml
@@ -3,7 +3,7 @@ node = "latest"
 pnpm = "latest"
 
 [tasks]
-lint = { run = "pnpm lint format" }
+lint = { run = ["pnpm format", "pnpm lint:fix", ] }
 build = { run = "pnpm build" }
 test = { run = "pnpm test", depends = "build" }
 seed_dev = { run = "pnpm db:push", depends = "build" }
@@ -11,6 +11,7 @@ seed_init_dev = { run = "../scripts/seed-discover-data.sh" }
 setup_new_local = { run = "cp .env.example .env", depends_post = [
   "start_db",
   "seed_dev",
+  "seed_init_dev",
 ] }
 start_dev = { run = "pnpm dev", depends = "start_db" }
 start_db = { run = "docker compose up -d --wait" }

--- a/backend/mise.toml
+++ b/backend/mise.toml
@@ -1,0 +1,22 @@
+[tools]
+node = "latest"
+pnpm = "latest"
+
+[tasks]
+lint = { run = "pnpm lint format" }
+build = { run = "pnpm build" }
+test = { run = "pnpm test", depends = "build" }
+seed_dev = { run = "pnpm db:push", depends = "build" }
+seed_init_dev = { run = "../scripts/seed-discover-data.sh" }
+setup_new_local = { run = "cp .env.example .env", depends_post = [
+  "start_db",
+  "seed_dev",
+] }
+start_dev = { run = "pnpm dev", depends = "start_db" }
+start_db = { run = "docker compose up -d --wait" }
+stop_db = { run = "docker compose stop" }
+clean_cache_build = { run = ["rm -rf node_modules", "rm -rf dist"] }
+clean_docker = { run = "docker compose down --rmi all --volumes --remove-orphans" }
+
+[prepare]
+pnpm = { auto = true }

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -4,6 +4,7 @@ flutter = "latest"
 [tasks]
 lint = { run = "dart fmt lib && flutter analyze", depends = "pub_get" } # dart fmt にpub_getが必要
 run_web = { run = "flutter run" }
-build = { run = "flutter build web" }
+build = { run = "flutter build web", depends = "clean" }
 pub_get = { run = "flutter pub get" }
 test = { run = "flutter test" }
+clean = { run = "flutter clean" }

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -1,0 +1,9 @@
+[tools]
+flutter = "latest"
+
+[tasks]
+lint = { run = "dart fmt lib && flutter analyze", depends = "pub_get" } # dart fmt にpub_getが必要
+run_web = { run = "flutter run" }
+build = { run = "flutter build web" }
+pub_get = { run = "flutter pub get" }
+test = { run = "flutter test" }

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -2,7 +2,7 @@
 flutter = "latest"
 
 [tasks]
-lint = { run = "dart fmt lib && flutter analyze", depends = "pub_get" } # dart fmt にpub_getが必要
+lint = { run = ["dart format lib test", "flutter analyze", ], depends = "pub_get" } # dart fmt にpub_getが必要
 run_web = { run = "flutter run" }
 build = { run = "flutter build web", depends = "clean" }
 pub_get = { run = "flutter pub get" }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+experimental_monorepo_root = true
+
+[tools]
+flutter = "latest"
+node = "latest"
+"npm:pnpm" = "latest"
+
+[monorepo]
+config_roots = [
+  "backend",
+  "frontend",
+]
+
+[settings]
+experimental = true


### PR DESCRIPTION
## Summary

[mise](https://mise.jdx.dev/getting-started.html) を追加して、便利タスクを追加した

追加したタスク自体は、PR作成時の開発に関わるコマンドを集めた程度

## Motivation

`mise.toml` にワークフローコマンドと、依存ランタイムの定義を追加することで、開発環境の統一運用を進める

## Changes

- README.md / CLAUDE.mdへの追記
- `mise.toml` とサブリポジトリ(サブディレクトリ)への追加
    - [サブディレクトリtaskの実行syntax](https://mise.jdx.dev/tasks/monorepo.html#task-path-syntax)
        - ただし、README.mdに記載した内容の方法でも間違いない

## Checklist

- [x] I have read the [CONTRIBUTING guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] I have tested my changes locally
- [x] I have added/updated documentation as needed
