### PR TITLE
Polish link type UI: forms, nodes, detail sheet (Idea 024)

### DIFF
--- a/.claude/rules/frontend-implementation.md
+++ b/.claude/rules/frontend-implementation.md
@@ -698,3 +698,43 @@ void _onControllerUpdate() {
 ```
 
 波形プログレスバー等の `CustomPainter.shouldRepaint` は最適化されていても、Widget ツリー構築コストは毎フレームかかる。
+
+### Flutter Web IME + Tab キーの assertion 対策
+
+**Flutter Web でテキスト入力フォームを実装する場合、`createImeSafeFocusNode(controller)` を使うこと。**
+
+IME で漢字変換候補が表示されている状態で Tab キーを押すと、composing 範囲とテキスト長が不整合になり `Range end N is out of text of length 0` assertion が発生する。`FocusNode.onKeyEvent` で composition 中の Tab を消費して防止する。
+
+```dart
+// ❌ 通常の FocusNode — IME 変換中に Tab でエラー
+final focusNode = FocusNode();
+
+// ✅ IME-safe FocusNode — composition 中は Tab を消費
+final focusNode = createImeSafeFocusNode(controller);
+```
+
+ユーティリティ: `lib/utils/ime_safe_focus.dart`。controller は FocusNode より長く生存する必要がある（FocusNode を先に dispose）。
+
+PR #192 の教訓: FocusNode の管理、FocusTraversalGroup、textInputAction の変更では解決せず、onKeyEvent での Tab 消費が唯一の有効な対策だった。
+
+### Stack 内 Image.network の errorBuilder に複合 UI を返さない
+
+**Stack 内で `Image.network` の `errorBuilder` にタイトル等を含む複合ウィジェットを返すと、Stack の他の Positioned 子要素（オーバーレイ等）と表示が重複する。**
+
+```dart
+// ❌ errorBuilder に _LinkFallback（タイトル含む）を返す → OverlayInfo のタイトルと重複
+Image.network(
+  url,
+  errorBuilder: (_, _, _) => _LinkFallback(post: post, ...),  // タイトルあり
+),
+Positioned(bottom: 8, child: _OverlayInfo(post: post, ...)),   // タイトルあり → 重複！
+
+// ✅ errorBuilder はプレーン背景のみ → 情報表示は Positioned に一元化
+Image.network(
+  url,
+  errorBuilder: (_, _, _) => Container(color: colorSurface2),  // 背景のみ
+),
+Positioned(bottom: 8, child: _OverlayInfo(post: post, ...)),   // タイトル1箇所のみ
+```
+
+PR #192 の教訓: OGP 画像ロードエラー時に `_LinkFallback` を返したところ、`_OverlayInfo` のタイトルと重複表示された。

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -1130,14 +1129,14 @@ class _FormStep extends ConsumerWidget {
                 style: TextStyle(
                   color: colorTextPrimary,
                   fontSize: fontSizeMd,
-                  fontFamily: GoogleFonts.jetBrainsMono().fontFamily,
+                  fontFamily: monoFontFamily,
                 ),
                 decoration: InputDecoration(
                   hintText: 'https://',
                   hintStyle: TextStyle(
                     color: colorTextMuted.withValues(alpha: 0.4),
                     fontSize: fontSizeMd,
-                    fontFamily: GoogleFonts.jetBrainsMono().fontFamily,
+                    fontFamily: monoFontFamily,
                   ),
                   icon: Icon(
                     Icons.link_rounded,

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -11,6 +12,7 @@ import '../../models/track.dart' show Track, parseHexColor;
 import '../../providers/create_post_provider.dart';
 import '../../providers/timeline_provider.dart';
 import '../../utils/constellation_layout.dart';
+import '../../utils/ime_safe_focus.dart';
 import '../../widgets/common/connection_type_picker.dart';
 import '../../widgets/common/error_banner.dart';
 import '../../widgets/common/event_at_picker.dart';
@@ -33,6 +35,11 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
   final _bodyController = TextEditingController();
   final _mediaUrlController = TextEditingController();
   final _quillController = QuillController.basic();
+  // FocusNodes that block Tab during IME composition to prevent
+  // Flutter Web assertion "Range end N is out of text of length 0".
+  late final _urlFocusNode = createImeSafeFocusNode(_mediaUrlController);
+  late final _linkTitleFocusNode = createImeSafeFocusNode(_titleController);
+  late final _linkCaptionFocusNode = createImeSafeFocusNode(_bodyController);
   String? _thumbnailUrl;
   int? _durationSeconds;
   DateTime? _eventAt;
@@ -46,6 +53,9 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     _bodyController.dispose();
     _mediaUrlController.dispose();
     _quillController.dispose();
+    _urlFocusNode.dispose();
+    _linkTitleFocusNode.dispose();
+    _linkCaptionFocusNode.dispose();
     // Provider reset is handled in _submit() success path.
     // autoDispose cleans up when no watchers remain.
     super.dispose();
@@ -191,6 +201,9 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
               mediaUrlController: _mediaUrlController,
               thumbnailUrl: _thumbnailUrl,
               durationSeconds: _durationSeconds,
+              urlFocusNode: _urlFocusNode,
+              linkTitleFocusNode: _linkTitleFocusNode,
+              linkCaptionFocusNode: _linkCaptionFocusNode,
               eventAt: _eventAt,
               onEventAtChanged: (dt) => setState(() => _eventAt = dt),
               onSubmit: _submit,
@@ -461,6 +474,9 @@ class _FormStep extends ConsumerWidget {
   final TextEditingController mediaUrlController;
   final String? thumbnailUrl;
   final int? durationSeconds;
+  final FocusNode? urlFocusNode;
+  final FocusNode? linkTitleFocusNode;
+  final FocusNode? linkCaptionFocusNode;
   final DateTime? eventAt;
   final ValueChanged<DateTime?> onEventAtChanged;
   final VoidCallback onSubmit;
@@ -474,6 +490,9 @@ class _FormStep extends ConsumerWidget {
     required this.mediaUrlController,
     this.thumbnailUrl,
     this.durationSeconds,
+    this.urlFocusNode,
+    this.linkTitleFocusNode,
+    this.linkCaptionFocusNode,
     this.eventAt,
     required this.onEventAtChanged,
     required this.onSubmit,
@@ -835,6 +854,7 @@ class _FormStep extends ConsumerWidget {
         padding: const EdgeInsets.symmetric(horizontal: spaceMd),
         child: TextFormField(
           controller: titleController,
+          focusNode: linkTitleFocusNode,
           maxLength: 100,
           maxLengthEnforcement: MaxLengthEnforcement.enforced,
           decoration: InputDecoration(
@@ -868,6 +888,7 @@ class _FormStep extends ConsumerWidget {
         padding: const EdgeInsets.symmetric(horizontal: spaceMd),
         child: TextFormField(
           controller: bodyController,
+          focusNode: linkCaptionFocusNode,
           maxLines: 4,
           minLines: 2,
           maxLength: 500,
@@ -1084,42 +1105,135 @@ class _FormStep extends ConsumerWidget {
     );
   }
 
-  // link: URL (required) + caption
+  // link: URL (required) + title + caption
   List<Widget> _buildLinkFields(ThemeData theme) {
     return [
-      TextFormField(
-        controller: mediaUrlController,
-        decoration: const InputDecoration(
-          labelText: 'URL',
-          border: OutlineInputBorder(),
-          hintText: 'https://',
-          prefixIcon: Icon(Icons.link),
+      // Wrap in FocusTraversalGroup to keep Tab navigation within these fields
+      // and prevent Flutter Web IME assertion on focus change.
+      FocusTraversalGroup(
+        policy: OrderedTraversalPolicy(),
+        child: Column(
+          children: [
+            // URL field
+            Container(
+              decoration: BoxDecoration(
+                color: colorSurface1,
+                borderRadius: BorderRadius.circular(radiusMd),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: spaceMd),
+              child: TextFormField(
+                controller: mediaUrlController,
+                focusNode: urlFocusNode,
+                keyboardType: TextInputType.url,
+                textInputAction: TextInputAction.next,
+                autofocus: true,
+                style: TextStyle(
+                  color: colorTextPrimary,
+                  fontSize: fontSizeMd,
+                  fontFamily: GoogleFonts.jetBrainsMono().fontFamily,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'https://',
+                  hintStyle: TextStyle(
+                    color: colorTextMuted.withValues(alpha: 0.4),
+                    fontSize: fontSizeMd,
+                    fontFamily: GoogleFonts.jetBrainsMono().fontFamily,
+                  ),
+                  icon: Icon(
+                    Icons.link_rounded,
+                    color: colorTextMuted,
+                    size: 20,
+                  ),
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.symmetric(vertical: spaceMd),
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'URL is required';
+                  }
+                  final uri = Uri.tryParse(value);
+                  if (uri == null || !['http', 'https'].contains(uri.scheme)) {
+                    return 'Enter a valid http(s) URL';
+                  }
+                  return null;
+                },
+              ),
+            ),
+            const SizedBox(height: spaceSm),
+            // Title
+            Container(
+              decoration: BoxDecoration(
+                color: colorSurface1,
+                borderRadius: BorderRadius.circular(radiusMd),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: spaceMd),
+              child: TextFormField(
+                controller: titleController,
+                focusNode: linkTitleFocusNode,
+                textInputAction: TextInputAction.next,
+                maxLength: 100,
+                maxLengthEnforcement: MaxLengthEnforcement.enforced,
+                style: const TextStyle(
+                  color: colorTextPrimary,
+                  fontSize: fontSizeLg,
+                  fontWeight: weightMedium,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'Title (auto-filled from link if empty)',
+                  hintStyle: const TextStyle(
+                    color: colorTextMuted,
+                    fontSize: fontSizeLg,
+                    fontWeight: weightMedium,
+                  ),
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.symmetric(vertical: spaceMd),
+                  counterStyle: TextStyle(
+                    fontSize: fontSizeXs,
+                    color: colorTextMuted.withValues(alpha: 0.5),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: spaceSm),
+            // Caption
+            Container(
+              decoration: BoxDecoration(
+                color: colorSurface1,
+                borderRadius: BorderRadius.circular(radiusMd),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: spaceMd),
+              child: TextFormField(
+                controller: bodyController,
+                focusNode: linkCaptionFocusNode,
+                textInputAction: TextInputAction.done,
+                maxLines: 3,
+                minLines: 2,
+                maxLength: 500,
+                maxLengthEnforcement: MaxLengthEnforcement.enforced,
+                style: const TextStyle(
+                  color: colorTextSecondary,
+                  fontSize: fontSizeMd,
+                  height: 1.5,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'Add a note...',
+                  hintStyle: const TextStyle(
+                    color: colorTextMuted,
+                    fontSize: fontSizeMd,
+                  ),
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.symmetric(vertical: spaceSm),
+                  counterStyle: TextStyle(
+                    fontSize: fontSizeXs,
+                    color: colorTextMuted.withValues(alpha: 0.5),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: spaceMd),
+          ],
         ),
-        keyboardType: TextInputType.url,
-        autofocus: true,
-        validator: (value) {
-          if (value == null || value.isEmpty) {
-            return 'URL is required';
-          }
-          final uri = Uri.tryParse(value);
-          if (uri == null || !['http', 'https'].contains(uri.scheme)) {
-            return 'Enter a valid http(s) URL';
-          }
-          return null;
-        },
       ),
-      const SizedBox(height: spaceLg),
-      TextFormField(
-        controller: bodyController,
-        decoration: const InputDecoration(
-          labelText: 'Caption (optional)',
-          border: OutlineInputBorder(),
-          alignLabelWithHint: true,
-        ),
-        maxLines: 3,
-        maxLength: 500,
-      ),
-      const SizedBox(height: spaceLg),
     ];
   }
 }

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -16,6 +17,7 @@ import '../../widgets/common/event_at_picker.dart';
 import '../../widgets/editor/rich_text_editor.dart';
 import '../../widgets/editor/text_body_counter.dart';
 import '../../utils/constellation_layout.dart';
+import '../../utils/ime_safe_focus.dart';
 import '../../widgets/timeline/seed_art_painter.dart';
 
 class EditPostScreen extends ConsumerStatefulWidget {
@@ -55,6 +57,10 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
   String? _thumbnailUrl;
   int? _durationSeconds;
   DateTime? _eventAt;
+  // IME-safe FocusNodes — block Tab during composition
+  late final FocusNode _titleFocusNode;
+  late final FocusNode _bodyFocusNode;
+  late final FocusNode _urlFocusNode;
 
   @override
   void initState() {
@@ -81,6 +87,9 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
     } else {
       _quillController = QuillController.basic();
     }
+    _titleFocusNode = createImeSafeFocusNode(_titleController);
+    _bodyFocusNode = createImeSafeFocusNode(_bodyController);
+    _urlFocusNode = createImeSafeFocusNode(_mediaUrlController);
     _importance = widget.post.importance;
     _visibility = widget.post.visibility;
     _selectedTrackId = widget.post.trackId;
@@ -95,6 +104,9 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
     _bodyController.dispose();
     _mediaUrlController.dispose();
     _quillController.dispose();
+    _titleFocusNode.dispose();
+    _bodyFocusNode.dispose();
+    _urlFocusNode.dispose();
     super.dispose();
   }
 
@@ -512,6 +524,7 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
         padding: const EdgeInsets.symmetric(horizontal: spaceMd),
         child: TextFormField(
           controller: _titleController,
+          focusNode: _titleFocusNode,
           maxLength: 100,
           maxLengthEnforcement: MaxLengthEnforcement.enforced,
           style: const TextStyle(
@@ -545,6 +558,7 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
         padding: const EdgeInsets.symmetric(horizontal: spaceMd),
         child: TextFormField(
           controller: _bodyController,
+          focusNode: _bodyFocusNode,
           maxLines: 4,
           minLines: 2,
           maxLength: 500,
@@ -780,31 +794,127 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
 
   List<Widget> _buildLinkFields() {
     return [
-      TextFormField(
-        controller: _mediaUrlController,
-        style: const TextStyle(color: colorTextPrimary),
-        decoration: _inputDecoration(
-          'URL',
-        ).copyWith(prefixIcon: const Icon(Icons.link, color: colorTextMuted)),
-        keyboardType: TextInputType.url,
-        validator: (value) {
-          if (value == null || value.trim().isEmpty) {
-            return 'URL is required';
-          }
-          final uri = Uri.tryParse(value.trim());
-          if (uri == null || !['http', 'https'].contains(uri.scheme)) {
-            return 'Enter a valid http(s) URL';
-          }
-          return null;
-        },
-      ),
-      const SizedBox(height: spaceLg),
-      TextFormField(
-        controller: _bodyController,
-        maxLines: 3,
-        maxLength: 500,
-        style: const TextStyle(color: colorTextPrimary),
-        decoration: _inputDecoration('Caption (optional)'),
+      FocusTraversalGroup(
+        policy: OrderedTraversalPolicy(),
+        child: Column(
+          children: [
+            // URL field
+            Container(
+              decoration: BoxDecoration(
+                color: colorSurface1,
+                borderRadius: BorderRadius.circular(radiusMd),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: spaceMd),
+              child: TextFormField(
+                controller: _mediaUrlController,
+                focusNode: _urlFocusNode,
+                keyboardType: TextInputType.url,
+                textInputAction: TextInputAction.next,
+                style: TextStyle(
+                  color: colorTextPrimary,
+                  fontSize: fontSizeMd,
+                  fontFamily: GoogleFonts.jetBrainsMono().fontFamily,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'https://',
+                  hintStyle: TextStyle(
+                    color: colorTextMuted.withValues(alpha: 0.4),
+                    fontSize: fontSizeMd,
+                    fontFamily: GoogleFonts.jetBrainsMono().fontFamily,
+                  ),
+                  icon: const Icon(
+                    Icons.link_rounded,
+                    color: colorTextMuted,
+                    size: 20,
+                  ),
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.symmetric(vertical: spaceMd),
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'URL is required';
+                  }
+                  final uri = Uri.tryParse(value.trim());
+                  if (uri == null || !['http', 'https'].contains(uri.scheme)) {
+                    return 'Enter a valid http(s) URL';
+                  }
+                  return null;
+                },
+              ),
+            ),
+            const SizedBox(height: spaceSm),
+            // Title
+            Container(
+              decoration: BoxDecoration(
+                color: colorSurface1,
+                borderRadius: BorderRadius.circular(radiusMd),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: spaceMd),
+              child: TextFormField(
+                controller: _titleController,
+                focusNode: _titleFocusNode,
+                textInputAction: TextInputAction.next,
+                maxLength: 100,
+                maxLengthEnforcement: MaxLengthEnforcement.enforced,
+                style: const TextStyle(
+                  color: colorTextPrimary,
+                  fontSize: fontSizeLg,
+                  fontWeight: weightMedium,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'Title (auto-filled from link if empty)',
+                  hintStyle: const TextStyle(
+                    color: colorTextMuted,
+                    fontSize: fontSizeLg,
+                    fontWeight: weightMedium,
+                  ),
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.symmetric(vertical: spaceMd),
+                  counterStyle: TextStyle(
+                    fontSize: fontSizeXs,
+                    color: colorTextMuted.withValues(alpha: 0.5),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: spaceSm),
+            // Caption
+            Container(
+              decoration: BoxDecoration(
+                color: colorSurface1,
+                borderRadius: BorderRadius.circular(radiusMd),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: spaceMd),
+              child: TextFormField(
+                controller: _bodyController,
+                focusNode: _bodyFocusNode,
+                textInputAction: TextInputAction.done,
+                maxLines: 3,
+                minLines: 2,
+                maxLength: 500,
+                maxLengthEnforcement: MaxLengthEnforcement.enforced,
+                style: const TextStyle(
+                  color: colorTextSecondary,
+                  fontSize: fontSizeMd,
+                  height: 1.5,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'Add a note...',
+                  hintStyle: const TextStyle(
+                    color: colorTextMuted,
+                    fontSize: fontSizeMd,
+                  ),
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.symmetric(vertical: spaceSm),
+                  counterStyle: TextStyle(
+                    fontSize: fontSizeXs,
+                    color: colorTextMuted.withValues(alpha: 0.5),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     ];
   }

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -813,14 +812,14 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
                 style: TextStyle(
                   color: colorTextPrimary,
                   fontSize: fontSizeMd,
-                  fontFamily: GoogleFonts.jetBrainsMono().fontFamily,
+                  fontFamily: monoFontFamily,
                 ),
                 decoration: InputDecoration(
                   hintText: 'https://',
                   hintStyle: TextStyle(
                     color: colorTextMuted.withValues(alpha: 0.4),
                     fontSize: fontSizeMd,
-                    fontFamily: GoogleFonts.jetBrainsMono().fontFamily,
+                    fontFamily: monoFontFamily,
                   ),
                   icon: const Icon(
                     Icons.link_rounded,

--- a/frontend/lib/theme/gleisner_tokens.dart
+++ b/frontend/lib/theme/gleisner_tokens.dart
@@ -150,3 +150,6 @@ final textLabel = GoogleFonts.plusJakartaSans(
   fontSize: fontSizeSm,
   fontWeight: weightMedium,
 );
+
+/// Monospace font family for URLs and code.
+final monoFontFamily = GoogleFonts.jetBrainsMono().fontFamily;

--- a/frontend/lib/utils/ime_safe_focus.dart
+++ b/frontend/lib/utils/ime_safe_focus.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Create a FocusNode that blocks Tab key during IME composition.
+///
+/// On Flutter Web, pressing Tab while the IME has uncommitted text
+/// (e.g. Japanese kanji candidates) causes the composition to commit
+/// AND focus to move simultaneously. This corrupts the text editing
+/// state, causing "Range end N is out of text of length 0" assertions.
+///
+/// This FocusNode intercepts Tab during active composition and consumes
+/// the event, forcing the user to confirm IME input before Tab-navigating.
+FocusNode createImeSafeFocusNode(TextEditingController controller) {
+  return FocusNode(
+    onKeyEvent: (node, event) {
+      if (event is KeyDownEvent &&
+          event.logicalKey == LogicalKeyboardKey.tab &&
+          controller.value.composing != TextRange.empty) {
+        return KeyEventResult.handled;
+      }
+      return KeyEventResult.ignored;
+    },
+  );
+}

--- a/frontend/lib/utils/ime_safe_focus.dart
+++ b/frontend/lib/utils/ime_safe_focus.dart
@@ -3,6 +3,9 @@ import 'package:flutter/services.dart';
 
 /// Create a FocusNode that blocks Tab key during IME composition.
 ///
+/// IMPORTANT: [controller] must outlive the returned [FocusNode].
+/// Dispose the FocusNode before disposing [controller].
+///
 /// On Flutter Web, pressing Tab while the IME has uncommitted text
 /// (e.g. Japanese kanji candidates) causes the composition to commit
 /// AND focus to move simultaneously. This corrupts the text editing

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -737,7 +737,7 @@ class _LinkContent extends StatelessWidget {
     final domain = post.mediaUrl != null
         ? Uri.tryParse(post.mediaUrl!)?.host ?? ''
         : '';
-    final displayTitle = post.ogTitle ?? post.title;
+    final displayTitle = post.title ?? post.ogTitle;
     final showInfo = node.showInfo;
     final totalH = node.mediaHeight + (showInfo ? 30 : 0);
 
@@ -759,11 +759,7 @@ class _LinkContent extends StatelessWidget {
                 if (loadingProgress == null) return child;
                 return Container(color: colorSurface2);
               },
-              errorBuilder: (_, _, _) => _LinkFallback(
-                post: post,
-                trackColor: trackColor,
-                domain: domain,
-              ),
+              errorBuilder: (_, _, _) => Container(color: colorSurface2),
             ),
             // Bottom gradient
             if (showInfo)
@@ -829,83 +825,60 @@ class _LinkFallback extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final displayTitle = post.ogTitle ?? post.title;
+    final displayTitle = post.title ?? post.ogTitle;
     return Container(
-      padding: const EdgeInsets.all(spaceSm),
       decoration: BoxDecoration(
+        border: Border(
+          left: BorderSide(color: trackColor.withValues(alpha: 0.5), width: 3),
+        ),
         gradient: LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
-          colors: [trackColor.withValues(alpha: 0.04), colorSurface1],
+          colors: [trackColor.withValues(alpha: 0.08), colorSurface1],
         ),
       ),
+      padding: const EdgeInsets.fromLTRB(spaceSm, spaceSm, spaceSm, spaceSm),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          Row(
-            children: [
-              Icon(Icons.link_rounded, size: fontSizeMd, color: trackColor),
-              const SizedBox(width: spaceXs),
-              Flexible(
-                child: _TrackLabel(
-                  trackName: post.trackName,
-                  color: trackColor,
+          // Domain row
+          if (domain.isNotEmpty) ...[
+            Row(
+              children: [
+                Icon(
+                  Icons.link_rounded,
+                  size: 10,
+                  color: trackColor.withValues(alpha: 0.5),
                 ),
-              ),
-            ],
-          ),
-          const SizedBox(height: spaceXs),
+                const SizedBox(width: spaceXs),
+                Flexible(
+                  child: Text(
+                    domain,
+                    style: TextStyle(
+                      color: trackColor.withValues(alpha: 0.5),
+                      fontSize: 9,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: spaceXs),
+          ],
           if (displayTitle != null)
             Text(
               displayTitle,
               style: const TextStyle(
                 color: colorTextPrimary,
-                fontSize: fontSizeSm,
+                fontSize: fontSizeMd,
                 fontWeight: weightSemibold,
                 height: 1.3,
               ),
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
             ),
-          if (post.ogDescription != null && post.ogDescription!.isNotEmpty) ...[
-            const SizedBox(height: 3),
-            Text(
-              post.ogDescription!,
-              style: TextStyle(
-                color: colorTextPrimary.withValues(alpha: 0.6),
-                fontSize: fontSizeXs,
-                height: 1.3,
-              ),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ] else if (post.plainTextPreview != null &&
-              post.plainTextPreview!.isNotEmpty) ...[
-            const SizedBox(height: 3),
-            Text(
-              post.plainTextPreview!,
-              style: TextStyle(
-                color: colorTextPrimary.withValues(alpha: 0.6),
-                fontSize: fontSizeXs,
-                height: 1.3,
-              ),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
-          if (domain.isNotEmpty) ...[
-            const SizedBox(height: spaceXxs),
-            Text(
-              domain,
-              style: TextStyle(
-                color: trackColor.withValues(alpha: 0.6),
-                fontSize: fontSizeXs,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
         ],
       ),
     );
@@ -945,24 +918,47 @@ class _OverlayInfo extends StatelessWidget {
   Widget build(BuildContext context) {
     // For link posts, prefer ogTitle over post.title
     final displayTitle = post.mediaType == MediaType.link
-        ? (post.ogTitle ?? post.title)
+        ? (post.title ?? post.ogTitle)
         : post.title;
     final hasTitle = displayTitle != null && displayTitle.isNotEmpty;
+    final isLink = post.mediaType == MediaType.link;
+    final domain = isLink && post.mediaUrl != null
+        ? Uri.tryParse(post.mediaUrl!)?.host
+        : null;
+    // For links: show domain instead of track name (track color already visible via glow)
+    final label = isLink ? domain : post.trackName?.toUpperCase();
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (post.trackName != null)
-          Text(
-            post.trackName!.toUpperCase(),
-            style: TextStyle(
-              color: trackColor.withValues(alpha: 0.9),
-              fontSize: 9,
-              fontWeight: weightSemibold,
-              letterSpacing: 0.5,
-            ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
+        if (label != null)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isLink)
+                Padding(
+                  padding: const EdgeInsets.only(right: spaceXxs),
+                  child: Icon(
+                    Icons.link_rounded,
+                    size: 9,
+                    color: trackColor.withValues(alpha: 0.8),
+                  ),
+                ),
+              Flexible(
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    color: trackColor.withValues(alpha: 0.9),
+                    fontSize: 9,
+                    fontWeight: weightSemibold,
+                    letterSpacing: isLink ? 0 : 0.5,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
           ),
         if (hasTitle) ...[
           const SizedBox(height: 1),

--- a/frontend/lib/widgets/timeline/post_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/post_detail_sheet.dart
@@ -1473,7 +1473,7 @@ class _PostDetailSheetState extends State<_PostDetailSheet> {
         ? Uri.tryParse(post.mediaUrl!)?.host ?? ''
         : '';
     final hasOgImage = post.ogImage != null && post.ogImage!.isNotEmpty;
-    final displayTitle = post.ogTitle ?? post.title;
+    final displayTitle = post.title ?? post.ogTitle;
 
     if (hasOgImage) {
       // Rich OGP card: large image + overlay info
@@ -1530,6 +1530,23 @@ class _PostDetailSheetState extends State<_PostDetailSheet> {
                           stops: const [0.0, 0.6, 1.0],
                         ),
                       ),
+                    ),
+                  ),
+                ),
+                // External link badge — top right
+                Positioned(
+                  top: spaceSm,
+                  right: spaceSm,
+                  child: Container(
+                    padding: const EdgeInsets.all(spaceXs),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(radiusSm),
+                    ),
+                    child: const Icon(
+                      Icons.open_in_new_rounded,
+                      size: 14,
+                      color: Colors.white70,
                     ),
                   ),
                 ),
@@ -1599,70 +1616,97 @@ class _PostDetailSheetState extends State<_PostDetailSheet> {
       );
     }
 
-    // Fallback: compact link card (no OGP image)
+    // Fallback: link card without OGP image
     return _withBadges(
       post,
       trackColor,
-      GestureDetector(
-        onTap: post.mediaUrl != null ? () => openUrlImpl(post.mediaUrl!) : null,
-        child: Container(
-          height: 120,
-          padding: const EdgeInsets.fromLTRB(
-            spaceLg,
-            spaceLg,
-            spaceLg,
-            spaceMd,
-          ),
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-              colors: [trackColor.withValues(alpha: 0.06), colorSurface1],
+      Container(
+        padding: const EdgeInsets.fromLTRB(spaceLg, spaceLg, spaceLg, spaceMd),
+        decoration: BoxDecoration(
+          border: Border(
+            left: BorderSide(
+              color: trackColor.withValues(alpha: 0.4),
+              width: 3,
             ),
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              if (displayTitle != null) ...[
-                Text(
-                  displayTitle,
-                  style: const TextStyle(
-                    color: colorTextPrimary,
-                    fontSize: fontSizeMd,
-                    fontWeight: weightSemibold,
-                    height: 1.3,
-                  ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: spaceSm),
-              ],
-              Row(
-                children: [
-                  Icon(Icons.link_rounded, size: 16, color: trackColor),
-                  const SizedBox(width: spaceXs),
-                  Flexible(
-                    child: Text(
-                      post.ogSiteName ?? domain,
-                      style: TextStyle(
-                        color: trackColor.withValues(alpha: 0.7),
-                        fontSize: fontSizeSm,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                  const SizedBox(width: spaceSm),
-                  Icon(
-                    Icons.open_in_new_rounded,
-                    size: 14,
-                    color: colorTextMuted.withValues(alpha: 0.5),
-                  ),
-                ],
-              ),
-            ],
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [trackColor.withValues(alpha: 0.06), colorSurface1],
           ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (displayTitle != null) ...[
+              Text(
+                displayTitle,
+                style: const TextStyle(
+                  color: colorTextPrimary,
+                  fontSize: fontSizeLg,
+                  fontWeight: weightSemibold,
+                  height: 1.3,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: spaceSm),
+            ],
+            if (post.ogDescription != null &&
+                post.ogDescription!.isNotEmpty) ...[
+              Text(
+                post.ogDescription!,
+                style: TextStyle(
+                  color: colorTextSecondary.withValues(alpha: 0.7),
+                  fontSize: fontSizeSm,
+                  height: 1.4,
+                ),
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: spaceSm),
+            ],
+            // URL + open button
+            GestureDetector(
+              onTap: post.mediaUrl != null
+                  ? () => openUrlImpl(post.mediaUrl!)
+                  : null,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: spaceSm,
+                  vertical: spaceXs,
+                ),
+                decoration: BoxDecoration(
+                  color: trackColor.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(radiusSm),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.open_in_new_rounded,
+                      size: 14,
+                      color: trackColor.withValues(alpha: 0.8),
+                    ),
+                    const SizedBox(width: spaceXs),
+                    Flexible(
+                      child: Text(
+                        post.ogSiteName ?? domain,
+                        style: TextStyle(
+                          color: trackColor.withValues(alpha: 0.8),
+                          fontSize: fontSizeSm,
+                          fontWeight: weightMedium,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary

Link 型投稿の UI を全面磨き込み（critique → polish パイプライン）。

### Forms (create + edit)
- OutlineInputBorder → colorSurface1 borderless cards（他メディアタイプと統一）
- Title フィールド追加（"Title (auto-filled from link if empty)" ヒント）
- URL フィールド: JetBrains Mono モノスペースフォント、link アイコン
- Caption: "Add a note..." ヒント
- FocusTraversalGroup で Tab キー制御
- IME composition 中の Tab を阻止する createImeSafeFocusNode ユーティリティ（全フォーム共通）

### Timeline nodes
- OGP 画像あり: full-bleed サムネイル + link バッジ + OverlayInfo（ドメイン + タイトル）
- OGP 画像なし: 左ボーダーアクセント + ドメイン行 + タイトル（gradient 強化）
- 画像ロードエラー: プレーン背景 + OverlayInfo（重複タイトル解消）

### Detail sheet
- OGP 画像あり: 240px リッチカード + 外部リンクバッジ（open_in_new）
- OGP 画像なし: 左ボーダー + ogDescription + 明示的 Open ボタン
- タイトル優先: post.title > ogTitle（ユーザー入力優先）

### New utility
- `utils/ime_safe_focus.dart`: Flutter Web IME + Tab キーの assertion エラーを防止

## Test plan

- [ ] Link 投稿フォーム: URL → Title → Caption の Tab 遷移が正常
- [ ] IME 変換中に Tab を押してもエラーにならない
- [ ] OGP サムネイルありリンクのノード表示（サムネイル + ドメイン + タイトル）
- [ ] OGP なしリンクのノード表示（左ボーダー + ドメイン + タイトル、重複なし）
- [ ] 詳細シート: OGP あり → リッチカード + 外部リンクバッジ
- [ ] 詳細シート: OGP なし → Open ボタン + ogDescription
- [ ] `dart analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)