### PR TITLE
Add responsive desktop/tablet layout (Idea 030)

### DIFF
--- a/frontend/lib/providers/media_upload_provider.dart
+++ b/frontend/lib/providers/media_upload_provider.dart
@@ -247,7 +247,8 @@ class MediaUploadNotifier extends Notifier<MediaUploadState>
       if (durationSeconds == null) {
         if (!disposed) {
           state = const MediaUploadState(
-            error: 'Could not determine video duration. Please try another file.',
+            error:
+                'Could not determine video duration. Please try another file.',
           );
         }
         return null;
@@ -335,7 +336,8 @@ class MediaUploadNotifier extends Notifier<MediaUploadState>
       if (durationSeconds == null) {
         if (!disposed) {
           state = const MediaUploadState(
-            error: 'Could not determine audio duration. Please try another file.',
+            error:
+                'Could not determine audio duration. Please try another file.',
           );
         }
         return null;

--- a/frontend/lib/screens/artist/artist_page_screen.dart
+++ b/frontend/lib/screens/artist/artist_page_screen.dart
@@ -133,499 +133,522 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
                 ),
 
                 SliverToBoxAdapter(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: spaceXl),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const SizedBox(height: spaceLg),
-                        // Avatar
-                        AvatarImage(
-                          imageUrl: artist.avatarUrl,
-                          seed: artist.artistUsername,
-                          size: 72,
-                          onTap: isSelf
-                              ? () => _uploadAvatarImage(context)
-                              : null,
+                  child: Center(
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(
+                        maxWidth: maxContentWidth,
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: spaceXl,
                         ),
-                        const SizedBox(height: spaceMd),
-
-                        // Header: name + username + tuned in count
-                        Row(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Flexible(
-                              child: GestureDetector(
-                                onTap: isSelf
-                                    ? () =>
-                                          _showEditDisplayName(context, artist)
-                                    : null,
-                                child: Row(
-                                  mainAxisSize: MainAxisSize.min,
+                            const SizedBox(height: spaceLg),
+                            // Avatar
+                            AvatarImage(
+                              imageUrl: artist.avatarUrl,
+                              seed: artist.artistUsername,
+                              size: 72,
+                              onTap: isSelf
+                                  ? () => _uploadAvatarImage(context)
+                                  : null,
+                            ),
+                            const SizedBox(height: spaceMd),
+
+                            // Header: name + username + tuned in count
+                            Row(
+                              children: [
+                                Flexible(
+                                  child: GestureDetector(
+                                    onTap: isSelf
+                                        ? () => _showEditDisplayName(
+                                            context,
+                                            artist,
+                                          )
+                                        : null,
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        Flexible(
+                                          child: Text(
+                                            artist.displayName ??
+                                                artist.artistUsername,
+                                            style: const TextStyle(
+                                              color: colorTextPrimary,
+                                              fontSize: fontSizeTitle,
+                                              fontWeight: weightBold,
+                                            ),
+                                          ),
+                                        ),
+                                        if (isSelf) ...[
+                                          const SizedBox(width: spaceXs),
+                                          const Icon(
+                                            Icons.edit_outlined,
+                                            size: 14,
+                                            color: colorTextMuted,
+                                          ),
+                                        ],
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                                if (artist.profileVisibility == 'private') ...[
+                                  const SizedBox(width: spaceSm),
+                                  const Icon(
+                                    Icons.lock_outline,
+                                    size: 18,
+                                    color: colorTextMuted,
+                                  ),
+                                ],
+                              ],
+                            ),
+                            const SizedBox(height: spaceXxs),
+                            Row(
+                              children: [
+                                Text(
+                                  '@${artist.artistUsername}',
+                                  style: const TextStyle(
+                                    color: colorTextMuted,
+                                    fontSize: fontSizeMd,
+                                  ),
+                                ),
+                                const SizedBox(width: spaceMd),
+                                const Icon(
+                                  Icons.headphones,
+                                  size: 13,
+                                  color: colorTextMuted,
+                                ),
+                                const SizedBox(width: spaceXxs),
+                                Text(
+                                  '${artist.tunedInCount}',
+                                  style: const TextStyle(
+                                    color: colorTextMuted,
+                                    fontSize: fontSizeSm,
+                                  ),
+                                ),
+                              ],
+                            ),
+
+                            const SizedBox(height: spaceLg),
+
+                            // Tune In button (not shown on own page)
+                            if (isAuthenticated && !isSelf)
+                              _TuneInButton(
+                                isTunedIn: isTunedIn,
+                                onTap: () async {
+                                  final tunedIn = await ref
+                                      .read(tuneInProvider.notifier)
+                                      .toggleTuneIn(artist.id);
+                                  if (!context.mounted) return;
+                                  if (tunedIn) {
+                                    ref
+                                        .read(pendingArtistProvider.notifier)
+                                        .set(artist.artistUsername);
+                                    context.go('/timeline');
+                                  }
+                                },
+                              ),
+
+                            // Genres
+                            if (artist.genres.isNotEmpty || isSelf) ...[
+                              const SizedBox(height: spaceXl),
+                              if (isSelf)
+                                Row(
                                   children: [
-                                    Flexible(
+                                    const Expanded(
                                       child: Text(
-                                        artist.displayName ??
-                                            artist.artistUsername,
-                                        style: const TextStyle(
-                                          color: colorTextPrimary,
-                                          fontSize: fontSizeTitle,
-                                          fontWeight: weightBold,
+                                        'GENRES',
+                                        style: TextStyle(
+                                          color: colorTextMuted,
+                                          fontSize: fontSizeXs,
+                                          fontWeight: weightSemibold,
+                                          letterSpacing: 1,
                                         ),
                                       ),
                                     ),
-                                    if (isSelf) ...[
-                                      const SizedBox(width: spaceXs),
-                                      const Icon(
+                                    IconButton(
+                                      icon: const Icon(
                                         Icons.edit_outlined,
-                                        size: 14,
+                                        size: 18,
                                         color: colorTextMuted,
                                       ),
+                                      onPressed: () =>
+                                          _showEditGenresSheet(context, artist),
+                                    ),
+                                  ],
+                                ),
+                              if (artist.genres.isNotEmpty)
+                                Wrap(
+                                  spacing: spaceSm,
+                                  runSpacing: spaceSm,
+                                  children: artist.genres.map((ag) {
+                                    return _Chip(
+                                      label: ag.genre.name,
+                                      color: colorTextSecondary,
+                                      bgColor: colorSurface2,
+                                      borderColor: colorBorder,
+                                    );
+                                  }).toList(),
+                                ),
+                            ],
+
+                            // About section
+                            if (isSelf ||
+                                artist.location != null ||
+                                artist.activeSince != null ||
+                                artist.tagline != null ||
+                                artist.bio != null) ...[
+                              const SizedBox(height: spaceXl),
+                              if (isSelf)
+                                Row(
+                                  children: [
+                                    const Expanded(
+                                      child: Text(
+                                        'ABOUT',
+                                        style: TextStyle(
+                                          color: colorTextMuted,
+                                          fontSize: fontSizeXs,
+                                          fontWeight: weightSemibold,
+                                          letterSpacing: 1,
+                                        ),
+                                      ),
+                                    ),
+                                    IconButton(
+                                      icon: const Icon(
+                                        Icons.edit_outlined,
+                                        size: 18,
+                                        color: colorTextMuted,
+                                      ),
+                                      onPressed: () =>
+                                          _showEditAboutSheet(context, artist),
+                                    ),
+                                  ],
+                                ),
+                              // Location + Active since
+                              if (artist.location != null ||
+                                  artist.activeSince != null)
+                                Padding(
+                                  padding: const EdgeInsets.only(
+                                    bottom: spaceSm,
+                                  ),
+                                  child: Row(
+                                    children: [
+                                      if (artist.location != null) ...[
+                                        const Icon(
+                                          Icons.place_outlined,
+                                          size: 14,
+                                          color: colorTextMuted,
+                                        ),
+                                        const SizedBox(width: spaceXxs),
+                                        Text(
+                                          artist.location!,
+                                          style: const TextStyle(
+                                            color: colorTextMuted,
+                                            fontSize: fontSizeSm,
+                                          ),
+                                        ),
+                                      ],
+                                      if (artist.location != null &&
+                                          artist.activeSince != null)
+                                        const Text(
+                                          ' · ',
+                                          style: TextStyle(
+                                            color: colorTextMuted,
+                                          ),
+                                        ),
+                                      if (artist.activeSince != null)
+                                        Text(
+                                          'Active since ${artist.activeSince}',
+                                          style: const TextStyle(
+                                            color: colorTextMuted,
+                                            fontSize: fontSizeSm,
+                                          ),
+                                        ),
                                     ],
-                                  ],
+                                  ),
                                 ),
-                              ),
-                            ),
-                            if (artist.profileVisibility == 'private') ...[
-                              const SizedBox(width: spaceSm),
-                              const Icon(
-                                Icons.lock_outline,
-                                size: 18,
-                                color: colorTextMuted,
-                              ),
-                            ],
-                          ],
-                        ),
-                        const SizedBox(height: spaceXxs),
-                        Row(
-                          children: [
-                            Text(
-                              '@${artist.artistUsername}',
-                              style: const TextStyle(
-                                color: colorTextMuted,
-                                fontSize: fontSizeMd,
-                              ),
-                            ),
-                            const SizedBox(width: spaceMd),
-                            const Icon(
-                              Icons.headphones,
-                              size: 13,
-                              color: colorTextMuted,
-                            ),
-                            const SizedBox(width: spaceXxs),
-                            Text(
-                              '${artist.tunedInCount}',
-                              style: const TextStyle(
-                                color: colorTextMuted,
-                                fontSize: fontSizeSm,
-                              ),
-                            ),
-                          ],
-                        ),
-
-                        const SizedBox(height: spaceLg),
-
-                        // Tune In button (not shown on own page)
-                        if (isAuthenticated && !isSelf)
-                          _TuneInButton(
-                            isTunedIn: isTunedIn,
-                            onTap: () async {
-                              final tunedIn = await ref
-                                  .read(tuneInProvider.notifier)
-                                  .toggleTuneIn(artist.id);
-                              if (!context.mounted) return;
-                              if (tunedIn) {
-                                ref
-                                    .read(pendingArtistProvider.notifier)
-                                    .set(artist.artistUsername);
-                                context.go('/timeline');
-                              }
-                            },
-                          ),
-
-                        // Genres
-                        if (artist.genres.isNotEmpty || isSelf) ...[
-                          const SizedBox(height: spaceXl),
-                          if (isSelf)
-                            Row(
-                              children: [
-                                const Expanded(
+                              // Tagline
+                              if (artist.tagline != null)
+                                Padding(
+                                  padding: const EdgeInsets.only(
+                                    bottom: spaceSm,
+                                  ),
                                   child: Text(
-                                    'GENRES',
-                                    style: TextStyle(
-                                      color: colorTextMuted,
-                                      fontSize: fontSizeXs,
-                                      fontWeight: weightSemibold,
-                                      letterSpacing: 1,
-                                    ),
-                                  ),
-                                ),
-                                IconButton(
-                                  icon: const Icon(
-                                    Icons.edit_outlined,
-                                    size: 18,
-                                    color: colorTextMuted,
-                                  ),
-                                  onPressed: () =>
-                                      _showEditGenresSheet(context, artist),
-                                ),
-                              ],
-                            ),
-                          if (artist.genres.isNotEmpty)
-                            Wrap(
-                              spacing: spaceSm,
-                              runSpacing: spaceSm,
-                              children: artist.genres.map((ag) {
-                                return _Chip(
-                                  label: ag.genre.name,
-                                  color: colorTextSecondary,
-                                  bgColor: colorSurface2,
-                                  borderColor: colorBorder,
-                                );
-                              }).toList(),
-                            ),
-                        ],
-
-                        // About section
-                        if (isSelf ||
-                            artist.location != null ||
-                            artist.activeSince != null ||
-                            artist.tagline != null ||
-                            artist.bio != null) ...[
-                          const SizedBox(height: spaceXl),
-                          if (isSelf)
-                            Row(
-                              children: [
-                                const Expanded(
-                                  child: Text(
-                                    'ABOUT',
-                                    style: TextStyle(
-                                      color: colorTextMuted,
-                                      fontSize: fontSizeXs,
-                                      fontWeight: weightSemibold,
-                                      letterSpacing: 1,
-                                    ),
-                                  ),
-                                ),
-                                IconButton(
-                                  icon: const Icon(
-                                    Icons.edit_outlined,
-                                    size: 18,
-                                    color: colorTextMuted,
-                                  ),
-                                  onPressed: () =>
-                                      _showEditAboutSheet(context, artist),
-                                ),
-                              ],
-                            ),
-                          // Location + Active since
-                          if (artist.location != null ||
-                              artist.activeSince != null)
-                            Padding(
-                              padding: const EdgeInsets.only(bottom: spaceSm),
-                              child: Row(
-                                children: [
-                                  if (artist.location != null) ...[
-                                    const Icon(
-                                      Icons.place_outlined,
-                                      size: 14,
-                                      color: colorTextMuted,
-                                    ),
-                                    const SizedBox(width: spaceXxs),
-                                    Text(
-                                      artist.location!,
-                                      style: const TextStyle(
-                                        color: colorTextMuted,
-                                        fontSize: fontSizeSm,
-                                      ),
-                                    ),
-                                  ],
-                                  if (artist.location != null &&
-                                      artist.activeSince != null)
-                                    const Text(
-                                      ' · ',
-                                      style: TextStyle(color: colorTextMuted),
-                                    ),
-                                  if (artist.activeSince != null)
-                                    Text(
-                                      'Active since ${artist.activeSince}',
-                                      style: const TextStyle(
-                                        color: colorTextMuted,
-                                        fontSize: fontSizeSm,
-                                      ),
-                                    ),
-                                ],
-                              ),
-                            ),
-                          // Tagline
-                          if (artist.tagline != null)
-                            Padding(
-                              padding: const EdgeInsets.only(bottom: spaceSm),
-                              child: Text(
-                                artist.tagline!,
-                                style: const TextStyle(
-                                  color: colorTextSecondary,
-                                  fontSize: fontSizeMd,
-                                  fontStyle: FontStyle.italic,
-                                  height: 1.5,
-                                ),
-                              ),
-                            ),
-                          // Bio
-                          if (artist.bio != null)
-                            Text(
-                              artist.bio!,
-                              style: const TextStyle(
-                                color: colorTextSecondary,
-                                fontSize: fontSizeMd,
-                                height: 1.6,
-                              ),
-                            ),
-                        ],
-
-                        // Links section
-                        if (artist.links.isNotEmpty || isSelf) ...[
-                          const SizedBox(height: spaceXl),
-                          if (isSelf)
-                            Row(
-                              children: [
-                                const Expanded(
-                                  child: Text(
-                                    'LINKS',
-                                    style: TextStyle(
-                                      color: colorTextMuted,
-                                      fontSize: fontSizeXs,
-                                      fontWeight: weightSemibold,
-                                      letterSpacing: 1,
-                                    ),
-                                  ),
-                                ),
-                                IconButton(
-                                  icon: const Icon(
-                                    Icons.edit_outlined,
-                                    size: 18,
-                                    color: colorTextMuted,
-                                  ),
-                                  onPressed: () =>
-                                      _showEditLinksSheet(context, artist),
-                                ),
-                              ],
-                            ),
-                          if (artist.links.isNotEmpty)
-                            _LinksSection(links: artist.links),
-                        ],
-
-                        // Career milestones section
-                        if (artist.milestones.isNotEmpty || isSelf) ...[
-                          const SizedBox(height: spaceXl),
-                          Row(
-                            children: [
-                              const Expanded(
-                                child: Text(
-                                  'CAREER',
-                                  style: TextStyle(
-                                    color: colorTextMuted,
-                                    fontSize: fontSizeXs,
-                                    fontWeight: weightSemibold,
-                                    letterSpacing: 1,
-                                  ),
-                                ),
-                              ),
-                              if (isSelf)
-                                IconButton(
-                                  icon: const Icon(
-                                    Icons.edit_outlined,
-                                    size: 18,
-                                    color: colorInteractive,
-                                  ),
-                                  onPressed: () =>
-                                      _showEditMilestonesSheet(context, artist),
-                                  visualDensity: VisualDensity.compact,
-                                ),
-                            ],
-                          ),
-                          if (artist.milestones.isNotEmpty)
-                            _MilestonesSection(milestones: artist.milestones),
-                        ],
-
-                        // Tracks section
-                        if (artist.tracks.isNotEmpty || isSelf) ...[
-                          const SizedBox(height: spaceXl),
-                          Row(
-                            children: [
-                              const Expanded(
-                                child: Text(
-                                  'TRACKS',
-                                  style: TextStyle(
-                                    color: colorTextMuted,
-                                    fontSize: fontSizeXs,
-                                    fontWeight: weightSemibold,
-                                    letterSpacing: 1,
-                                  ),
-                                ),
-                              ),
-                              if (isSelf)
-                                IconButton(
-                                  icon: const Icon(
-                                    Icons.edit_outlined,
-                                    size: 18,
-                                    color: colorTextMuted,
-                                  ),
-                                  onPressed: () =>
-                                      _showEditTracksSheet(context, artist),
-                                ),
-                            ],
-                          ),
-                          const SizedBox(height: spaceXxs),
-                          const Text(
-                            "This artist's content streams",
-                            style: TextStyle(
-                              color: colorTextMuted,
-                              fontSize: fontSizeXs,
-                            ),
-                          ),
-                          const SizedBox(height: spaceMd),
-                          Wrap(
-                            spacing: spaceSm,
-                            runSpacing: spaceSm,
-                            children: artist.tracks.map((track) {
-                              return _Chip(
-                                label: track.name,
-                                color: track.displayColor,
-                                bgColor: track.displayColor.withValues(
-                                  alpha: 0.1,
-                                ),
-                                borderColor: track.displayColor.withValues(
-                                  alpha: 0.3,
-                                ),
-                                dot: true,
-                              );
-                            }).toList(),
-                          ),
-                        ],
-
-                        // Recent Posts section
-                        if (state.recentPosts.isNotEmpty) ...[
-                          const SizedBox(height: spaceXl),
-                          const Text(
-                            'RECENT POSTS',
-                            style: TextStyle(
-                              color: colorTextMuted,
-                              fontSize: fontSizeXs,
-                              fontWeight: weightSemibold,
-                              letterSpacing: 1,
-                            ),
-                          ),
-                          const SizedBox(height: spaceMd),
-                          const SizedBox(height: spaceSm),
-                          Wrap(
-                            spacing: spaceSm,
-                            runSpacing: spaceSm,
-                            children: state.recentPosts
-                                .map(
-                                  (p) => SizedBox(
-                                    width:
-                                        (MediaQuery.of(context).size.width -
-                                            spaceXl * 2 -
-                                            spaceSm) /
-                                        2,
-                                    child: _RecentPostCard(
-                                      post: p,
-                                      onTap: () =>
-                                          showPostDetailSheet(context, p),
-                                    ),
-                                  ),
-                                )
-                                .toList(),
-                          ),
-                        ],
-
-                        // Unassigned posts link (own view only)
-                        if (isSelf && unassignedCount > 0) ...[
-                          const SizedBox(height: spaceLg),
-                          InkWell(
-                            borderRadius: BorderRadius.circular(radiusMd),
-                            onTap: () => Navigator.of(context).push(
-                              MaterialPageRoute<void>(
-                                builder: (_) => UnassignedPostsScreen(
-                                  tracks: artist.tracks,
-                                ),
-                              ),
-                            ),
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: spaceMd,
-                                vertical: spaceSm,
-                              ),
-                              decoration: BoxDecoration(
-                                color: colorSurface1,
-                                borderRadius: BorderRadius.circular(radiusMd),
-                                border: Border.all(color: colorBorder),
-                              ),
-                              child: Row(
-                                children: [
-                                  const Icon(
-                                    Icons.inventory_2_outlined,
-                                    size: 16,
-                                    color: colorTextMuted,
-                                  ),
-                                  const SizedBox(width: spaceSm),
-                                  Text(
-                                    'Unassigned posts',
+                                    artist.tagline!,
                                     style: const TextStyle(
                                       color: colorTextSecondary,
-                                      fontSize: fontSizeSm,
+                                      fontSize: fontSizeMd,
+                                      fontStyle: FontStyle.italic,
+                                      height: 1.5,
                                     ),
                                   ),
-                                  const Spacer(),
-                                  Container(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: spaceSm,
-                                      vertical: spaceXxs,
-                                    ),
-                                    decoration: BoxDecoration(
-                                      color: colorAccentGold.withValues(
-                                        alpha: 0.15,
+                                ),
+                              // Bio
+                              if (artist.bio != null)
+                                Text(
+                                  artist.bio!,
+                                  style: const TextStyle(
+                                    color: colorTextSecondary,
+                                    fontSize: fontSizeMd,
+                                    height: 1.6,
+                                  ),
+                                ),
+                            ],
+
+                            // Links section
+                            if (artist.links.isNotEmpty || isSelf) ...[
+                              const SizedBox(height: spaceXl),
+                              if (isSelf)
+                                Row(
+                                  children: [
+                                    const Expanded(
+                                      child: Text(
+                                        'LINKS',
+                                        style: TextStyle(
+                                          color: colorTextMuted,
+                                          fontSize: fontSizeXs,
+                                          fontWeight: weightSemibold,
+                                          letterSpacing: 1,
+                                        ),
                                       ),
-                                      borderRadius: BorderRadius.circular(
-                                        radiusSm,
-                                      ),
                                     ),
+                                    IconButton(
+                                      icon: const Icon(
+                                        Icons.edit_outlined,
+                                        size: 18,
+                                        color: colorTextMuted,
+                                      ),
+                                      onPressed: () =>
+                                          _showEditLinksSheet(context, artist),
+                                    ),
+                                  ],
+                                ),
+                              if (artist.links.isNotEmpty)
+                                _LinksSection(links: artist.links),
+                            ],
+
+                            // Career milestones section
+                            if (artist.milestones.isNotEmpty || isSelf) ...[
+                              const SizedBox(height: spaceXl),
+                              Row(
+                                children: [
+                                  const Expanded(
                                     child: Text(
-                                      '$unassignedCount',
-                                      style: const TextStyle(
-                                        color: colorAccentGold,
+                                      'CAREER',
+                                      style: TextStyle(
+                                        color: colorTextMuted,
                                         fontSize: fontSizeXs,
                                         fontWeight: weightSemibold,
+                                        letterSpacing: 1,
                                       ),
                                     ),
                                   ),
-                                  const SizedBox(width: spaceXs),
-                                  const Icon(
-                                    Icons.chevron_right,
-                                    size: 18,
-                                    color: colorInteractiveMuted,
-                                  ),
+                                  if (isSelf)
+                                    IconButton(
+                                      icon: const Icon(
+                                        Icons.edit_outlined,
+                                        size: 18,
+                                        color: colorInteractive,
+                                      ),
+                                      onPressed: () => _showEditMilestonesSheet(
+                                        context,
+                                        artist,
+                                      ),
+                                      visualDensity: VisualDensity.compact,
+                                    ),
                                 ],
                               ),
-                            ),
-                          ),
-                        ],
+                              if (artist.milestones.isNotEmpty)
+                                _MilestonesSection(
+                                  milestones: artist.milestones,
+                                ),
+                            ],
 
-                        // View full timeline link
-                        const SizedBox(height: spaceXl),
-                        const Divider(color: colorBorder),
-                        const SizedBox(height: spaceMd),
-                        TextButton.icon(
-                          onPressed: () =>
-                              context.push('/@${artist.artistUsername}'),
-                          icon: const Icon(Icons.grid_view, size: 16),
-                          label: const Text('View full timeline'),
-                          style: TextButton.styleFrom(
-                            foregroundColor: colorInteractive,
-                          ),
+                            // Tracks section
+                            if (artist.tracks.isNotEmpty || isSelf) ...[
+                              const SizedBox(height: spaceXl),
+                              Row(
+                                children: [
+                                  const Expanded(
+                                    child: Text(
+                                      'TRACKS',
+                                      style: TextStyle(
+                                        color: colorTextMuted,
+                                        fontSize: fontSizeXs,
+                                        fontWeight: weightSemibold,
+                                        letterSpacing: 1,
+                                      ),
+                                    ),
+                                  ),
+                                  if (isSelf)
+                                    IconButton(
+                                      icon: const Icon(
+                                        Icons.edit_outlined,
+                                        size: 18,
+                                        color: colorTextMuted,
+                                      ),
+                                      onPressed: () =>
+                                          _showEditTracksSheet(context, artist),
+                                    ),
+                                ],
+                              ),
+                              const SizedBox(height: spaceXxs),
+                              const Text(
+                                "This artist's content streams",
+                                style: TextStyle(
+                                  color: colorTextMuted,
+                                  fontSize: fontSizeXs,
+                                ),
+                              ),
+                              const SizedBox(height: spaceMd),
+                              Wrap(
+                                spacing: spaceSm,
+                                runSpacing: spaceSm,
+                                children: artist.tracks.map((track) {
+                                  return _Chip(
+                                    label: track.name,
+                                    color: track.displayColor,
+                                    bgColor: track.displayColor.withValues(
+                                      alpha: 0.1,
+                                    ),
+                                    borderColor: track.displayColor.withValues(
+                                      alpha: 0.3,
+                                    ),
+                                    dot: true,
+                                  );
+                                }).toList(),
+                              ),
+                            ],
+
+                            // Recent Posts section
+                            if (state.recentPosts.isNotEmpty) ...[
+                              const SizedBox(height: spaceXl),
+                              const Text(
+                                'RECENT POSTS',
+                                style: TextStyle(
+                                  color: colorTextMuted,
+                                  fontSize: fontSizeXs,
+                                  fontWeight: weightSemibold,
+                                  letterSpacing: 1,
+                                ),
+                              ),
+                              const SizedBox(height: spaceMd),
+                              const SizedBox(height: spaceSm),
+                              Wrap(
+                                spacing: spaceSm,
+                                runSpacing: spaceSm,
+                                children: state.recentPosts
+                                    .map(
+                                      (p) => SizedBox(
+                                        width:
+                                            (MediaQuery.of(context).size.width -
+                                                spaceXl * 2 -
+                                                spaceSm) /
+                                            2,
+                                        child: _RecentPostCard(
+                                          post: p,
+                                          onTap: () =>
+                                              showPostDetailSheet(context, p),
+                                        ),
+                                      ),
+                                    )
+                                    .toList(),
+                              ),
+                            ],
+
+                            // Unassigned posts link (own view only)
+                            if (isSelf && unassignedCount > 0) ...[
+                              const SizedBox(height: spaceLg),
+                              InkWell(
+                                borderRadius: BorderRadius.circular(radiusMd),
+                                onTap: () => Navigator.of(context).push(
+                                  MaterialPageRoute<void>(
+                                    builder: (_) => UnassignedPostsScreen(
+                                      tracks: artist.tracks,
+                                    ),
+                                  ),
+                                ),
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: spaceMd,
+                                    vertical: spaceSm,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: colorSurface1,
+                                    borderRadius: BorderRadius.circular(
+                                      radiusMd,
+                                    ),
+                                    border: Border.all(color: colorBorder),
+                                  ),
+                                  child: Row(
+                                    children: [
+                                      const Icon(
+                                        Icons.inventory_2_outlined,
+                                        size: 16,
+                                        color: colorTextMuted,
+                                      ),
+                                      const SizedBox(width: spaceSm),
+                                      Text(
+                                        'Unassigned posts',
+                                        style: const TextStyle(
+                                          color: colorTextSecondary,
+                                          fontSize: fontSizeSm,
+                                        ),
+                                      ),
+                                      const Spacer(),
+                                      Container(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: spaceSm,
+                                          vertical: spaceXxs,
+                                        ),
+                                        decoration: BoxDecoration(
+                                          color: colorAccentGold.withValues(
+                                            alpha: 0.15,
+                                          ),
+                                          borderRadius: BorderRadius.circular(
+                                            radiusSm,
+                                          ),
+                                        ),
+                                        child: Text(
+                                          '$unassignedCount',
+                                          style: const TextStyle(
+                                            color: colorAccentGold,
+                                            fontSize: fontSizeXs,
+                                            fontWeight: weightSemibold,
+                                          ),
+                                        ),
+                                      ),
+                                      const SizedBox(width: spaceXs),
+                                      const Icon(
+                                        Icons.chevron_right,
+                                        size: 18,
+                                        color: colorInteractiveMuted,
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ],
+
+                            // View full timeline link
+                            const SizedBox(height: spaceXl),
+                            const Divider(color: colorBorder),
+                            const SizedBox(height: spaceMd),
+                            TextButton.icon(
+                              onPressed: () =>
+                                  context.push('/@${artist.artistUsername}'),
+                              icon: const Icon(Icons.grid_view, size: 16),
+                              label: const Text('View full timeline'),
+                              style: TextButton.styleFrom(
+                                foregroundColor: colorInteractive,
+                              ),
+                            ),
+                            const SizedBox(height: spaceXl),
+                          ],
                         ),
-                        const SizedBox(height: spaceXl),
-                      ],
+                      ),
                     ),
                   ),
                 ),

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -23,7 +23,11 @@ import '../../providers/media_upload_provider.dart';
 import '../../widgets/timeline/seed_art_painter.dart';
 
 class CreatePostScreen extends ConsumerStatefulWidget {
-  const CreatePostScreen({super.key});
+  /// Optional callback invoked after successful post creation (e.g. from Dialog).
+  /// When null, defaults to `context.go('/timeline')`.
+  final VoidCallback? onSuccess;
+
+  const CreatePostScreen({super.key, this.onSuccess});
 
   @override
   ConsumerState<CreatePostScreen> createState() => _CreatePostScreenState();
@@ -141,7 +145,13 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
       // dispose() also calls reset(), but autoDispose + ref.read in dispose
       // can race — explicit reset here ensures clean state for next visit.
       ref.read(createPostProvider.notifier).reset();
-      if (mounted) context.go('/timeline');
+      if (mounted) {
+        if (widget.onSuccess != null) {
+          widget.onSuccess!();
+        } else {
+          context.go('/timeline');
+        }
+      }
     }
   }
 

--- a/frontend/lib/screens/discover/discover_screen.dart
+++ b/frontend/lib/screens/discover/discover_screen.dart
@@ -169,27 +169,34 @@ class _DiscoverScreenState extends ConsumerState<DiscoverScreen> {
                   ),
                 ),
               )
-            // Artist grid
+            // Artist grid (responsive columns: 2 mobile / 3 tablet / 4 desktop)
             else
-              SliverPadding(
-                padding: const EdgeInsets.all(spaceLg),
-                sliver: SliverGrid(
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    mainAxisSpacing: spaceMd,
-                    crossAxisSpacing: spaceMd,
-                    childAspectRatio: 0.72,
-                  ),
-                  delegate: SliverChildBuilderDelegate((context, index) {
-                    final artist = state.artists[index];
-                    return _ArtistCard(
-                      artist: artist,
-                      onTap: () {
-                        context.push('/artist/${artist.artistUsername}');
-                      },
-                    );
-                  }, childCount: state.artists.length),
-                ),
+              SliverLayoutBuilder(
+                builder: (context, constraints) {
+                  final columns = responsiveGridColumns(
+                    constraints.crossAxisExtent,
+                  );
+                  return SliverPadding(
+                    padding: const EdgeInsets.all(spaceLg),
+                    sliver: SliverGrid(
+                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: columns,
+                        mainAxisSpacing: spaceMd,
+                        crossAxisSpacing: spaceMd,
+                        childAspectRatio: 0.72,
+                      ),
+                      delegate: SliverChildBuilderDelegate((context, index) {
+                        final artist = state.artists[index];
+                        return _ArtistCard(
+                          artist: artist,
+                          onTap: () {
+                            context.push('/artist/${artist.artistUsername}');
+                          },
+                        );
+                      }, childCount: state.artists.length),
+                    ),
+                  );
+                },
               ),
           ],
         ),

--- a/frontend/lib/screens/profile/profile_screen.dart
+++ b/frontend/lib/screens/profile/profile_screen.dart
@@ -68,315 +68,325 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           ),
         ],
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(spaceXl),
-        children: [
-          // User info
-          Row(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: maxContentWidth),
+          child: ListView(
+            padding: const EdgeInsets.all(spaceXl),
             children: [
-              AvatarImage(
-                imageUrl: user.avatarUrl,
-                seed: user.username,
-                size: 64,
-              ),
-              const SizedBox(width: spaceLg),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(user.displayName ?? user.username, style: textHeading),
-                    const SizedBox(height: spaceXxs),
-                    Text(
-                      '@${user.username}',
-                      style: textCaption.copyWith(color: colorTextMuted),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-
-          // Bio
-          if (user.bio != null && user.bio!.isNotEmpty) ...[
-            const SizedBox(height: spaceLg),
-            Text(
-              user.bio!,
-              style: textBody.copyWith(color: colorTextSecondary),
-            ),
-          ],
-
-          // Meta: Joined + Tuned In
-          const SizedBox(height: spaceMd),
-          Wrap(
-            spacing: spaceLg,
-            children: [
-              Text(
-                'Joined ${_formatJoinDate(user.createdAt)}',
-                style: textCaption.copyWith(color: colorTextMuted),
-              ),
-              if (tuneInState.tunedInArtists.isNotEmpty)
-                Text(
-                  '${tuneInState.tunedInArtists.length} Tuned In',
-                  style: textCaption.copyWith(color: colorTextMuted),
-                ),
-            ],
-          ),
-          const SizedBox(height: spaceXxl),
-
-          // Artist section
-          if (artist != null) ...[
-            // Registered artist info
-            Container(
-              padding: const EdgeInsets.all(spaceLg),
-              decoration: BoxDecoration(
-                color: colorSurface1,
-                borderRadius: BorderRadius.circular(radiusLg),
-                border: Border.all(color: colorBorder),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+              // User info
+              Row(
                 children: [
-                  Row(
-                    children: [
-                      const Icon(
-                        Icons.auto_awesome,
-                        size: 16,
-                        color: colorAccentGold,
-                      ),
-                      const SizedBox(width: spaceSm),
-                      Text(
-                        'Artist',
-                        style: textLabel.copyWith(color: colorAccentGold),
-                      ),
-                    ],
+                  AvatarImage(
+                    imageUrl: user.avatarUrl,
+                    seed: user.username,
+                    size: 64,
                   ),
-                  const SizedBox(height: spaceMd),
-                  Text(
-                    artist.displayName ?? artist.artistUsername,
-                    style: textHeading,
-                  ),
-                  const SizedBox(height: spaceXxs),
-                  Text(
-                    '@${artist.artistUsername}',
-                    style: textCaption.copyWith(color: colorTextMuted),
-                  ),
-                  if (artist.tracks.isNotEmpty) ...[
-                    const SizedBox(height: spaceMd),
-                    Text(
-                      '${artist.tracks.length} track${artist.tracks.length == 1 ? '' : 's'}',
-                      style: textCaption.copyWith(color: colorTextSecondary),
-                    ),
-                  ],
-                  // Artist visibility toggle
-                  const SizedBox(height: spaceMd),
-                  Row(
-                    children: [
-                      Icon(
-                        artist.profileVisibility == 'private'
-                            ? Icons.lock_outline
-                            : Icons.public,
-                        size: 14,
-                        color: colorTextMuted,
-                      ),
-                      const SizedBox(width: spaceXs),
-                      Text(
-                        artist.profileVisibility == 'private'
-                            ? 'Private'
-                            : 'Public',
-                        style: textCaption.copyWith(color: colorTextMuted),
-                      ),
-                      const Spacer(),
-                      Switch(
-                        value: artist.profileVisibility == 'public',
-                        activeColor: colorAccentGold,
-                        onChanged: (isPublic) async {
-                          final v = isPublic ? 'public' : 'private';
-                          await ref
-                              .read(editArtistProvider.notifier)
-                              .updateArtist(profileVisibility: v);
-                          ref.read(discoverProvider.notifier).loadInitial();
-                        },
-                      ),
-                    ],
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: spaceSm),
-                    child: Text(
-                      artist.profileVisibility == 'private'
-                          ? 'Your artist page is hidden from Discover and search. Only existing fans and direct links can access it.'
-                          : 'Your artist page is visible in Discover and search. Anyone can view your profile and Tune In.',
-                      style: textCaption.copyWith(
-                        color: colorTextMuted,
-                        fontStyle: FontStyle.italic,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: spaceSm),
-                  SizedBox(
-                    width: double.infinity,
-                    child: OutlinedButton.icon(
-                      onPressed: () =>
-                          context.push('/artist/${artist.artistUsername}'),
-                      icon: const Icon(Icons.person, size: 16),
-                      label: const Text('View Artist Page'),
-                      style: OutlinedButton.styleFrom(
-                        foregroundColor: colorAccentGold,
-                        side: BorderSide(
-                          color: colorAccentGold.withValues(alpha: 0.3),
+                  const SizedBox(width: spaceLg),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          user.displayName ?? user.username,
+                          style: textHeading,
                         ),
-                      ),
+                        const SizedBox(height: spaceXxs),
+                        Text(
+                          '@${user.username}',
+                          style: textCaption.copyWith(color: colorTextMuted),
+                        ),
+                      ],
                     ),
                   ),
                 ],
               ),
-            ),
-          ] else ...[
-            // Become an artist CTA
-            GestureDetector(
-              onTap: () => _showRegisterSheet(context),
-              child: Container(
-                padding: const EdgeInsets.all(spaceLg),
-                decoration: BoxDecoration(
-                  color: colorSurface1,
-                  borderRadius: BorderRadius.circular(radiusLg),
-                  border: Border.all(
-                    color: colorAccentGold.withValues(alpha: 0.3),
-                  ),
+
+              // Bio
+              if (user.bio != null && user.bio!.isNotEmpty) ...[
+                const SizedBox(height: spaceLg),
+                Text(
+                  user.bio!,
+                  style: textBody.copyWith(color: colorTextSecondary),
                 ),
-                child: Row(
-                  children: [
-                    Container(
-                      width: 44,
-                      height: 44,
-                      decoration: BoxDecoration(
-                        color: colorAccentGold.withValues(alpha: 0.1),
-                        borderRadius: BorderRadius.circular(radiusMd),
-                      ),
-                      child: const Icon(
-                        Icons.auto_awesome,
-                        color: colorAccentGold,
-                      ),
+              ],
+
+              // Meta: Joined + Tuned In
+              const SizedBox(height: spaceMd),
+              Wrap(
+                spacing: spaceLg,
+                children: [
+                  Text(
+                    'Joined ${_formatJoinDate(user.createdAt)}',
+                    style: textCaption.copyWith(color: colorTextMuted),
+                  ),
+                  if (tuneInState.tunedInArtists.isNotEmpty)
+                    Text(
+                      '${tuneInState.tunedInArtists.length} Tuned In',
+                      style: textCaption.copyWith(color: colorTextMuted),
                     ),
-                    const SizedBox(width: spaceLg),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+                ],
+              ),
+              const SizedBox(height: spaceXxl),
+
+              // Artist section
+              if (artist != null) ...[
+                // Registered artist info
+                Container(
+                  padding: const EdgeInsets.all(spaceLg),
+                  decoration: BoxDecoration(
+                    color: colorSurface1,
+                    borderRadius: BorderRadius.circular(radiusLg),
+                    border: Border.all(color: colorBorder),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
                         children: [
-                          Text('Become an Artist', style: textHeading),
-                          const SizedBox(height: spaceXxs),
+                          const Icon(
+                            Icons.auto_awesome,
+                            size: 16,
+                            color: colorAccentGold,
+                          ),
+                          const SizedBox(width: spaceSm),
                           Text(
-                            'Start sharing your creative journey',
-                            style: textCaption.copyWith(
-                              color: colorTextSecondary,
-                            ),
+                            'Artist',
+                            style: textLabel.copyWith(color: colorAccentGold),
                           ),
                         ],
                       ),
+                      const SizedBox(height: spaceMd),
+                      Text(
+                        artist.displayName ?? artist.artistUsername,
+                        style: textHeading,
+                      ),
+                      const SizedBox(height: spaceXxs),
+                      Text(
+                        '@${artist.artistUsername}',
+                        style: textCaption.copyWith(color: colorTextMuted),
+                      ),
+                      if (artist.tracks.isNotEmpty) ...[
+                        const SizedBox(height: spaceMd),
+                        Text(
+                          '${artist.tracks.length} track${artist.tracks.length == 1 ? '' : 's'}',
+                          style: textCaption.copyWith(
+                            color: colorTextSecondary,
+                          ),
+                        ),
+                      ],
+                      // Artist visibility toggle
+                      const SizedBox(height: spaceMd),
+                      Row(
+                        children: [
+                          Icon(
+                            artist.profileVisibility == 'private'
+                                ? Icons.lock_outline
+                                : Icons.public,
+                            size: 14,
+                            color: colorTextMuted,
+                          ),
+                          const SizedBox(width: spaceXs),
+                          Text(
+                            artist.profileVisibility == 'private'
+                                ? 'Private'
+                                : 'Public',
+                            style: textCaption.copyWith(color: colorTextMuted),
+                          ),
+                          const Spacer(),
+                          Switch(
+                            value: artist.profileVisibility == 'public',
+                            activeColor: colorAccentGold,
+                            onChanged: (isPublic) async {
+                              final v = isPublic ? 'public' : 'private';
+                              await ref
+                                  .read(editArtistProvider.notifier)
+                                  .updateArtist(profileVisibility: v);
+                              ref.read(discoverProvider.notifier).loadInitial();
+                            },
+                          ),
+                        ],
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: spaceSm),
+                        child: Text(
+                          artist.profileVisibility == 'private'
+                              ? 'Your artist page is hidden from Discover and search. Only existing fans and direct links can access it.'
+                              : 'Your artist page is visible in Discover and search. Anyone can view your profile and Tune In.',
+                          style: textCaption.copyWith(
+                            color: colorTextMuted,
+                            fontStyle: FontStyle.italic,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: spaceSm),
+                      SizedBox(
+                        width: double.infinity,
+                        child: OutlinedButton.icon(
+                          onPressed: () =>
+                              context.push('/artist/${artist.artistUsername}'),
+                          icon: const Icon(Icons.person, size: 16),
+                          label: const Text('View Artist Page'),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: colorAccentGold,
+                            side: BorderSide(
+                              color: colorAccentGold.withValues(alpha: 0.3),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ] else ...[
+                // Become an artist CTA
+                GestureDetector(
+                  onTap: () => _showRegisterSheet(context),
+                  child: Container(
+                    padding: const EdgeInsets.all(spaceLg),
+                    decoration: BoxDecoration(
+                      color: colorSurface1,
+                      borderRadius: BorderRadius.circular(radiusLg),
+                      border: Border.all(
+                        color: colorAccentGold.withValues(alpha: 0.3),
+                      ),
                     ),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 44,
+                          height: 44,
+                          decoration: BoxDecoration(
+                            color: colorAccentGold.withValues(alpha: 0.1),
+                            borderRadius: BorderRadius.circular(radiusMd),
+                          ),
+                          child: const Icon(
+                            Icons.auto_awesome,
+                            color: colorAccentGold,
+                          ),
+                        ),
+                        const SizedBox(width: spaceLg),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text('Become an Artist', style: textHeading),
+                              const SizedBox(height: spaceXxs),
+                              Text(
+                                'Start sharing your creative journey',
+                                style: textCaption.copyWith(
+                                  color: colorTextSecondary,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const Icon(
+                          Icons.chevron_right,
+                          color: colorInteractiveMuted,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+
+              // Guardian section: child accounts (not shown for child accounts)
+              if (!isChild) ...[
+                const SizedBox(height: spaceXxl),
+                Row(
+                  children: [
                     const Icon(
-                      Icons.chevron_right,
-                      color: colorInteractiveMuted,
+                      Icons.people_outline,
+                      size: 18,
+                      color: colorTextMuted,
+                    ),
+                    const SizedBox(width: spaceSm),
+                    Text(
+                      'Child Accounts',
+                      style: textHeading.copyWith(fontSize: 16),
                     ),
                   ],
                 ),
-              ),
-            ),
-          ],
-
-          // Guardian section: child accounts (not shown for child accounts)
-          if (!isChild) ...[
-            const SizedBox(height: spaceXxl),
-            Row(
-              children: [
-                const Icon(
-                  Icons.people_outline,
-                  size: 18,
-                  color: colorTextMuted,
-                ),
-                const SizedBox(width: spaceSm),
-                Text(
-                  'Child Accounts',
-                  style: textHeading.copyWith(fontSize: 16),
-                ),
+                const SizedBox(height: spaceMd),
+                if (guardianState.isLoading)
+                  const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(spaceLg),
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  )
+                else ...[
+                  // Child cards
+                  ...guardianState.children.map(
+                    (child) => Padding(
+                      padding: const EdgeInsets.only(bottom: spaceSm),
+                      child: _buildChildCard(child),
+                    ),
+                  ),
+                  // Add child button
+                  OutlinedButton.icon(
+                    onPressed: () => _showCreateChildSheet(context),
+                    icon: const Icon(Icons.add, size: 16),
+                    label: const Text('Add Child Account'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: colorTextSecondary,
+                      side: const BorderSide(color: colorBorder),
+                    ),
+                  ),
+                ],
               ],
-            ),
-            const SizedBox(height: spaceMd),
-            if (guardianState.isLoading)
-              const Center(
-                child: Padding(
-                  padding: EdgeInsets.all(spaceLg),
-                  child: CircularProgressIndicator(strokeWidth: 2),
+
+              const SizedBox(height: spaceXxl),
+
+              // Child mode: show "Return to My Account" prominently above Logout
+              if (isChild) ...[
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _switchBackToGuardian,
+                    icon: const Icon(Icons.swap_horiz, size: 16),
+                    label: const Text('Return to My Account'),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: colorAccentGold,
+                      foregroundColor: colorSurface0,
+                      padding: const EdgeInsets.symmetric(vertical: spaceMd),
+                    ),
+                  ),
                 ),
-              )
-            else ...[
-              // Child cards
-              ...guardianState.children.map(
-                (child) => Padding(
-                  padding: const EdgeInsets.only(bottom: spaceSm),
-                  child: _buildChildCard(child),
+                const SizedBox(height: spaceMd),
+              ],
+
+              // About
+              TextButton(
+                onPressed: () => context.push('/about'),
+                child: Text(
+                  'About Gleisner',
+                  style: textCaption.copyWith(color: colorTextMuted),
                 ),
               ),
-              // Add child button
-              OutlinedButton.icon(
-                onPressed: () => _showCreateChildSheet(context),
-                icon: const Icon(Icons.add, size: 16),
-                label: const Text('Add Child Account'),
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: colorTextSecondary,
-                  side: const BorderSide(color: colorBorder),
-                ),
+              const SizedBox(height: spaceSm),
+
+              // Logout
+              OutlinedButton(
+                onPressed: () async {
+                  await ref.read(authProvider.notifier).logout();
+                  ref.invalidate(graphqlClientProvider);
+                  ref.invalidate(timelineProvider);
+                  ref.invalidate(myArtistProvider);
+                  ref.invalidate(tuneInProvider);
+                  ref.invalidate(discoverProvider);
+                  ref.invalidate(unassignedPostsProvider);
+                  ref.invalidate(analyticsProvider);
+                  ref.invalidate(guardianProvider);
+                  await ref.read(tutorialProvider.notifier).reset();
+                  ref.invalidate(tutorialProvider);
+                },
+                child: const Text('Logout'),
               ),
             ],
-          ],
-
-          const SizedBox(height: spaceXxl),
-
-          // Child mode: show "Return to My Account" prominently above Logout
-          if (isChild) ...[
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton.icon(
-                onPressed: _switchBackToGuardian,
-                icon: const Icon(Icons.swap_horiz, size: 16),
-                label: const Text('Return to My Account'),
-                style: FilledButton.styleFrom(
-                  backgroundColor: colorAccentGold,
-                  foregroundColor: colorSurface0,
-                  padding: const EdgeInsets.symmetric(vertical: spaceMd),
-                ),
-              ),
-            ),
-            const SizedBox(height: spaceMd),
-          ],
-
-          // About
-          TextButton(
-            onPressed: () => context.push('/about'),
-            child: Text(
-              'About Gleisner',
-              style: textCaption.copyWith(color: colorTextMuted),
-            ),
           ),
-          const SizedBox(height: spaceSm),
-
-          // Logout
-          OutlinedButton(
-            onPressed: () async {
-              await ref.read(authProvider.notifier).logout();
-              ref.invalidate(graphqlClientProvider);
-              ref.invalidate(timelineProvider);
-              ref.invalidate(myArtistProvider);
-              ref.invalidate(tuneInProvider);
-              ref.invalidate(discoverProvider);
-              ref.invalidate(unassignedPostsProvider);
-              ref.invalidate(analyticsProvider);
-              ref.invalidate(guardianProvider);
-              await ref.read(tutorialProvider.notifier).reset();
-              ref.invalidate(tutorialProvider);
-            },
-            child: const Text('Logout'),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -11,6 +11,7 @@ import '../../providers/pending_artist_provider.dart';
 import '../../providers/timeline_provider.dart';
 import '../../providers/tune_in_provider.dart';
 import '../../utils/constellation_layout.dart';
+import '../../utils/date_format.dart';
 import '../../widgets/timeline/avatar_rail.dart';
 import '../../widgets/timeline/constellation_painter.dart';
 import '../../widgets/timeline/milestone_detail_sheet.dart';
@@ -603,7 +604,7 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                                         : 'Constellation · ${timeline.constellationPostIds!.length} posts',
                                     style: const TextStyle(
                                       color: colorTextSecondary,
-                                      fontSize: 13,
+                                      fontSize: fontSizeSm,
                                     ),
                                     maxLines: 1,
                                     overflow: TextOverflow.ellipsis,
@@ -960,7 +961,7 @@ class _DateLabel extends StatelessWidget {
             day.date.day.toString(),
             style: TextStyle(
               color: dayColor,
-              fontSize: 13,
+              fontSize: fontSizeSm,
               fontWeight: FontWeight.w700,
               height: 1.1,
             ),
@@ -1389,7 +1390,7 @@ class _DesktopDetailPanel extends StatelessWidget {
                       ),
                     ),
                   Text(
-                    '${post.mediaType.name} · ${_formatDate(post.createdAt)}',
+                    '${post.mediaType.name} · ${formatDate(post.createdAt)}',
                     style: const TextStyle(
                       color: colorTextMuted,
                       fontSize: fontSizeSm,
@@ -1432,9 +1433,5 @@ class _DesktopDetailPanel extends StatelessWidget {
         ],
       ),
     );
-  }
-
-  static String _formatDate(DateTime date) {
-    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
   }
 }

--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import '../../models/artist.dart';
+import '../../models/post.dart';
 import '../../models/timeline_item.dart';
 import '../../models/track.dart';
 import '../../providers/my_artist_provider.dart';
@@ -20,6 +21,7 @@ import '../../providers/tutorial_provider.dart';
 import '../../theme/gleisner_assets.dart';
 import '../../theme/gleisner_tokens.dart';
 import '../../widgets/timeline/post_detail_sheet.dart';
+import '../create_post/create_post_screen.dart';
 import '../../widgets/tutorial/tutorial_spotlight.dart';
 
 class TimelineScreen extends ConsumerStatefulWidget {
@@ -37,6 +39,9 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
   String? _focusedPostId;
   final _fabLayerLink = LayerLink();
   bool _showFirstPostTutorial = false;
+
+  /// Post shown in the desktop side panel (null = panel closed).
+  String? _sidePanelPostId;
 
   // Synapse dot animation — continuous cycle through all connections
   late final AnimationController _dotController;
@@ -346,231 +351,311 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                             .read(tutorialProvider.notifier)
                             .markSeen(TutorialIds.firstPost);
                       }
-                      context.go('/create-post');
+                      final screenWidth = MediaQuery.of(context).size.width;
+                      if (isDesktop(screenWidth)) {
+                        showDialog(
+                          context: context,
+                          builder: (dialogContext) => Dialog(
+                            backgroundColor: colorSurface0,
+                            insetPadding: const EdgeInsets.symmetric(
+                              horizontal: 80,
+                              vertical: 40,
+                            ),
+                            child: ClipRRect(
+                              borderRadius: const BorderRadius.all(
+                                Radius.circular(radiusLg),
+                              ),
+                              child: CreatePostScreen(
+                                onSuccess: () {
+                                  Navigator.of(dialogContext).pop();
+                                  ref.read(timelineProvider.notifier).refresh();
+                                },
+                              ),
+                            ),
+                          ),
+                        );
+                      } else {
+                        context.go('/create-post');
+                      }
                     },
                   ),
                 )
               : null,
-          body: Column(
+          body: Row(
             children: [
-              if (timeline.artist != null && timeline.artist!.tracks.isNotEmpty)
-                _TrackSelector(
-                  tracks: timeline.artist!.tracks,
-                  selectedTrackIds: timeline.selectedTrackIds,
-                  allSelected: timeline.allSelected,
-                  onToggleTrack: (trackId) =>
-                      ref.read(timelineProvider.notifier).toggleTrack(trackId),
-                  onToggleAll: () =>
-                      ref.read(timelineProvider.notifier).toggleAll(),
-                ),
-              // Avatar rail — always visible (not inside scroll)
-              if (tuneIn.tunedInArtists.isNotEmpty ||
-                  selfArtistUsername != null)
-                AvatarRail(
-                  artists: tuneIn.tunedInArtists,
-                  selfArtistUsername: selfArtistUsername,
-                  selfAvatarUrl: myArtist?.avatarUrl,
-                  selfIsPrivate: myArtist?.isPrivate ?? false,
-                  selectedArtistUsername:
-                      _viewingArtistUsername ??
-                      (timeline.artist?.artistUsername),
-                  onSelectArtist: _switchToArtist,
-                  onSelectSelf: () {
-                    if (_ownArtistUsername != null) {
-                      _switchToArtist(_ownArtistUsername!);
-                    }
-                  },
-                ),
-              if (timeline.error != null)
-                Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Text(
-                    timeline.error!,
-                    style: TextStyle(color: theme.colorScheme.error),
-                  ),
-                ),
               Expanded(
-                child: timeline.isLoading && timeline.posts.isEmpty
-                    ? const Center(child: CircularProgressIndicator())
-                    : timeline.posts.isEmpty && !isOwn
-                    ? Center(
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Icon(
-                              Icons.headphones,
-                              size: 40,
-                              color: colorInteractiveMuted,
-                            ),
-                            const SizedBox(height: spaceMd),
-                            Text(
-                              'No posts from this artist yet',
-                              style: TextStyle(
-                                color: colorInteractive,
-                                fontSize: theme.textTheme.bodyLarge?.fontSize,
-                              ),
-                            ),
-                          ],
-                        ),
-                      )
-                    : timeline.posts.isEmpty
-                    ? Center(
+                child: Column(
+                  children: [
+                    if (timeline.artist != null &&
+                        timeline.artist!.tracks.isNotEmpty)
+                      _TrackSelector(
+                        tracks: timeline.artist!.tracks,
+                        selectedTrackIds: timeline.selectedTrackIds,
+                        allSelected: timeline.allSelected,
+                        onToggleTrack: (trackId) => ref
+                            .read(timelineProvider.notifier)
+                            .toggleTrack(trackId),
+                        onToggleAll: () =>
+                            ref.read(timelineProvider.notifier).toggleAll(),
+                      ),
+                    // Avatar rail — always visible (not inside scroll)
+                    if (tuneIn.tunedInArtists.isNotEmpty ||
+                        selfArtistUsername != null)
+                      AvatarRail(
+                        artists: tuneIn.tunedInArtists,
+                        selfArtistUsername: selfArtistUsername,
+                        selfAvatarUrl: myArtist?.avatarUrl,
+                        selfIsPrivate: myArtist?.isPrivate ?? false,
+                        selectedArtistUsername:
+                            _viewingArtistUsername ??
+                            (timeline.artist?.artistUsername),
+                        onSelectArtist: _switchToArtist,
+                        onSelectSelf: () {
+                          if (_ownArtistUsername != null) {
+                            _switchToArtist(_ownArtistUsername!);
+                          }
+                        },
+                      ),
+                    if (timeline.error != null)
+                      Padding(
+                        padding: const EdgeInsets.all(16),
                         child: Text(
-                          timeline.artist == null
-                              ? 'Discover artists and tune in to fill your timeline'
-                              : 'No posts yet',
-                          style: TextStyle(
-                            color: colorInteractive,
-                            fontSize: theme.textTheme.bodyLarge?.fontSize,
-                          ),
+                          timeline.error!,
+                          style: TextStyle(color: theme.colorScheme.error),
                         ),
-                      )
-                    : RefreshIndicator(
-                        onRefresh: () =>
-                            ref.read(timelineProvider.notifier).refresh(),
-                        child: LayoutBuilder(
-                          builder: (context, constraints) {
-                            final width = constraints.maxWidth;
-                            if (_lastWidth != width) {
-                              _lastWidth = width;
-                              WidgetsBinding.instance.addPostFrameCallback((_) {
-                                ref
-                                    .read(timelineProvider.notifier)
-                                    .computeLayout(width);
-                              });
-                            }
-
-                            final layout = timeline.layout;
-                            if (layout == null) {
-                              return const Center(
-                                child: CircularProgressIndicator(),
-                              );
-                            }
-
-                            return NotificationListener<ScrollNotification>(
-                              onNotification: (n) {
-                                setState(
-                                  () => _scrollOffset = n.metrics.pixels,
-                                );
-                                return false;
-                              },
-                              child: SingleChildScrollView(
-                                controller: _scrollController,
-                                physics: const AlwaysScrollableScrollPhysics(),
-                                child: Column(
-                                  children: [
-                                    GestureDetector(
-                                      onTap: () {
-                                        if (timeline.constellationPostIds !=
-                                            null) {
-                                          ref
-                                              .read(timelineProvider.notifier)
-                                              .clearConstellation();
-                                        } else if (_focusedPostId != null) {
-                                          setState(() => _focusedPostId = null);
-                                        }
-                                      },
-                                      child: SizedBox(
-                                        height: layout.totalHeight,
-                                        child: Stack(
-                                          children: [
-                                            // Background: spine + synapses + travelling dot
-                                            Positioned.fill(
-                                              child: AnimatedBuilder(
-                                                animation: _dotController,
-                                                builder: (context, _) => CustomPaint(
-                                                  painter: ConstellationPainter(
-                                                    layout: layout,
-                                                    constellationPostIds: timeline
-                                                        .constellationPostIds,
-                                                    animationValue:
-                                                        _dotController.value,
-                                                    scrollOffset: _scrollOffset,
-                                                    viewportHeight:
-                                                        constraints.maxHeight,
-                                                  ),
-                                                ),
-                                              ),
-                                            ),
-                                            // Day labels on the spine
-                                            // Find the one day closest above the midpoint
-                                            ..._buildDateLabels(
-                                              layout.days,
-                                              _scrollOffset,
-                                              constraints.maxHeight,
-                                            ),
-                                            // Nodes (focused node rendered last for z-order)
-                                            ..._buildNodes(
-                                              layout,
-                                              timeline.highlightPostId,
-                                              timeline.constellationPostIds,
-                                            ),
-                                          ],
-                                        ),
-                                      ),
+                      ),
+                    Expanded(
+                      child: timeline.isLoading && timeline.posts.isEmpty
+                          ? const Center(child: CircularProgressIndicator())
+                          : timeline.posts.isEmpty && !isOwn
+                          ? Center(
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  const Icon(
+                                    Icons.headphones,
+                                    size: 40,
+                                    color: colorInteractiveMuted,
+                                  ),
+                                  const SizedBox(height: spaceMd),
+                                  Text(
+                                    'No posts from this artist yet',
+                                    style: TextStyle(
+                                      color: colorInteractive,
+                                      fontSize:
+                                          theme.textTheme.bodyLarge?.fontSize,
                                     ),
-                                  ],
+                                  ),
+                                ],
+                              ),
+                            )
+                          : timeline.posts.isEmpty
+                          ? Center(
+                              child: Text(
+                                timeline.artist == null
+                                    ? 'Discover artists and tune in to fill your timeline'
+                                    : 'No posts yet',
+                                style: TextStyle(
+                                  color: colorInteractive,
+                                  fontSize: theme.textTheme.bodyLarge?.fontSize,
                                 ),
                               ),
-                            );
-                          },
-                        ),
-                      ),
-              ),
-              // Constellation highlight banner
-              if (timeline.constellationPostIds != null)
-                Builder(
-                  builder: (context) {
-                    final constellationName = timeline.posts
-                        .where(
-                          (p) =>
-                              timeline.constellationPostIds!.contains(p.id) &&
-                              p.constellation != null,
-                        )
-                        .map((p) => p.constellation!.name)
-                        .firstOrNull;
-                    return Container(
-                      color: colorSurface1,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 10,
-                      ),
-                      child: Row(
-                        children: [
-                          const Icon(
-                            Icons.auto_awesome,
-                            size: 16,
-                            color: colorInteractive,
-                          ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: Text(
-                              constellationName != null
-                                  ? '$constellationName · ${timeline.constellationPostIds!.length} posts'
-                                  : 'Constellation · ${timeline.constellationPostIds!.length} posts',
-                              style: const TextStyle(
-                                color: colorTextSecondary,
-                                fontSize: 13,
+                            )
+                          : RefreshIndicator(
+                              onRefresh: () =>
+                                  ref.read(timelineProvider.notifier).refresh(),
+                              child: LayoutBuilder(
+                                builder: (context, constraints) {
+                                  final width = constraints.maxWidth;
+                                  if (_lastWidth != width) {
+                                    _lastWidth = width;
+                                    WidgetsBinding.instance
+                                        .addPostFrameCallback((_) {
+                                          ref
+                                              .read(timelineProvider.notifier)
+                                              .computeLayout(width);
+                                        });
+                                  }
+
+                                  final layout = timeline.layout;
+                                  if (layout == null) {
+                                    return const Center(
+                                      child: CircularProgressIndicator(),
+                                    );
+                                  }
+
+                                  return NotificationListener<
+                                    ScrollNotification
+                                  >(
+                                    onNotification: (n) {
+                                      setState(
+                                        () => _scrollOffset = n.metrics.pixels,
+                                      );
+                                      return false;
+                                    },
+                                    child: SingleChildScrollView(
+                                      controller: _scrollController,
+                                      physics:
+                                          const AlwaysScrollableScrollPhysics(),
+                                      child: Column(
+                                        children: [
+                                          GestureDetector(
+                                            onTap: () {
+                                              if (timeline
+                                                      .constellationPostIds !=
+                                                  null) {
+                                                ref
+                                                    .read(
+                                                      timelineProvider.notifier,
+                                                    )
+                                                    .clearConstellation();
+                                              } else if (_focusedPostId !=
+                                                  null) {
+                                                setState(
+                                                  () => _focusedPostId = null,
+                                                );
+                                              }
+                                            },
+                                            child: SizedBox(
+                                              height: layout.totalHeight,
+                                              child: Stack(
+                                                children: [
+                                                  // Background: spine + synapses + travelling dot
+                                                  Positioned.fill(
+                                                    child: AnimatedBuilder(
+                                                      animation: _dotController,
+                                                      builder: (context, _) => CustomPaint(
+                                                        painter: ConstellationPainter(
+                                                          layout: layout,
+                                                          constellationPostIds:
+                                                              timeline
+                                                                  .constellationPostIds,
+                                                          animationValue:
+                                                              _dotController
+                                                                  .value,
+                                                          scrollOffset:
+                                                              _scrollOffset,
+                                                          viewportHeight:
+                                                              constraints
+                                                                  .maxHeight,
+                                                        ),
+                                                      ),
+                                                    ),
+                                                  ),
+                                                  // Day labels on the spine
+                                                  // Find the one day closest above the midpoint
+                                                  ..._buildDateLabels(
+                                                    layout.days,
+                                                    _scrollOffset,
+                                                    constraints.maxHeight,
+                                                  ),
+                                                  // Nodes (focused node rendered last for z-order)
+                                                  ..._buildNodes(
+                                                    layout,
+                                                    timeline.highlightPostId,
+                                                    timeline
+                                                        .constellationPostIds,
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  );
+                                },
                               ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
                             ),
-                          ),
-                          GestureDetector(
-                            onTap: () => ref
-                                .read(timelineProvider.notifier)
-                                .clearConstellation(),
-                            child: const Icon(
-                              Icons.close,
-                              size: 18,
-                              color: colorInteractive,
+                    ),
+                    // Constellation highlight banner
+                    if (timeline.constellationPostIds != null)
+                      Builder(
+                        builder: (context) {
+                          final constellationName = timeline.posts
+                              .where(
+                                (p) =>
+                                    timeline.constellationPostIds!.contains(
+                                      p.id,
+                                    ) &&
+                                    p.constellation != null,
+                              )
+                              .map((p) => p.constellation!.name)
+                              .firstOrNull;
+                          return Container(
+                            color: colorSurface1,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 10,
                             ),
-                          ),
-                        ],
+                            child: Row(
+                              children: [
+                                const Icon(
+                                  Icons.auto_awesome,
+                                  size: 16,
+                                  color: colorInteractive,
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    constellationName != null
+                                        ? '$constellationName · ${timeline.constellationPostIds!.length} posts'
+                                        : 'Constellation · ${timeline.constellationPostIds!.length} posts',
+                                    style: const TextStyle(
+                                      color: colorTextSecondary,
+                                      fontSize: 13,
+                                    ),
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                                GestureDetector(
+                                  onTap: () => ref
+                                      .read(timelineProvider.notifier)
+                                      .clearConstellation(),
+                                  child: const Icon(
+                                    Icons.close,
+                                    size: 18,
+                                    color: colorInteractive,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        },
                       ),
-                    );
-                  },
+                  ],
                 ),
+              ),
+              // Desktop side panel for post detail
+              if (_sidePanelPostId != null) ...[
+                const VerticalDivider(
+                  width: 1,
+                  thickness: 1,
+                  color: colorBorder,
+                ),
+                SizedBox(
+                  width: sidePanelWidth,
+                  child: _DesktopDetailPanel(
+                    postId: _sidePanelPostId!,
+                    posts: timeline.posts,
+                    isOwn: isOwn,
+                    onClose: () => setState(() => _sidePanelPostId = null),
+                    onToggleReaction: (id, emoji) => ref
+                        .read(timelineProvider.notifier)
+                        .toggleReaction(id, emoji),
+                    onReactionsChanged: (id, counts, myReactions) => ref
+                        .read(timelineProvider.notifier)
+                        .updatePostReactions(id, counts, myReactions),
+                    onEdit: isOwn
+                        ? (post) {
+                            setState(() => _sidePanelPostId = null);
+                            context.push('/edit-post', extra: post);
+                          }
+                        : null,
+                  ),
+                ),
+              ],
             ],
           ),
         ),
@@ -674,6 +759,17 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
   }
 
   void _openDetailSheet(String postId) {
+    // Desktop: show side panel instead of bottom sheet
+    final screenWidth = MediaQuery.of(context).size.width;
+    if (isDesktop(screenWidth)) {
+      setState(() => _sidePanelPostId = postId);
+      return;
+    }
+
+    _showDetailBottomSheet(postId);
+  }
+
+  void _showDetailBottomSheet(String postId) {
     final post = ref
         .read(timelineProvider)
         .posts
@@ -1102,5 +1198,243 @@ class _GlowingStarButtonState extends State<_GlowingStarButton>
         ),
       ),
     );
+  }
+}
+
+/// Desktop-only side panel showing post detail inline.
+class _DesktopDetailPanel extends StatelessWidget {
+  final String postId;
+  final List<Post> posts;
+  final bool isOwn;
+  final VoidCallback onClose;
+  final Future<bool> Function(String, String) onToggleReaction;
+  final void Function(String, List<ReactionCount>, List<String>)
+  onReactionsChanged;
+  final void Function(Post)? onEdit;
+
+  const _DesktopDetailPanel({
+    required this.postId,
+    required this.posts,
+    required this.isOwn,
+    required this.onClose,
+    required this.onToggleReaction,
+    required this.onReactionsChanged,
+    this.onEdit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final post = posts.where((p) => p.id == postId).firstOrNull;
+    if (post == null) return const SizedBox.shrink();
+
+    return Container(
+      color: colorSurface1,
+      child: Column(
+        children: [
+          // Header
+          Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: spaceLg,
+              vertical: spaceSm,
+            ),
+            decoration: const BoxDecoration(
+              border: Border(bottom: BorderSide(color: colorBorder)),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    post.title ?? 'Untitled',
+                    style: const TextStyle(
+                      color: colorTextPrimary,
+                      fontSize: fontSizeLg,
+                      fontWeight: weightSemibold,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (onEdit != null)
+                  IconButton(
+                    icon: const Icon(
+                      Icons.edit_outlined,
+                      size: 18,
+                      color: colorInteractive,
+                    ),
+                    onPressed: () => onEdit!(post),
+                    tooltip: 'Edit',
+                  ),
+                IconButton(
+                  icon: const Icon(
+                    Icons.close,
+                    size: 18,
+                    color: colorInteractive,
+                  ),
+                  onPressed: onClose,
+                  tooltip: 'Close',
+                ),
+              ],
+            ),
+          ),
+          // Content
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(spaceLg),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Image: show directly
+                  if (post.mediaUrl != null &&
+                      post.mediaType == MediaType.image)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: spaceLg),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(radiusMd),
+                        child: Image.network(
+                          post.mediaUrl!,
+                          width: double.infinity,
+                          fit: BoxFit.cover,
+                          cacheWidth: 800,
+                          errorBuilder: (_, _, _) => Container(
+                            height: 120,
+                            color: colorSurface2,
+                            child: const Center(
+                              child: Icon(
+                                Icons.broken_image,
+                                color: colorInteractiveMuted,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  // Video: show thumbnail if available, else placeholder
+                  if (post.mediaType == MediaType.video)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: spaceLg),
+                      child: Container(
+                        height: 160,
+                        decoration: BoxDecoration(
+                          color: colorSurface2,
+                          borderRadius: BorderRadius.circular(radiusMd),
+                          image: post.thumbnailUrl != null
+                              ? DecorationImage(
+                                  image: NetworkImage(post.thumbnailUrl!),
+                                  fit: BoxFit.cover,
+                                )
+                              : null,
+                        ),
+                        child: Center(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(
+                                Icons.play_circle_outline,
+                                size: 40,
+                                color: colorTextPrimary,
+                              ),
+                              if (post.duration != null)
+                                Text(
+                                  '${post.duration! ~/ 60}:${(post.duration! % 60).toString().padLeft(2, '0')}',
+                                  style: const TextStyle(
+                                    color: colorTextSecondary,
+                                    fontSize: fontSizeSm,
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  // Audio: show placeholder with duration
+                  if (post.mediaType == MediaType.audio)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: spaceLg),
+                      child: Container(
+                        padding: const EdgeInsets.all(spaceLg),
+                        decoration: BoxDecoration(
+                          color: colorSurface2,
+                          borderRadius: BorderRadius.circular(radiusMd),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(
+                              Icons.audiotrack,
+                              size: 24,
+                              color: colorInteractive,
+                            ),
+                            const SizedBox(width: spaceMd),
+                            Text(
+                              post.duration != null
+                                  ? '${post.duration! ~/ 60}:${(post.duration! % 60).toString().padLeft(2, '0')}'
+                                  : 'Audio',
+                              style: const TextStyle(
+                                color: colorTextSecondary,
+                                fontSize: fontSizeMd,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  if (post.body != null && post.body!.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: spaceLg),
+                      child: Text(
+                        post.body!,
+                        style: const TextStyle(
+                          color: colorTextSecondary,
+                          fontSize: fontSizeMd,
+                          height: 1.6,
+                        ),
+                      ),
+                    ),
+                  Text(
+                    '${post.mediaType.name} · ${_formatDate(post.createdAt)}',
+                    style: const TextStyle(
+                      color: colorTextMuted,
+                      fontSize: fontSizeSm,
+                    ),
+                  ),
+                  if (post.reactionCounts.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: spaceLg),
+                      child: Wrap(
+                        spacing: spaceSm,
+                        runSpacing: spaceXs,
+                        children: post.reactionCounts.map((rc) {
+                          final isMine = post.myReactions.contains(rc.emoji);
+                          return ActionChip(
+                            label: Text(
+                              '${rc.emoji} ${rc.count}',
+                              style: TextStyle(
+                                fontSize: fontSizeSm,
+                                color: isMine
+                                    ? colorAccentGold
+                                    : colorTextSecondary,
+                              ),
+                            ),
+                            backgroundColor: isMine
+                                ? colorSurface2
+                                : colorSurface0,
+                            side: BorderSide(
+                              color: isMine ? colorAccentGold : colorBorder,
+                            ),
+                            onPressed: () =>
+                                onToggleReaction(post.id, rc.emoji),
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _formatDate(DateTime date) {
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
   }
 }

--- a/frontend/lib/theme/gleisner_tokens.dart
+++ b/frontend/lib/theme/gleisner_tokens.dart
@@ -83,6 +83,35 @@ const radiusSheet = 20.0;
 const radiusFull = 999.0;
 
 // ---------------------------------------------------------------------------
+// Responsive breakpoints (Idea 030)
+// ---------------------------------------------------------------------------
+
+const breakpointTablet = 600.0;
+const breakpointDesktop = 1024.0;
+
+/// Content max-width on large screens (centered with padding)
+const maxContentWidth = 1200.0;
+
+/// Side panel width on desktop (detail sheet replacement)
+const sidePanelWidth = 420.0;
+
+/// Navigation rail width on desktop/tablet
+const navRailWidth = 72.0;
+
+/// True if the width is tablet or wider (>= 600px).
+bool isTabletOrWider(double width) => width >= breakpointTablet;
+
+/// True if the width is desktop (>= 1024px).
+bool isDesktop(double width) => width >= breakpointDesktop;
+
+/// Responsive grid column count for card grids (Discover, etc.).
+int responsiveGridColumns(double width) {
+  if (width >= breakpointDesktop) return 4;
+  if (width >= breakpointTablet) return 3;
+  return 2;
+}
+
+// ---------------------------------------------------------------------------
 // Track color presets (for auto-assignment)
 // ---------------------------------------------------------------------------
 

--- a/frontend/lib/utils/date_format.dart
+++ b/frontend/lib/utils/date_format.dart
@@ -1,3 +1,8 @@
+/// Format date as YYYY-MM-DD.
+String formatDate(DateTime date) {
+  return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+}
+
 String formatRelativeDate(DateTime date, {DateTime? now}) {
   final ref = now ?? DateTime.now();
   final diff = ref.difference(date);

--- a/frontend/lib/widgets/auth/auth_layout.dart
+++ b/frontend/lib/widgets/auth/auth_layout.dart
@@ -5,8 +5,8 @@ import '../common/app_footer.dart';
 import 'gleisner_hero.dart';
 
 /// Responsive layout shared by login and signup screens.
-/// Wide (>= 800px): hero left + form right, side by side.
-/// Narrow (< 800px): form on top, compact hero below.
+/// Wide (tablet+): hero left + form right, side by side.
+/// Narrow (mobile): form on top, compact hero below.
 class AuthLayout extends StatelessWidget {
   final Widget form;
 
@@ -31,7 +31,7 @@ class AuthLayout extends StatelessWidget {
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final isWide = constraints.maxWidth >= 800;
+            final isWide = isTabletOrWider(constraints.maxWidth);
 
             if (isWide) {
               return Column(

--- a/frontend/lib/widgets/common/bottom_nav_shell.dart
+++ b/frontend/lib/widgets/common/bottom_nav_shell.dart
@@ -7,10 +7,10 @@ import '../../providers/guardian_provider.dart';
 import '../../theme/gleisner_tokens.dart';
 import '../../utils/account_switch_helper.dart';
 
-/// Shell wrapper providing bottom navigation for the main app tabs.
+/// Responsive shell: NavigationRail on tablet+, BottomNavigationBar on mobile.
 ///
 /// Each branch (Timeline, Discover, Profile) has its own Scaffold with AppBar.
-/// This outer Scaffold holds only the NavigationBar — the nested Scaffold
+/// This outer Scaffold holds only the navigation — the nested Scaffold
 /// pattern is intentional and standard for StatefulShellRoute with per-tab
 /// AppBars (see go_router docs).
 ///
@@ -22,43 +22,109 @@ class BottomNavShell extends ConsumerWidget {
 
   const BottomNavShell({super.key, required this.navigationShell});
 
+  void _onDestinationSelected(int index) {
+    navigationShell.goBranch(
+      index,
+      initialLocation: index == navigationShell.currentIndex,
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final user = ref.watch(authProvider).user;
     final isChild = user?.isChildAccount ?? false;
     final guardianLoading = ref.watch(guardianProvider).isLoading;
+    final screenWidth = MediaQuery.of(context).size.width;
+    final useRail = isTabletOrWider(screenWidth);
+
+    Widget body = Column(
+      children: [
+        if (isChild)
+          _ChildModeBanner(
+            childName: user?.displayName ?? user?.username ?? '',
+            isLoading: guardianLoading,
+            onReturn: () async {
+              final success = await ref
+                  .read(guardianProvider.notifier)
+                  .switchBackToGuardian();
+              if (!success) return;
+              await reloadAfterAccountSwitch(ref);
+              await ref
+                  .read(guardianProvider.notifier)
+                  .loadChildren(forceReload: true);
+            },
+          ),
+        Expanded(child: navigationShell),
+      ],
+    );
+
+    if (useRail) {
+      return Scaffold(
+        body: Row(
+          children: [
+            NavigationRail(
+              backgroundColor: colorSurface1,
+              selectedIndex: navigationShell.currentIndex,
+              onDestinationSelected: _onDestinationSelected,
+              labelType: NavigationRailLabelType.all,
+              indicatorColor: Colors.transparent,
+              minWidth: navRailWidth,
+              destinations: const [
+                NavigationRailDestination(
+                  icon: Icon(
+                    Icons.grid_view_outlined,
+                    color: colorInteractiveMuted,
+                  ),
+                  selectedIcon: Icon(Icons.grid_view, color: colorTextPrimary),
+                  label: Text(
+                    'Timeline',
+                    style: TextStyle(
+                      fontSize: fontSizeXs,
+                      color: colorTextMuted,
+                    ),
+                  ),
+                ),
+                NavigationRailDestination(
+                  icon: Icon(Icons.search, color: colorInteractiveMuted),
+                  selectedIcon: Icon(Icons.search, color: colorTextPrimary),
+                  label: Text(
+                    'Discover',
+                    style: TextStyle(
+                      fontSize: fontSizeXs,
+                      color: colorTextMuted,
+                    ),
+                  ),
+                ),
+                NavigationRailDestination(
+                  icon: Icon(
+                    Icons.person_outline,
+                    color: colorInteractiveMuted,
+                  ),
+                  selectedIcon: Icon(Icons.person, color: colorTextPrimary),
+                  label: Text(
+                    'Profile',
+                    style: TextStyle(
+                      fontSize: fontSizeXs,
+                      color: colorTextMuted,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            VerticalDivider(width: 1, thickness: 1, color: colorBorder),
+            Expanded(child: body),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
-      body: Column(
-        children: [
-          if (isChild)
-            _ChildModeBanner(
-              childName: user?.displayName ?? user?.username ?? '',
-              isLoading: guardianLoading,
-              onReturn: () async {
-                final success = await ref
-                    .read(guardianProvider.notifier)
-                    .switchBackToGuardian();
-                if (!success) return;
-                await reloadAfterAccountSwitch(ref);
-                await ref
-                    .read(guardianProvider.notifier)
-                    .loadChildren(forceReload: true);
-              },
-            ),
-          Expanded(child: navigationShell),
-        ],
-      ),
+      body: body,
       bottomNavigationBar: NavigationBar(
         backgroundColor: colorSurface1,
         indicatorColor: Colors.transparent,
         selectedIndex: navigationShell.currentIndex,
-        onDestinationSelected: (index) {
-          navigationShell.goBranch(
-            index,
-            initialLocation: index == navigationShell.currentIndex,
-          );
-        },
+        onDestinationSelected: _onDestinationSelected,
         destinations: const [
           NavigationDestination(
             icon: Icon(Icons.grid_view_outlined, color: colorInteractiveMuted),


### PR DESCRIPTION
## Summary
- **NavigationRail** on tablet+ (≥600px), BottomNavigationBar on mobile
- **Discover** grid: 2 cols (mobile) → 3 (tablet) → 4 (desktop)
- **Timeline**: desktop side panel for post detail (media-type-aware)
- **Create post**: dialog on desktop with `onSuccess` callback
- **Profile**: centered with max-width constraint
- Breakpoint tokens in `gleisner_tokens.dart` (600/1024px)

Phase 0 roadmap item 1.1 (partial — horizontal timeline scroll deferred to separate PR)

## Changes
| File | What |
|------|------|
| `gleisner_tokens.dart` | Breakpoint constants + helpers |
| `bottom_nav_shell.dart` | NavigationRail / BottomNav responsive switch |
| `discover_screen.dart` | `SliverLayoutBuilder` + `responsiveGridColumns` |
| `timeline_screen.dart` | Side panel, dialog create, media-type display |
| `create_post_screen.dart` | `onSuccess` callback for dialog mode |
| `profile_screen.dart` | `ConstrainedBox(maxWidth: maxContentWidth)` |
| `auth_layout.dart` | Use shared breakpoint instead of hardcoded 800px |

## Test plan
- [ ] **Mobile (< 600px)**: BottomNavigationBar visible, no side rail
- [ ] **Tablet (600–1024px)**: NavigationRail visible, Discover 3 cols
- [ ] **Desktop (> 1024px)**: NavigationRail, Discover 4 cols, side panel on post tap
- [ ] **Create post (desktop)**: FAB opens dialog, post submits and dialog closes
- [ ] **Create post (mobile)**: FAB navigates to full-screen as before
- [ ] **Profile (desktop)**: content centered with max-width
- [ ] **Login/Signup**: responsive layout uses shared breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)