### PR TITLE
Bump drizzle-orm from 0.45.1 to 0.45.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "@hono/node-server": "^1.19.12",
     "@pothos/core": "^4.12.0",
     "dotenv": "^17.3.1",
-    "drizzle-orm": "^0.45.1",
+    "drizzle-orm": "^0.45.2",
     "graphql": "^16.13.2",
     "graphql-yoga": "^5.18.1",
     "hono": "^4.12.9",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: ^17.3.1
         version: 17.3.1
       drizzle-orm:
-        specifier: ^0.45.1
-        version: 0.45.1(postgres@3.4.8)
+        specifier: ^0.45.2
+        version: 0.45.2(postgres@3.4.8)
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
@@ -867,8 +867,8 @@ packages:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
-  drizzle-orm@0.45.1:
-    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -2118,7 +2118,7 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.1(postgres@3.4.8):
+  drizzle-orm@0.45.2(postgres@3.4.8):
     optionalDependencies:
       postgres: 3.4.8
 


### PR DESCRIPTION
Replaces dependabot PR #91 (had merge conflicts with #98).

## Test plan
- [x] `pnpm build` → pass
- [x] `pnpm test` → 203 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)