### PR TITLE
Split text type into thought (280-char bubble) and article (rich text + genre)

### DIFF
--- a/.claude/rules/backend-implementation.md
+++ b/.claude/rules/backend-implementation.md
@@ -425,3 +425,78 @@ seed スクリプトの `create_post` は `> /dev/null` でエラーを握り潰
 - [ ] 新しい必須フィールドを追加した場合 → seed の `create_post` にフィールドを追加
 
 PR #197 の教訓: PR #195 で動画60秒/音声300秒制限を追加したが seed データ未更新 → 12件の投稿が無言で失敗 → 17件の connection が全滅。
+
+### MediaType enum 値の追加/変更チェックリスト
+
+**⚠ MediaType の enum 値を追加・変更・削除する場合、以下を同時に更新すること:**
+
+バックエンド:
+1. `src/db/schema/post.ts` の `mediaTypeEnum` 配列
+2. `src/graphql/types/post.ts` の `MediaTypeEnum` + `PostShape` の `mediaType` 型
+3. `src/graphql/types/post.ts` の `createPost` バリデーション（型固有の制約）
+4. `src/graphql/types/post.ts` の `updatePost` バリデーション（**createPost と同等の制約を漏れなく**）
+5. `src/auth/signing.ts` の `computeContentHash`（型固有フィールドがある場合）
+6. `src/graphql/__tests__/helpers.ts` の `CREATE_POST_MUTATION` 文字列（新引数追加時）
+7. `src/graphql/__tests__/post.test.ts` の全テストで旧 enum 値を新値に置換
+8. マイグレーション SQL（既存データの変換 + enum 再作成）
+9. `scripts/seed-test-data.sh` + `scripts/seed-discover-data.sh` の投稿データ
+
+フロントエンド:
+10. `lib/models/post.dart` の `MediaType` enum + `_parseMediaType` + backward compat
+11. `lib/graphql/queries/post.dart` の `postFields`（型固有フィールド追加時）
+12. `lib/graphql/mutations/post.dart` の `createPostMutation` / `updatePostMutation`（新引数）
+13. 全 switch expression（`dart analyze` で exhaustive check エラーとして検出可能）
+14. `create_post_screen.dart` の型選択 UI + フォーム分岐
+15. `edit_post_screen.dart` のフォーム分岐
+16. `node_card.dart` のノード表示分岐
+17. `post_detail_sheet.dart` のメディアエリア + コンテンツセクション分岐
+
+PR #202 の教訓: text → thought + article の分割で 20箇所以上の同時更新が必要だった。switch exhaustive check のおかげでフロントエンドのコンパイルエラーは検出できたが、バックエンドのバリデーション漏れは3回のレビューで段階的に発見。
+
+### updatePost のバリデーションは createPost と完全同等にする
+
+**createPost に型固有のバリデーションを追加した場合、updatePost にも同じバリデーションを effective value パターンで追加すること。**
+
+「effective value パターン」とは、`args` の値だけでなく既存の `post` の値も組み合わせてバリデーションすること。mediaType を変更する場合、変更後の型の制約を既存データにも適用する必要がある。
+
+```typescript
+// ❌ args のみチェック — mediaType 変更時に既存データをバイパス
+if (args.mediaType === "thought") {
+  if (args.title != null) throw ...;  // 既存の title は見ていない
+}
+
+// ✅ effective value で既存値も再チェック
+const effectiveMediaType = args.mediaType ?? post.mediaType;
+if (effectiveMediaType === "thought") {
+  const effectiveTitle = args.title !== undefined ? args.title : post.title;
+  if (effectiveTitle != null && effectiveTitle.trim() !== "") throw ...;
+}
+```
+
+対象: mediaType 固有のバリデーション、フィールド間の cross-check（externalPublish × visibility 等）。
+
+PR #202 の教訓: createPost に thought の制約を追加 → updatePost に忘れ → effective value も漏れ → 3回のレビューで段階的に修正。
+
+### テスト helpers の mutation 文字列は引数追加時に必ず更新
+
+**GraphQL mutation/query に新しい引数を追加した場合、`src/graphql/__tests__/helpers.ts` の対応する mutation 文字列にも同じ引数を追加すること。**
+
+helpers の mutation 文字列に引数がないと、テストで変数として渡しても GraphQL が無視する（`undefined` として resolver に届く）。結果、バリデーションテストが空振りして通過してしまう。
+
+```typescript
+// ❌ helpers に bodyFormat がない → テストで bodyFormat: "delta" を渡しても無視される
+const CREATE_POST_MUTATION = `
+  mutation($trackId: String!, $mediaType: MediaType!, $body: String) {
+    createPost(trackId: $trackId, mediaType: $mediaType, body: $body) { id }
+  }
+`;
+
+// ✅ 新引数を追加
+const CREATE_POST_MUTATION = `
+  mutation($trackId: String!, $mediaType: MediaType!, $body: String, $bodyFormat: String) {
+    createPost(trackId: $trackId, mediaType: $mediaType, body: $body, bodyFormat: $bodyFormat) { id }
+  }
+`;
+```
+
+PR #202 の教訓: `bodyFormat` と `externalPublish` を helpers に追加し忘れ、thought のバリデーションテストが空振り。インライン mutation で通ったことで原因が判明。

--- a/backend/drizzle/0009_wide_human_fly.sql
+++ b/backend/drizzle/0009_wide_human_fly.sql
@@ -1,0 +1,21 @@
+-- Step 1: Convert column to text temporarily
+ALTER TABLE "posts" ALTER COLUMN "media_type" SET DATA TYPE text;--> statement-breakpoint
+
+-- Step 2: Migrate existing 'text' posts to thought/article
+-- article: has title OR uses delta format
+-- thought: everything else (short plain text)
+UPDATE "posts" SET "media_type" = 'article'
+  WHERE "media_type" = 'text' AND ("title" IS NOT NULL OR "body_format" = 'delta');--> statement-breakpoint
+UPDATE "posts" SET "media_type" = 'thought'
+  WHERE "media_type" = 'text';--> statement-breakpoint
+
+-- Step 3: Replace enum type
+DROP TYPE "public"."media_type";--> statement-breakpoint
+CREATE TYPE "public"."media_type" AS ENUM('thought', 'article', 'image', 'video', 'audio', 'link');--> statement-breakpoint
+
+-- Step 4: Cast back to enum (all values are now valid)
+ALTER TABLE "posts" ALTER COLUMN "media_type" SET DATA TYPE "public"."media_type" USING "media_type"::"public"."media_type";--> statement-breakpoint
+
+-- Step 5: Add new columns
+ALTER TABLE "posts" ADD COLUMN "article_genre" varchar(20);--> statement-breakpoint
+ALTER TABLE "posts" ADD COLUMN "external_publish" boolean DEFAULT false NOT NULL;

--- a/backend/drizzle/meta/0009_snapshot.json
+++ b/backend/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1790 @@
+{
+  "id": "29866d14-cdf9-4a75-9824-0d4482738b3a",
+  "prevId": "90dd3f2d-bf89-4fdd-96f6-960e25108cbe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analytics_events": {
+      "name": "analytics_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analytics_event_type_created_idx": {
+          "name": "analytics_event_type_created_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_event_user_id_idx": {
+          "name": "analytics_event_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_event_session_id_idx": {
+          "name": "analytics_event_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_genres": {
+      "name": "artist_genres",
+      "schema": "",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_genres_artist_id_artists_id_fk": {
+          "name": "artist_genres_artist_id_artists_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_genres_genre_id_genres_id_fk": {
+          "name": "artist_genres_genre_id_genres_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_genres_artist_id_genre_id_pk": {
+          "name": "artist_genres_artist_id_genre_id_pk",
+          "columns": [
+            "artist_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_links": {
+      "name": "artist_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_category": {
+          "name": "link_category",
+          "type": "link_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_links_artist_id_artists_id_fk": {
+          "name": "artist_links_artist_id_artists_id_fk",
+          "tableFrom": "artist_links",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_milestones": {
+      "name": "artist_milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "milestone_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artist_milestones_artist_id_idx": {
+          "name": "artist_milestones_artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_milestones_artist_id_artists_id_fk": {
+          "name": "artist_milestones_artist_id_artists_id_fk",
+          "tableFrom": "artist_milestones",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_username": {
+          "name": "artist_username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_since": {
+          "name": "active_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "tuned_in_count": {
+          "name": "tuned_in_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artists_user_id_users_id_fk": {
+          "name": "artists_user_id_users_id_fk",
+          "tableFrom": "artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artists_user_id_unique": {
+          "name": "artists_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "artists_artist_username_unique": {
+          "name": "artists_artist_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_post_id_posts_id_fk": {
+          "name": "comments_post_id_posts_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "connection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_connection": {
+          "name": "unique_connection",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_source_id_posts_id_fk": {
+          "name": "connections_source_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_target_id_posts_id_fk": {
+          "name": "connections_target_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_neq_target": {
+          "name": "source_neq_target",
+          "value": "\"connections\".\"source_id\" != \"connections\".\"target_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.constellations": {
+      "name": "constellations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_post_id": {
+          "name": "anchor_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "constellations_artist_id_artists_id_fk": {
+          "name": "constellations_artist_id_artists_id_fk",
+          "tableFrom": "constellations",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "constellations_anchor_post_id_posts_id_fk": {
+          "name": "constellations_anchor_post_id_posts_id_fk",
+          "tableFrom": "constellations",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "anchor_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "constellations_anchor_post_id_unique": {
+          "name": "constellations_anchor_post_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anchor_post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "name": "follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "follower_neq_following": {
+          "name": "follower_neq_following",
+          "value": "\"follows\".\"follower_id\" != \"follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_promoted": {
+          "name": "is_promoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "genres_normalized_name_unique": {
+          "name": "genres_normalized_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "normalized_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_users_id_fk": {
+          "name": "invites_created_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_used_by_users_id_fk": {
+          "name": "invites_used_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_reactions": {
+      "name": "milestone_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestone_reactions_milestone_id_artist_milestones_id_fk": {
+          "name": "milestone_reactions_milestone_id_artist_milestones_id_fk",
+          "tableFrom": "milestone_reactions",
+          "tableTo": "artist_milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_reactions_user_id_users_id_fk": {
+          "name": "milestone_reactions_user_id_users_id_fk",
+          "tableFrom": "milestone_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_reactions_milestone_id_user_id_emoji_unique": {
+          "name": "milestone_reactions_milestone_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_format": {
+          "name": "body_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'plain'"
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importance": {
+          "name": "importance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_fetched_at": {
+          "name": "og_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_genre": {
+          "name": "article_genre",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_publish": {
+          "name": "external_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_x": {
+          "name": "layout_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "layout_y": {
+          "name": "layout_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_author_og_fetched_idx": {
+          "name": "posts_author_og_fetched_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "og_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_media_url_og_fetched_idx": {
+          "name": "posts_media_url_og_fetched_idx",
+          "columns": [
+            {
+              "expression": "media_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "og_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_track_id_tracks_id_fk": {
+          "name": "posts_track_id_tracks_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reactions_post_id_posts_id_fk": {
+          "name": "reactions_post_id_posts_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_user_id_users_id_fk": {
+          "name": "reactions_user_id_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_post_id_user_id_emoji_unique": {
+          "name": "reactions_post_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracks": {
+      "name": "tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_artist_track_name": {
+          "name": "unique_artist_track_name",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracks_artist_id_artists_id_fk": {
+          "name": "tracks_artist_id_artists_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tune_ins": {
+      "name": "tune_ins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tune_ins_user_id_users_id_fk": {
+          "name": "tune_ins_user_id_users_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tune_ins_artist_id_artists_id_fk": {
+          "name": "tune_ins_artist_id_artists_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tune_ins_user_id_artist_id_pk": {
+          "name": "tune_ins_user_id_artist_id_pk",
+          "columns": [
+            "user_id",
+            "artist_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "did": {
+          "name": "did",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_salt": {
+          "name": "password_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_private_key": {
+          "name": "encrypted_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_salt": {
+          "name": "encryption_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_year_month": {
+          "name": "birth_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_id": {
+          "name": "guardian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_guardian_id_users_id_fk": {
+          "name": "users_guardian_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "guardian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_did_unique": {
+          "name": "users_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_type": {
+      "name": "connection_type",
+      "schema": "public",
+      "values": [
+        "reply",
+        "remix",
+        "reference",
+        "evolution"
+      ]
+    },
+    "public.link_category": {
+      "name": "link_category",
+      "schema": "public",
+      "values": [
+        "social",
+        "music",
+        "video",
+        "website",
+        "store",
+        "other"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "thought",
+        "article",
+        "image",
+        "video",
+        "audio",
+        "link"
+      ]
+    },
+    "public.milestone_category": {
+      "name": "milestone_category",
+      "schema": "public",
+      "values": [
+        "award",
+        "release",
+        "event",
+        "affiliation",
+        "education",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1775741817322,
       "tag": "0008_neat_wrecker",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1775929456355,
+      "tag": "0009_wide_human_fly",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/auth/signing.ts
+++ b/backend/src/auth/signing.ts
@@ -36,6 +36,7 @@ export function computeContentHash(fields: {
   mediaType: string;
   importance: number;
   duration?: number | null;
+  articleGenre?: string | null;
 }): string {
   // Normalize body to plain text for format-independent hashing
   let bodyText = "";
@@ -52,6 +53,7 @@ export function computeContentHash(fields: {
     mediaType: fields.mediaType,
     importance: fields.importance,
     duration: fields.duration ?? null,
+    articleGenre: fields.articleGenre ?? null,
   });
   return createHash("sha256").update(canonical).digest("hex");
 }

--- a/backend/src/db/schema/post.ts
+++ b/backend/src/db/schema/post.ts
@@ -5,6 +5,7 @@ import {
   text,
   real,
   integer,
+  boolean,
   timestamp,
   pgEnum,
   jsonb,
@@ -14,7 +15,8 @@ import { tracks } from "./track.js";
 import { users } from "./user.js";
 
 export const mediaTypeEnum = pgEnum("media_type", [
-  "text",
+  "thought",
+  "article",
   "image",
   "video",
   "audio",
@@ -52,6 +54,8 @@ export const posts = pgTable(
     ogImage: text("og_image"),
     ogSiteName: varchar("og_site_name", { length: 100 }),
     ogFetchedAt: timestamp("og_fetched_at", { withTimezone: true }),
+    articleGenre: varchar("article_genre", { length: 20 }),
+    externalPublish: boolean("external_publish").default(false).notNull(),
     eventAt: timestamp("event_at", { withTimezone: true }),
     layoutX: integer("layout_x").default(0).notNull(),
     layoutY: integer("layout_y").default(0).notNull(),

--- a/backend/src/graphql/__tests__/comment.test.ts
+++ b/backend/src/graphql/__tests__/comment.test.ts
@@ -189,7 +189,7 @@ async function createPostForTest(
   const postResult = await gql(
     app,
     CREATE_POST_MUTATION,
-    { trackId, mediaType: "text" },
+    { trackId, mediaType: "thought" },
     token,
   );
   return (postResult.data!.createPost as { id: string }).id;

--- a/backend/src/graphql/__tests__/connection.test.ts
+++ b/backend/src/graphql/__tests__/connection.test.ts
@@ -198,7 +198,7 @@ async function createPostForTest(
   const postResult = await gql(
     app,
     CREATE_POST_MUTATION,
-    { trackId, mediaType: "text" },
+    { trackId, mediaType: "thought" },
     token,
   );
   return (postResult.data!.createPost as { id: string }).id;

--- a/backend/src/graphql/__tests__/constellation.test.ts
+++ b/backend/src/graphql/__tests__/constellation.test.ts
@@ -65,19 +65,19 @@ describe("Constellation GraphQL integration", () => {
     const postA = await gql(
       app,
       CREATE_POST_MUTATION,
-      { trackId, mediaType: "text" },
+      { trackId, mediaType: "thought" },
       token,
     );
     const postB = await gql(
       app,
       CREATE_POST_MUTATION,
-      { trackId, mediaType: "text" },
+      { trackId, mediaType: "thought" },
       token,
     );
     const postC = await gql(
       app,
       CREATE_POST_MUTATION,
-      { trackId, mediaType: "text" },
+      { trackId, mediaType: "thought" },
       token,
     );
     const idA = (postA.data!.createPost as { id: string }).id;

--- a/backend/src/graphql/__tests__/helpers.ts
+++ b/backend/src/graphql/__tests__/helpers.ts
@@ -103,8 +103,8 @@ export const CREATE_TRACK_MUTATION = `
 `;
 
 export const CREATE_POST_MUTATION = `
-  mutation CreatePost($trackId: String!, $mediaType: MediaType!, $title: String, $body: String, $mediaUrl: String, $thumbnailUrl: String, $importance: Float, $layoutX: Int, $layoutY: Int, $eventAt: String, $visibility: String) {
-    createPost(trackId: $trackId, mediaType: $mediaType, title: $title, body: $body, mediaUrl: $mediaUrl, thumbnailUrl: $thumbnailUrl, importance: $importance, layoutX: $layoutX, layoutY: $layoutY, eventAt: $eventAt, visibility: $visibility) {
+  mutation CreatePost($trackId: String!, $mediaType: MediaType!, $title: String, $body: String, $bodyFormat: String, $mediaUrl: String, $thumbnailUrl: String, $importance: Float, $layoutX: Int, $layoutY: Int, $eventAt: String, $visibility: String, $articleGenre: ArticleGenre, $externalPublish: Boolean) {
+    createPost(trackId: $trackId, mediaType: $mediaType, title: $title, body: $body, bodyFormat: $bodyFormat, mediaUrl: $mediaUrl, thumbnailUrl: $thumbnailUrl, importance: $importance, layoutX: $layoutX, layoutY: $layoutY, eventAt: $eventAt, visibility: $visibility, articleGenre: $articleGenre, externalPublish: $externalPublish) {
       id mediaType title body mediaUrl thumbnailUrl importance layoutX layoutY visibility createdAt
     }
   }

--- a/backend/src/graphql/__tests__/helpers.ts
+++ b/backend/src/graphql/__tests__/helpers.ts
@@ -247,7 +247,7 @@ export async function createPostForTest(
   const postResult = await gql(
     testApp,
     CREATE_POST_MUTATION,
-    { trackId, mediaType: "text" },
+    { trackId, mediaType: "thought" },
     token,
   );
   return (postResult.data!.createPost as { id: string }).id;

--- a/backend/src/graphql/__tests__/post.test.ts
+++ b/backend/src/graphql/__tests__/post.test.ts
@@ -296,13 +296,13 @@ describe("Post GraphQL integration", () => {
       const result = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text" },
+        { trackId, mediaType: "thought" },
         token,
       );
 
       expect(result.errors).toBeUndefined();
       const post = result.data!.createPost as Record<string, unknown>;
-      expect(post.mediaType).toBe("text");
+      expect(post.mediaType).toBe("thought");
       expect(post.title).toBeNull();
       expect(post.body).toBeNull();
       expect(post.mediaUrl).toBeNull();
@@ -314,7 +314,7 @@ describe("Post GraphQL integration", () => {
     it("rejects unauthenticated request", async () => {
       const result = await gql(app, CREATE_POST_MUTATION, {
         trackId: "00000000-0000-0000-0000-000000000000",
-        mediaType: "text",
+        mediaType: "thought",
       });
 
       expect(result.errors).toBeDefined();
@@ -374,7 +374,7 @@ describe("Post GraphQL integration", () => {
       const result = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "Text Only" },
+        { trackId, mediaType: "article", title: "Text Only" },
         token,
       );
 
@@ -412,7 +412,7 @@ describe("Post GraphQL integration", () => {
         CREATE_POST_MUTATION,
         {
           trackId: "00000000-0000-0000-0000-000000000000",
-          mediaType: "text",
+          mediaType: "thought",
         },
         token,
       );
@@ -440,7 +440,7 @@ describe("Post GraphQL integration", () => {
       const result = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text" },
+        { trackId, mediaType: "thought" },
         otherToken,
       );
 
@@ -461,7 +461,7 @@ describe("Post GraphQL integration", () => {
       const result = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "a".repeat(101) },
+        { trackId, mediaType: "article", title: "a".repeat(101) },
         token,
       );
 
@@ -482,7 +482,7 @@ describe("Post GraphQL integration", () => {
       const result = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", importance: 1.5 },
+        { trackId, mediaType: "thought", importance: 1.5 },
         token,
       );
 
@@ -503,13 +503,13 @@ describe("Post GraphQL integration", () => {
       const result = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", body: "a".repeat(10001) },
+        { trackId, mediaType: "thought", body: "a".repeat(281) },
         token,
       );
 
       expect(result.errors).toBeDefined();
       expect(result.errors![0].message).toContain(
-        "Body must be 10000 characters or less",
+        "Body must be 280 characters or less",
       );
     });
   });
@@ -526,7 +526,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "Original" },
+        { trackId, mediaType: "article", title: "Original" },
         token,
       );
       const postId = (createResult.data!.createPost as { id: string }).id;
@@ -563,7 +563,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "Text Post" },
+        { trackId, mediaType: "article", title: "Text Post" },
         token,
       );
       const postId = (createResult.data!.createPost as { id: string }).id;
@@ -631,7 +631,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "Mine" },
+        { trackId, mediaType: "article", title: "Mine" },
         token,
       );
       const postId = (createResult.data!.createPost as { id: string }).id;
@@ -670,7 +670,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "Original" },
+        { trackId, mediaType: "article", title: "Original" },
         token,
       );
       const postId = (createResult.data!.createPost as { id: string }).id;
@@ -699,7 +699,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "Original" },
+        { trackId, mediaType: "article", title: "Original" },
         token,
       );
       const postId = (createResult.data!.createPost as { id: string }).id;
@@ -730,7 +730,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "ToDelete" },
+        { trackId, mediaType: "article", title: "ToDelete" },
         token,
       );
       const postId = (createResult.data!.createPost as { id: string }).id;
@@ -768,7 +768,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "NotYours" },
+        { trackId, mediaType: "article", title: "NotYours" },
         token,
       );
       const postId = (createResult.data!.createPost as { id: string }).id;
@@ -839,7 +839,7 @@ describe("Post GraphQL integration", () => {
       await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "Post A" },
+        { trackId, mediaType: "article", title: "Post A" },
         token,
       );
       await gql(
@@ -885,7 +885,7 @@ describe("Post GraphQL integration", () => {
       await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "Nested Post" },
+        { trackId, mediaType: "article", title: "Nested Post" },
         token,
       );
 
@@ -911,7 +911,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "With Relations" },
+        { trackId, mediaType: "article", title: "With Relations" },
         token,
       );
       const postId = (createResult.data!.createPost as { id: string }).id;
@@ -971,7 +971,7 @@ describe("Post GraphQL integration", () => {
       await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "Orphan A" },
+        { trackId, mediaType: "article", title: "Orphan A" },
         token,
       );
       await gql(
@@ -1022,7 +1022,7 @@ describe("Post GraphQL integration", () => {
       await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "User1 Post" },
+        { trackId, mediaType: "article", title: "User1 Post" },
         token1,
       );
       await gql(app, DELETE_TRACK_MUTATION_LOCAL, { id: trackId }, token1);
@@ -1046,7 +1046,7 @@ describe("Post GraphQL integration", () => {
       await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId, mediaType: "text", title: "Will Vanish" },
+        { trackId, mediaType: "article", title: "Will Vanish" },
         token,
       );
       await gql(app, DELETE_TRACK_MUTATION_LOCAL, { id: trackId }, token);
@@ -1063,7 +1063,7 @@ describe("Post GraphQL integration", () => {
       await gql(
         app,
         CREATE_POST_MUTATION,
-        { trackId: newTrackId, mediaType: "text", title: "Visible Post" },
+        { trackId: newTrackId, mediaType: "article", title: "Visible Post" },
         token,
       );
 
@@ -1122,7 +1122,7 @@ describe("Post GraphQL integration", () => {
       const result = await gql(
         app,
         CREATE_POST_WITH_HASH,
-        { trackId, mediaType: "text", title: "Hash Test", body: "Body" },
+        { trackId, mediaType: "article", title: "Hash Test", body: "Body" },
         token,
       );
 
@@ -1145,7 +1145,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_WITH_HASH,
-        { trackId, mediaType: "text", title: "Original" },
+        { trackId, mediaType: "article", title: "Original" },
         token,
       );
       const created = createResult.data!.createPost as Record<string, unknown>;
@@ -1208,7 +1208,7 @@ describe("Post GraphQL integration", () => {
         title: "Signed Post",
         body: null,
         mediaUrl: null,
-        mediaType: "text",
+        mediaType: "article",
         importance: 0.5,
       });
       const sigBuf = sign(null, Buffer.from(contentHash), testPrivKey);
@@ -1219,7 +1219,7 @@ describe("Post GraphQL integration", () => {
         CREATE_POST_WITH_HASH,
         {
           trackId,
-          mediaType: "text",
+          mediaType: "article",
           title: "Signed Post",
           signature: signatureB64,
         },
@@ -1245,7 +1245,7 @@ describe("Post GraphQL integration", () => {
         CREATE_POST_WITH_HASH,
         {
           trackId,
-          mediaType: "text",
+          mediaType: "article",
           title: "Bad Sig",
           signature:
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -1295,7 +1295,7 @@ describe("Post GraphQL integration", () => {
         title: "Signed Original",
         body: null,
         mediaUrl: null,
-        mediaType: "text",
+        mediaType: "article",
         importance: 0.5,
       });
       const { sign } = await import("node:crypto");
@@ -1307,7 +1307,7 @@ describe("Post GraphQL integration", () => {
         CREATE_POST_WITH_HASH,
         {
           trackId,
-          mediaType: "text",
+          mediaType: "article",
           title: "Signed Original",
           signature: signatureB64,
         },
@@ -1436,7 +1436,7 @@ describe("Post GraphQL integration", () => {
       const result = await gql(
         app,
         CREATE_POST_WITH_DURATION,
-        { trackId, mediaType: "text", duration: 3600 },
+        { trackId, mediaType: "thought", duration: 3600 },
         token,
       );
       expect(result.errors).toBeUndefined();
@@ -1491,7 +1491,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_WITH_DURATION,
-        { trackId, mediaType: "text", duration: 120 },
+        { trackId, mediaType: "thought", duration: 120 },
         token,
       );
       const postId = (createResult.data!.createPost as { id: string }).id;
@@ -1551,7 +1551,7 @@ describe("Post GraphQL integration", () => {
       const createResult = await gql(
         app,
         CREATE_POST_WITH_DURATION,
-        { trackId, mediaType: "text", duration: 120 },
+        { trackId, mediaType: "thought", duration: 120 },
         token,
       );
       const postId = (createResult.data!.createPost as { id: string }).id;

--- a/backend/src/graphql/__tests__/post.test.ts
+++ b/backend/src/graphql/__tests__/post.test.ts
@@ -512,6 +512,83 @@ describe("Post GraphQL integration", () => {
         "Body must be 280 characters or less",
       );
     });
+
+    it("rejects thought post with title", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "thoughttitle@example.com",
+        "thoughttitleuser",
+        "thoughttitleartist",
+      );
+      const result = await gql(
+        app,
+        CREATE_POST_MUTATION,
+        { trackId, mediaType: "thought", title: "Not allowed", body: "Hi" },
+        token,
+      );
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "Thought posts cannot have a title",
+      );
+    });
+
+    it("rejects thought post with delta bodyFormat", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "thoughtdelta@example.com",
+        "thoughtdeltauser",
+        "thoughtdeltaartist",
+      );
+      const THOUGHT_DELTA_MUTATION = `
+        mutation($trackId: String!, $mediaType: MediaType!, $body: String, $bodyFormat: String) {
+          createPost(trackId: $trackId, mediaType: $mediaType, body: $body, bodyFormat: $bodyFormat) { id }
+        }
+      `;
+      const result = await gql(
+        app,
+        THOUGHT_DELTA_MUTATION,
+        {
+          trackId,
+          mediaType: "thought",
+          body: '[{"insert":"hi"}]',
+          bodyFormat: "delta",
+        },
+        token,
+      );
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "Thought posts use plain text only (no rich text)",
+      );
+    });
+
+    it("rejects externalPublish on non-article type", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "thoughtext@example.com",
+        "thoughtextuser",
+        "thoughtextartist",
+      );
+      const EXT_PUBLISH_MUTATION = `
+        mutation($trackId: String!, $mediaType: MediaType!, $body: String, $externalPublish: Boolean) {
+          createPost(trackId: $trackId, mediaType: $mediaType, body: $body, externalPublish: $externalPublish) { id }
+        }
+      `;
+      const result = await gql(
+        app,
+        EXT_PUBLISH_MUTATION,
+        {
+          trackId,
+          mediaType: "thought",
+          body: "Hi",
+          externalPublish: true,
+        },
+        token,
+      );
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "externalPublish is only for article posts",
+      );
+    });
   });
 
   describe("updatePost", () => {

--- a/backend/src/graphql/__tests__/public-user.test.ts
+++ b/backend/src/graphql/__tests__/public-user.test.ts
@@ -220,7 +220,7 @@ describe("PublicUserType email exposure prevention", () => {
     const postResult = await gql(
       app,
       CREATE_POST_MUTATION,
-      { trackId, mediaType: "text" },
+      { trackId, mediaType: "thought" },
       token,
     );
     const postId = (postResult.data!.createPost as { id: string }).id;
@@ -267,7 +267,7 @@ describe("PublicUserType email exposure prevention", () => {
     const postResult = await gql(
       app,
       CREATE_POST_MUTATION,
-      { trackId, mediaType: "text" },
+      { trackId, mediaType: "thought" },
       token,
     );
     const postId = (postResult.data!.createPost as { id: string }).id;
@@ -313,7 +313,7 @@ describe("PublicUserType email exposure prevention", () => {
     const postResult = await gql(
       app,
       CREATE_POST_MUTATION,
-      { trackId, mediaType: "text" },
+      { trackId, mediaType: "thought" },
       token,
     );
     const postId = (postResult.data!.createPost as { id: string }).id;
@@ -353,7 +353,7 @@ describe("PublicUserType email exposure prevention", () => {
     const postResult = await gql(
       app,
       CREATE_POST_MUTATION,
-      { trackId, mediaType: "text" },
+      { trackId, mediaType: "thought" },
       token,
     );
     const postId = (postResult.data!.createPost as { id: string }).id;

--- a/backend/src/graphql/__tests__/reaction.test.ts
+++ b/backend/src/graphql/__tests__/reaction.test.ts
@@ -181,7 +181,7 @@ async function createPostForTest(
   const postResult = await gql(
     app,
     CREATE_POST_MUTATION,
-    { trackId, mediaType: "text" },
+    { trackId, mediaType: "thought" },
     token,
   );
   return (postResult.data!.createPost as { id: string }).id;

--- a/backend/src/graphql/types/post.ts
+++ b/backend/src/graphql/types/post.ts
@@ -495,9 +495,40 @@ builder.mutationFields((t) => ({
         throw new GraphQLError("Not authorized to update this post");
       }
 
+      // Effective media type (args override or existing)
+      const effectiveMediaType =
+        (args.mediaType as string | undefined) ?? post.mediaType;
+
       // Validate title
       if (args.title != null && args.title.length > 100) {
         throw new GraphQLError("Title must be 100 characters or less");
+      }
+
+      // Thought-specific validation
+      if (effectiveMediaType === "thought") {
+        if (args.title != null && args.title.trim() !== "") {
+          throw new GraphQLError("Thought posts cannot have a title");
+        }
+        if ((args.bodyFormat ?? post.bodyFormat) === "delta") {
+          throw new GraphQLError(
+            "Thought posts use plain text only (no rich text)",
+          );
+        }
+        if (args.articleGenre != null) {
+          throw new GraphQLError("articleGenre is only for article posts");
+        }
+      }
+
+      // Article-specific: externalPublish only when visibility is public
+      if (args.externalPublish && effectiveMediaType !== "article") {
+        throw new GraphQLError("externalPublish is only for article posts");
+      }
+      const effectiveVisibility =
+        (args.visibility as string | undefined) ?? post.visibility;
+      if (args.externalPublish && effectiveVisibility !== "public") {
+        throw new GraphQLError(
+          "externalPublish requires visibility to be public",
+        );
       }
 
       // Validate body + bodyFormat
@@ -552,8 +583,14 @@ builder.mutationFields((t) => ({
               }
               updateBodyValue = ops;
             } else {
-              if (args.body.length > 10000) {
-                throw new GraphQLError("Body must be 10000 characters or less");
+              const maxBody =
+                effectiveMediaType === "thought"
+                  ? MAX_THOUGHT_BODY_LENGTH
+                  : 10000;
+              if (args.body.length > maxBody) {
+                throw new GraphQLError(
+                  `Body must be ${maxBody} characters or less`,
+                );
               }
               updateBodyValue = args.body;
             }
@@ -688,7 +725,9 @@ builder.mutationFields((t) => ({
         args.mediaUrl !== undefined ||
         args.mediaType !== undefined ||
         args.importance !== undefined ||
-        args.duration !== undefined;
+        args.duration !== undefined ||
+        args.articleGenre !== undefined ||
+        args.clearArticleGenre;
 
       if (!contentChanged && args.signature !== undefined) {
         throw new GraphQLError(
@@ -723,6 +762,11 @@ builder.mutationFields((t) => ({
           importance:
             args.importance != null ? args.importance : post.importance,
           duration: args.duration !== undefined ? args.duration : post.duration,
+          articleGenre: args.clearArticleGenre
+            ? null
+            : args.articleGenre !== undefined
+              ? args.articleGenre
+              : post.articleGenre,
         });
 
         // Verify signature before committing any hash/signature to updateData

--- a/backend/src/graphql/types/post.ts
+++ b/backend/src/graphql/types/post.ts
@@ -527,6 +527,19 @@ builder.mutationFields((t) => ({
         if (effectiveGenre != null) {
           throw new GraphQLError("articleGenre is only for article posts");
         }
+        // Body length: check effective value (existing body may exceed 280 chars
+        // when mediaType is changed from article to thought without updating body)
+        const effectiveBody =
+          args.body !== undefined ? args.body : (post.body as string | null);
+        if (
+          effectiveBody != null &&
+          typeof effectiveBody === "string" &&
+          effectiveBody.length > MAX_THOUGHT_BODY_LENGTH
+        ) {
+          throw new GraphQLError(
+            `Body must be ${MAX_THOUGHT_BODY_LENGTH} characters or less`,
+          );
+        }
       }
 
       // externalPublish: effective value pattern

--- a/backend/src/graphql/types/post.ts
+++ b/backend/src/graphql/types/post.ts
@@ -20,8 +20,25 @@ import { fetchOgpMetadata } from "../../ogp/fetcher.js";
 const MEDIA_FILE_REQUIRED_TYPES = ["image", "video", "audio"];
 
 const MediaTypeEnum = builder.enumType("MediaType", {
-  values: ["text", "image", "video", "audio", "link"] as const,
+  values: ["thought", "article", "image", "video", "audio", "link"] as const,
 });
+
+const ArticleGenreEnum = builder.enumType("ArticleGenre", {
+  values: [
+    "fiction",
+    "poetry",
+    "essay",
+    "technical",
+    "opinion",
+    "diary",
+    "review",
+    "travel",
+    "other",
+  ] as const,
+});
+
+/** Maximum body length for thought posts (characters). */
+const MAX_THOUGHT_BODY_LENGTH = 280;
 
 /**
  * Fetch author's publicKey and verify an Ed25519 signature against a contentHash.
@@ -58,7 +75,7 @@ type PostShape = {
   id: string;
   trackId: string | null;
   authorId: string;
-  mediaType: "text" | "image" | "video" | "audio" | "link";
+  mediaType: "thought" | "article" | "image" | "video" | "audio" | "link";
   title: string | null;
   body: unknown; // jsonb: string (plain) or Delta ops array (delta)
   bodyFormat: string;
@@ -74,6 +91,8 @@ type PostShape = {
   ogImage: string | null;
   ogSiteName: string | null;
   ogFetchedAt: Date | null;
+  articleGenre: string | null;
+  externalPublish: boolean;
   eventAt: Date | null;
   layoutX: number;
   layoutY: number;
@@ -121,6 +140,13 @@ PostType.implement({
     ogDescription: t.exposeString("ogDescription", { nullable: true }),
     ogImage: t.exposeString("ogImage", { nullable: true }),
     ogSiteName: t.exposeString("ogSiteName", { nullable: true }),
+    articleGenre: t.field({
+      type: ArticleGenreEnum,
+      nullable: true,
+      resolve: (post) =>
+        post.articleGenre as (typeof ArticleGenreEnum)["$inferType"] | null,
+    }),
+    externalPublish: t.exposeBoolean("externalPublish"),
     eventAt: t.string({
       nullable: true,
       resolve: (post) => post.eventAt?.toISOString() ?? null,
@@ -178,6 +204,8 @@ builder.mutationFields((t) => ({
       importance: t.arg.float(),
       visibility: t.arg.string(),
       eventAt: t.arg.string(),
+      articleGenre: t.arg({ type: ArticleGenreEnum }),
+      externalPublish: t.arg.boolean(),
       layoutX: t.arg.int(),
       layoutY: t.arg.int(),
       signature: t.arg.string(),
@@ -213,6 +241,32 @@ builder.mutationFields((t) => ({
       // Validate title
       if (args.title != null && args.title.length > 100) {
         throw new GraphQLError("Title must be 100 characters or less");
+      }
+
+      // Thought-specific validation
+      if (args.mediaType === "thought") {
+        if (args.title != null && args.title.trim() !== "") {
+          throw new GraphQLError("Thought posts cannot have a title");
+        }
+        if (args.bodyFormat === "delta") {
+          throw new GraphQLError(
+            "Thought posts use plain text only (no rich text)",
+          );
+        }
+        if (args.articleGenre != null) {
+          throw new GraphQLError("articleGenre is only for article posts");
+        }
+      }
+
+      // Article-specific: externalPublish only when visibility is public
+      if (args.externalPublish && args.mediaType !== "article") {
+        throw new GraphQLError("externalPublish is only for article posts");
+      }
+      const effectiveVisibility = args.visibility ?? "public";
+      if (args.externalPublish && effectiveVisibility !== "public") {
+        throw new GraphQLError(
+          "externalPublish requires visibility to be public",
+        );
       }
 
       // Validate body + bodyFormat
@@ -260,14 +314,18 @@ builder.mutationFields((t) => ({
           }
           bodyValue = ops;
         } else {
-          if (args.body.length > 10000) {
-            throw new GraphQLError("Body must be 10000 characters or less");
+          const maxBody =
+            args.mediaType === "thought" ? MAX_THOUGHT_BODY_LENGTH : 10000;
+          if (args.body.length > maxBody) {
+            throw new GraphQLError(
+              `Body must be ${maxBody} characters or less`,
+            );
           }
           bodyValue = args.body;
         }
       }
 
-      // Require mediaUrl for image, video, audio types (not text or link)
+      // Require mediaUrl for image, video, audio types
       const mediaFileTypes = MEDIA_FILE_REQUIRED_TYPES;
       if (
         mediaFileTypes.includes(args.mediaType) &&
@@ -357,6 +415,12 @@ builder.mutationFields((t) => ({
           ...(args.importance != null ? { importance: args.importance } : {}),
           ...(args.layoutX != null ? { layoutX: args.layoutX } : {}),
           ...(args.layoutY != null ? { layoutY: args.layoutY } : {}),
+          ...(args.articleGenre != null
+            ? { articleGenre: args.articleGenre }
+            : {}),
+          ...(args.externalPublish != null
+            ? { externalPublish: args.externalPublish }
+            : {}),
         })
         .returning();
 
@@ -406,6 +470,9 @@ builder.mutationFields((t) => ({
       importance: t.arg.float(),
       visibility: t.arg.string(),
       eventAt: t.arg.string(),
+      articleGenre: t.arg({ type: ArticleGenreEnum }),
+      clearArticleGenre: t.arg.boolean(),
+      externalPublish: t.arg.boolean(),
       layoutX: t.arg.int(),
       layoutY: t.arg.int(),
       signature: t.arg.string(),
@@ -603,6 +670,11 @@ builder.mutationFields((t) => ({
         updateData.visibility = args.visibility;
       if (args.layoutX !== undefined) updateData.layoutX = args.layoutX;
       if (args.layoutY !== undefined) updateData.layoutY = args.layoutY;
+      if (args.articleGenre !== undefined)
+        updateData.articleGenre = args.articleGenre;
+      if (args.clearArticleGenre) updateData.articleGenre = null;
+      if (args.externalPublish !== undefined)
+        updateData.externalPublish = args.externalPublish;
 
       // Recompute contentHash if content fields changed.
       // layoutX/Y are presentation-only and intentionally excluded from the

--- a/backend/src/graphql/types/post.ts
+++ b/backend/src/graphql/types/post.ts
@@ -373,6 +373,7 @@ builder.mutationFields((t) => ({
         mediaType: args.mediaType,
         importance: args.importance ?? 0.5,
         duration: args.duration ?? null,
+        articleGenre: args.articleGenre ?? null,
       });
 
       // Signature is optional for MVP: clients that support Ed25519 signing
@@ -504,9 +505,12 @@ builder.mutationFields((t) => ({
         throw new GraphQLError("Title must be 100 characters or less");
       }
 
-      // Thought-specific validation
+      // Thought-specific validation (effective value pattern)
       if (effectiveMediaType === "thought") {
-        if (args.title != null && args.title.trim() !== "") {
+        // Title: check both args and existing
+        const effectiveTitle =
+          args.title !== undefined ? args.title : post.title;
+        if (effectiveTitle != null && effectiveTitle.trim() !== "") {
           throw new GraphQLError("Thought posts cannot have a title");
         }
         if ((args.bodyFormat ?? post.bodyFormat) === "delta") {
@@ -514,18 +518,28 @@ builder.mutationFields((t) => ({
             "Thought posts use plain text only (no rich text)",
           );
         }
-        if (args.articleGenre != null) {
+        // articleGenre: check both args and existing
+        const effectiveGenre = args.clearArticleGenre
+          ? null
+          : args.articleGenre !== undefined
+            ? args.articleGenre
+            : post.articleGenre;
+        if (effectiveGenre != null) {
           throw new GraphQLError("articleGenre is only for article posts");
         }
       }
 
-      // Article-specific: externalPublish only when visibility is public
-      if (args.externalPublish && effectiveMediaType !== "article") {
-        throw new GraphQLError("externalPublish is only for article posts");
-      }
+      // externalPublish: effective value pattern
+      const effectiveExternalPublish =
+        args.externalPublish !== undefined
+          ? args.externalPublish
+          : post.externalPublish;
       const effectiveVisibility =
         (args.visibility as string | undefined) ?? post.visibility;
-      if (args.externalPublish && effectiveVisibility !== "public") {
+      if (effectiveExternalPublish && effectiveMediaType !== "article") {
+        throw new GraphQLError("externalPublish is only for article posts");
+      }
+      if (effectiveExternalPublish && effectiveVisibility !== "public") {
         throw new GraphQLError(
           "externalPublish requires visibility to be public",
         );

--- a/frontend/lib/graphql/mutations/post.dart
+++ b/frontend/lib/graphql/mutations/post.dart
@@ -13,7 +13,9 @@ const createPostMutation =
     \$duration: Int,
     \$importance: Float,
     \$visibility: String,
-    \$eventAt: String
+    \$eventAt: String,
+    \$articleGenre: ArticleGenre,
+    \$externalPublish: Boolean
   ) {
     createPost(
       trackId: \$trackId,
@@ -26,7 +28,9 @@ const createPostMutation =
       duration: \$duration,
       importance: \$importance,
       visibility: \$visibility,
-      eventAt: \$eventAt
+      eventAt: \$eventAt,
+      articleGenre: \$articleGenre,
+      externalPublish: \$externalPublish
     ) {
       $postFields
     }
@@ -46,7 +50,10 @@ const updatePostMutation =
     \$duration: Int,
     \$importance: Float,
     \$visibility: String,
-    \$eventAt: String
+    \$eventAt: String,
+    \$articleGenre: ArticleGenre,
+    \$clearArticleGenre: Boolean,
+    \$externalPublish: Boolean
   ) {
     updatePost(
       id: \$id,
@@ -59,7 +66,10 @@ const updatePostMutation =
       duration: \$duration,
       importance: \$importance,
       visibility: \$visibility,
-      eventAt: \$eventAt
+      eventAt: \$eventAt,
+      articleGenre: \$articleGenre,
+      clearArticleGenre: \$clearArticleGenre,
+      externalPublish: \$externalPublish
     ) {
       $postFields
     }

--- a/frontend/lib/graphql/queries/post.dart
+++ b/frontend/lib/graphql/queries/post.dart
@@ -13,6 +13,8 @@ const postFields = '''
   layoutX
   layoutY
   contentHash
+  articleGenre
+  externalPublish
   ogTitle
   ogDescription
   ogImage

--- a/frontend/lib/models/post.dart
+++ b/frontend/lib/models/post.dart
@@ -42,7 +42,19 @@ enum ArticleGenre {
   diary,
   review,
   travel,
-  other,
+  other;
+
+  String get label => switch (this) {
+    fiction => 'Fiction',
+    poetry => 'Poetry',
+    essay => 'Essay',
+    technical => 'Technical',
+    opinion => 'Opinion',
+    diary => 'Diary',
+    review => 'Review',
+    travel => 'Travel',
+    other => 'Other',
+  };
 }
 
 class ReactionCount {

--- a/frontend/lib/models/post.dart
+++ b/frontend/lib/models/post.dart
@@ -31,7 +31,19 @@ class PostAuthor {
   }
 }
 
-enum MediaType { text, image, video, audio, link }
+enum MediaType { thought, article, image, video, audio, link }
+
+enum ArticleGenre {
+  fiction,
+  poetry,
+  essay,
+  technical,
+  opinion,
+  diary,
+  review,
+  travel,
+  other,
+}
 
 class ReactionCount {
   final String emoji;
@@ -148,6 +160,9 @@ class Post {
   final List<PostConnection> outgoingConnections;
   final List<PostConnection> incomingConnections;
   final PostConstellation? constellation;
+  // Article metadata
+  final ArticleGenre? articleGenre;
+  final bool externalPublish;
   // OGP metadata (link-type posts only)
   final String? ogTitle;
   final String? ogDescription;
@@ -181,6 +196,8 @@ class Post {
     this.outgoingConnections = const [],
     this.incomingConnections = const [],
     this.constellation,
+    this.articleGenre,
+    this.externalPublish = false,
     this.ogTitle,
     this.ogDescription,
     this.ogImage,
@@ -209,6 +226,8 @@ class Post {
     List<PostConnection>? outgoingConnections,
     List<PostConnection>? incomingConnections,
     Object? constellation = sentinel,
+    Object? articleGenre = sentinel,
+    Object? externalPublish = sentinel,
     Object? ogTitle = sentinel,
     Object? ogDescription = sentinel,
     Object? ogImage = sentinel,
@@ -251,6 +270,12 @@ class Post {
       constellation: constellation == sentinel
           ? this.constellation
           : constellation as PostConstellation?,
+      articleGenre: articleGenre == sentinel
+          ? this.articleGenre
+          : articleGenre as ArticleGenre?,
+      externalPublish: externalPublish == sentinel
+          ? this.externalPublish
+          : externalPublish as bool,
       ogTitle: ogTitle == sentinel ? this.ogTitle : ogTitle as String?,
       ogDescription: ogDescription == sentinel
           ? this.ogDescription
@@ -377,6 +402,8 @@ class Post {
               json['constellation'] as Map<String, dynamic>,
             )
           : null,
+      articleGenre: _parseArticleGenre(json['articleGenre'] as String?),
+      externalPublish: json['externalPublish'] as bool? ?? false,
       ogTitle: json['ogTitle'] as String?,
       ogDescription: json['ogDescription'] as String?,
       ogImage: json['ogImage'] as String?,
@@ -386,10 +413,20 @@ class Post {
 }
 
 MediaType _parseMediaType(String value) {
+  // Backward compatibility: 'text' → 'article'
+  if (value == 'text') return MediaType.article;
   for (final type in MediaType.values) {
     if (type.name == value) return type;
   }
-  return MediaType.text;
+  return MediaType.article;
+}
+
+ArticleGenre? _parseArticleGenre(String? value) {
+  if (value == null) return null;
+  for (final genre in ArticleGenre.values) {
+    if (genre.name == value) return genre;
+  }
+  return null;
 }
 
 /// Parse Delta ops from body string when bodyFormat is 'delta'.

--- a/frontend/lib/providers/create_post_provider.dart
+++ b/frontend/lib/providers/create_post_provider.dart
@@ -21,6 +21,8 @@ class CreatePostState {
   final bool isSubmitting;
   final String? error;
   final List<PendingConnection> selectedConnections;
+  final ArticleGenre? articleGenre;
+  final bool externalPublish;
 
   const CreatePostState({
     this.step = 0,
@@ -31,6 +33,8 @@ class CreatePostState {
     this.isSubmitting = false,
     this.error,
     this.selectedConnections = const [],
+    this.articleGenre,
+    this.externalPublish = false,
   });
 
   CreatePostState copyWith({
@@ -42,6 +46,8 @@ class CreatePostState {
     bool? isSubmitting,
     Object? error = sentinel,
     List<PendingConnection>? selectedConnections,
+    Object? articleGenre = sentinel,
+    bool? externalPublish,
   }) {
     return CreatePostState(
       step: step ?? this.step,
@@ -56,6 +62,10 @@ class CreatePostState {
       isSubmitting: isSubmitting ?? this.isSubmitting,
       error: error == sentinel ? this.error : error as String?,
       selectedConnections: selectedConnections ?? this.selectedConnections,
+      articleGenre: articleGenre == sentinel
+          ? this.articleGenre
+          : articleGenre as ArticleGenre?,
+      externalPublish: externalPublish ?? this.externalPublish,
     );
   }
 }
@@ -162,6 +172,9 @@ class CreatePostNotifier extends Notifier<CreatePostState>
             if (eventAt != null) 'eventAt': eventAt.toIso8601String(),
             'importance': state.importance,
             'visibility': state.visibility,
+            if (state.articleGenre != null)
+              'articleGenre': state.articleGenre!.name,
+            if (state.externalPublish) 'externalPublish': true,
           },
         ),
       );

--- a/frontend/lib/providers/create_post_provider.dart
+++ b/frontend/lib/providers/create_post_provider.dart
@@ -95,6 +95,18 @@ class CreatePostNotifier extends Notifier<CreatePostState>
 
   void setVisibility(String value) {
     state = state.copyWith(visibility: value);
+    // Clear externalPublish when switching to draft
+    if (value != 'public' && state.externalPublish) {
+      state = state.copyWith(externalPublish: false);
+    }
+  }
+
+  void setArticleGenre(ArticleGenre? genre) {
+    state = state.copyWith(articleGenre: genre);
+  }
+
+  void setExternalPublish(bool value) {
+    state = state.copyWith(externalPublish: value);
   }
 
   void addConnection(Post post, ConnectionType connectionType) {

--- a/frontend/lib/providers/timeline_provider.dart
+++ b/frontend/lib/providers/timeline_provider.dart
@@ -558,6 +558,9 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
     bool clearEventAt = false,
     double? importance,
     String? visibility,
+    String? articleGenre,
+    bool clearArticleGenre = false,
+    bool? externalPublish,
   }) async {
     if (thumbnailUrl != null && clearThumbnail) {
       debugPrint(
@@ -602,6 +605,9 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
             if (eventAt != null) 'eventAt': eventAt,
             if (clearEventAt) 'eventAt': null,
             if (importance != null) 'importance': importance,
+            if (articleGenre != null) 'articleGenre': articleGenre,
+            if (clearArticleGenre) 'clearArticleGenre': true,
+            if (externalPublish != null) 'externalPublish': externalPublish,
           },
         ),
       );

--- a/frontend/lib/providers/unassigned_posts_provider.dart
+++ b/frontend/lib/providers/unassigned_posts_provider.dart
@@ -66,6 +66,9 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
     bool clearEventAt = false,
     double? importance,
     String? visibility,
+    String? articleGenre,
+    bool clearArticleGenre = false,
+    bool? externalPublish,
   }) async {
     if (thumbnailUrl != null && clearThumbnail) {
       debugPrint(
@@ -104,6 +107,9 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
             if (clearEventAt) 'eventAt': null,
             if (importance != null) 'importance': importance,
             if (visibility != null) 'visibility': visibility,
+            if (articleGenre != null) 'articleGenre': articleGenre,
+            if (clearArticleGenre) 'clearArticleGenre': true,
+            if (externalPublish != null) 'externalPublish': externalPublish,
           },
         ),
       );

--- a/frontend/lib/screens/artist/artist_page_screen.dart
+++ b/frontend/lib/screens/artist/artist_page_screen.dart
@@ -1239,7 +1239,8 @@ class _RecentPostCard extends StatelessWidget {
 
   static IconData _mediaIcon(MediaType type) {
     return switch (type) {
-      MediaType.text => Icons.article_outlined,
+      MediaType.thought => Icons.chat_bubble_outline,
+      MediaType.article => Icons.description_outlined,
       MediaType.image => Icons.image_outlined,
       MediaType.video => Icons.videocam_outlined,
       MediaType.audio => Icons.headphones_outlined,

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -1533,18 +1533,6 @@ class _ArticleGenrePicker extends StatelessWidget {
   final WidgetRef ref;
   const _ArticleGenrePicker({required this.ref});
 
-  static const _genreLabels = {
-    ArticleGenre.fiction: 'Fiction',
-    ArticleGenre.poetry: 'Poetry',
-    ArticleGenre.essay: 'Essay',
-    ArticleGenre.technical: 'Technical',
-    ArticleGenre.opinion: 'Opinion',
-    ArticleGenre.diary: 'Diary',
-    ArticleGenre.review: 'Review',
-    ArticleGenre.travel: 'Travel',
-    ArticleGenre.other: 'Other',
-  };
-
   @override
   Widget build(BuildContext context) {
     final selected = ref.watch(
@@ -1570,7 +1558,7 @@ class _ArticleGenrePicker extends StatelessWidget {
             final isSelected = genre == selected;
             return ChoiceChip(
               label: Text(
-                _genreLabels[genre] ?? genre.name,
+                genre.label,
                 style: TextStyle(
                   fontSize: fontSizeSm,
                   color: isSelected ? colorSurface0 : colorTextSecondary,

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -83,10 +83,11 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     if (!_formKey.currentState!.validate()) return;
     if (ref.read(mediaUploadProvider).isUploading) return;
 
-    // Require media file for non-text types
+    // Require media file for media types (not thought/article/link)
     final mediaType = ref.read(createPostProvider).selectedMediaType;
     if (mediaType != null &&
-        mediaType != MediaType.text &&
+        mediaType != MediaType.article &&
+        mediaType != MediaType.thought &&
         _mediaUrlController.text.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -97,12 +98,12 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
       return;
     }
 
-    // For text type, use Quill Delta; for others, use plain body
-    final isTextType =
-        ref.read(createPostProvider).selectedMediaType == MediaType.text;
+    // Article: use Quill Delta; Thought + others: use plain body
+    final isArticle =
+        ref.read(createPostProvider).selectedMediaType == MediaType.article;
     String? bodyValue;
     String? bodyFormat;
-    if (isTextType) {
+    if (isArticle) {
       final delta = _quillController.document.toDelta().toJson();
       bodyValue = jsonEncode(delta);
       bodyFormat = 'delta';
@@ -421,7 +422,8 @@ class _MediaTypeStep extends ConsumerWidget {
   const _MediaTypeStep();
 
   static const _mediaTypeOptions = [
-    (MediaType.text, Icons.article, 'Text'),
+    (MediaType.thought, Icons.chat_bubble_outline, 'Thought'),
+    (MediaType.article, Icons.description_outlined, 'Article'),
     (MediaType.image, Icons.image, 'Image'),
     (MediaType.video, Icons.videocam, 'Video'),
     (MediaType.audio, Icons.audiotrack, 'Audio'),
@@ -729,7 +731,9 @@ class _FormStep extends ConsumerWidget {
     WidgetRef ref,
   ) {
     switch (mediaType) {
-      case MediaType.text:
+      case MediaType.thought:
+        return _buildThoughtFields(theme);
+      case MediaType.article:
         return _buildTextFields(theme);
       case MediaType.image:
       case MediaType.video:
@@ -740,7 +744,40 @@ class _FormStep extends ConsumerWidget {
     }
   }
 
-  // text: title (optional) + rich text editor
+  // thought: plain text body only, 280 char limit, no title
+  List<Widget> _buildThoughtFields(ThemeData theme) {
+    return [
+      Container(
+        decoration: BoxDecoration(
+          color: colorSurface1,
+          borderRadius: BorderRadius.circular(radiusLg),
+          border: Border.all(color: colorBorder),
+        ),
+        child: TextField(
+          controller: bodyController,
+          maxLines: 6,
+          maxLength: 280,
+          style: const TextStyle(
+            color: colorTextPrimary,
+            fontSize: fontSizeMd,
+            height: 1.5,
+          ),
+          decoration: const InputDecoration(
+            hintText: "What's on your mind?",
+            hintStyle: TextStyle(color: colorInteractiveMuted),
+            border: InputBorder.none,
+            contentPadding: EdgeInsets.all(spaceLg),
+            counterStyle: TextStyle(
+              color: colorTextMuted,
+              fontSize: fontSizeXs,
+            ),
+          ),
+        ),
+      ),
+    ];
+  }
+
+  // article: title (optional) + rich text editor
   List<Widget> _buildTextFields(ThemeData theme) {
     return [
       Container(
@@ -1477,7 +1514,8 @@ class _TagPill extends StatelessWidget {
 
 IconData _mediaTypeIcon(MediaType type) {
   return switch (type) {
-    MediaType.text => Icons.text_fields,
+    MediaType.thought => Icons.chat_bubble_outline,
+    MediaType.article => Icons.text_fields,
     MediaType.image => Icons.image_outlined,
     MediaType.video => Icons.videocam_outlined,
     MediaType.audio => Icons.headphones_outlined,

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -734,7 +734,7 @@ class _FormStep extends ConsumerWidget {
       case MediaType.thought:
         return _buildThoughtFields(theme);
       case MediaType.article:
-        return _buildTextFields(theme);
+        return _buildTextFields(theme, ref);
       case MediaType.image:
       case MediaType.video:
       case MediaType.audio:
@@ -778,7 +778,7 @@ class _FormStep extends ConsumerWidget {
   }
 
   // article: title (optional) + rich text editor
-  List<Widget> _buildTextFields(ThemeData theme) {
+  List<Widget> _buildTextFields(ThemeData theme, WidgetRef ref) {
     return [
       Container(
         decoration: const BoxDecoration(
@@ -825,6 +825,11 @@ class _FormStep extends ConsumerWidget {
       // Character count for text body
       TextBodyCounter(controller: quillController),
       const SizedBox(height: spaceMd),
+      // Article genre picker
+      _ArticleGenrePicker(ref: ref),
+      const SizedBox(height: spaceMd),
+      // External publish toggle (only when visibility is public)
+      _ExternalPublishToggle(ref: ref),
     ];
   }
 
@@ -1521,4 +1526,120 @@ IconData _mediaTypeIcon(MediaType type) {
     MediaType.audio => Icons.headphones_outlined,
     MediaType.link => Icons.link,
   };
+}
+
+/// Genre picker for article posts.
+class _ArticleGenrePicker extends StatelessWidget {
+  final WidgetRef ref;
+  const _ArticleGenrePicker({required this.ref});
+
+  static const _genreLabels = {
+    ArticleGenre.fiction: 'Fiction',
+    ArticleGenre.poetry: 'Poetry',
+    ArticleGenre.essay: 'Essay',
+    ArticleGenre.technical: 'Technical',
+    ArticleGenre.opinion: 'Opinion',
+    ArticleGenre.diary: 'Diary',
+    ArticleGenre.review: 'Review',
+    ArticleGenre.travel: 'Travel',
+    ArticleGenre.other: 'Other',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = ref.watch(
+      createPostProvider.select((s) => s.articleGenre),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Genre',
+          style: TextStyle(
+            color: colorTextMuted,
+            fontSize: fontSizeSm,
+            fontWeight: weightSemibold,
+          ),
+        ),
+        const SizedBox(height: spaceXs),
+        Wrap(
+          spacing: spaceSm,
+          runSpacing: spaceXs,
+          children: ArticleGenre.values.map((genre) {
+            final isSelected = genre == selected;
+            return ChoiceChip(
+              label: Text(
+                _genreLabels[genre] ?? genre.name,
+                style: TextStyle(
+                  fontSize: fontSizeSm,
+                  color: isSelected ? colorSurface0 : colorTextSecondary,
+                ),
+              ),
+              selected: isSelected,
+              selectedColor: colorAccentGold,
+              backgroundColor: colorSurface1,
+              side: BorderSide(
+                color: isSelected ? colorAccentGold : colorBorder,
+              ),
+              onSelected: (on) {
+                ref
+                    .read(createPostProvider.notifier)
+                    .setArticleGenre(on ? genre : null);
+              },
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}
+
+/// External publish toggle for article posts (only when visibility is public).
+class _ExternalPublishToggle extends StatelessWidget {
+  final WidgetRef ref;
+  const _ExternalPublishToggle({required this.ref});
+
+  @override
+  Widget build(BuildContext context) {
+    final visibility = ref.watch(
+      createPostProvider.select((s) => s.visibility),
+    );
+    final externalPublish = ref.watch(
+      createPostProvider.select((s) => s.externalPublish),
+    );
+
+    if (visibility != 'public') return const SizedBox.shrink();
+
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Publish externally',
+                style: TextStyle(
+                  color: colorTextSecondary,
+                  fontSize: fontSizeSm,
+                  fontWeight: weightMedium,
+                ),
+              ),
+              const SizedBox(height: spaceXxs),
+              Text(
+                'Make available on the public article site',
+                style: TextStyle(color: colorTextMuted, fontSize: fontSizeXs),
+              ),
+            ],
+          ),
+        ),
+        Switch(
+          value: externalPublish,
+          activeColor: colorAccentGold,
+          onChanged: (v) =>
+              ref.read(createPostProvider.notifier).setExternalPublish(v),
+        ),
+      ],
+    );
+  }
 }

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -826,10 +826,10 @@ class _FormStep extends ConsumerWidget {
       TextBodyCounter(controller: quillController),
       const SizedBox(height: spaceMd),
       // Article genre picker
-      _ArticleGenrePicker(ref: ref),
+      const _ArticleGenrePicker(),
       const SizedBox(height: spaceMd),
       // External publish toggle (only when visibility is public)
-      _ExternalPublishToggle(ref: ref),
+      const _ExternalPublishToggle(),
       const SizedBox(height: spaceLg),
     ];
   }
@@ -1530,12 +1530,11 @@ IconData _mediaTypeIcon(MediaType type) {
 }
 
 /// Genre picker for article posts.
-class _ArticleGenrePicker extends StatelessWidget {
-  final WidgetRef ref;
-  const _ArticleGenrePicker({required this.ref});
+class _ArticleGenrePicker extends ConsumerWidget {
+  const _ArticleGenrePicker();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final selected = ref.watch(
       createPostProvider.select((s) => s.articleGenre),
     );
@@ -1585,12 +1584,11 @@ class _ArticleGenrePicker extends StatelessWidget {
 }
 
 /// External publish toggle for article posts (only when visibility is public).
-class _ExternalPublishToggle extends StatelessWidget {
-  final WidgetRef ref;
-  const _ExternalPublishToggle({required this.ref});
+class _ExternalPublishToggle extends ConsumerWidget {
+  const _ExternalPublishToggle();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final visibility = ref.watch(
       createPostProvider.select((s) => s.visibility),
     );

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -830,6 +830,7 @@ class _FormStep extends ConsumerWidget {
       const SizedBox(height: spaceMd),
       // External publish toggle (only when visibility is public)
       _ExternalPublishToggle(ref: ref),
+      const SizedBox(height: spaceLg),
     ];
   }
 

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -76,7 +76,7 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
         document: Document.fromJson(widget.post.bodyDelta!),
         selection: const TextSelection.collapsed(offset: 0),
       );
-    } else if (widget.post.mediaType == MediaType.text &&
+    } else if (widget.post.mediaType == MediaType.article &&
         widget.post.body != null) {
       // Convert plain text to Delta for editing
       _quillController = QuillController(
@@ -113,7 +113,7 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
     if (!_formKey.currentState!.validate()) return;
 
     // Prevent clearing media file for non-text types
-    if (widget.post.mediaType != MediaType.text &&
+    if (widget.post.mediaType != MediaType.article &&
         _mediaUrlController.text.trim().isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -135,7 +135,7 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
     // For text type, use Quill Delta; for others, use plain body
     String body;
     String? bodyFormat;
-    if (widget.post.mediaType == MediaType.text) {
+    if (widget.post.mediaType == MediaType.article) {
       final delta = _quillController.document.toDelta().toJson();
       body = jsonEncode(delta);
       bodyFormat = 'delta';
@@ -394,7 +394,9 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
 
   List<Widget> _buildContentFields() {
     switch (widget.post.mediaType) {
-      case MediaType.text:
+      case MediaType.thought:
+        return _buildTextFields(); // thought edit uses same plain text field
+      case MediaType.article:
         return _buildTextFields();
       case MediaType.image:
       case MediaType.video:

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -112,8 +112,9 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
 
-    // Prevent clearing media file for non-text types
+    // Prevent clearing media file for media types (not thought/article/link)
     if (widget.post.mediaType != MediaType.article &&
+        widget.post.mediaType != MediaType.thought &&
         _mediaUrlController.text.trim().isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -132,7 +133,7 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
     final title = _titleController.text.trim();
     final mediaUrl = _mediaUrlController.text.trim();
 
-    // For text type, use Quill Delta; for others, use plain body
+    // Article: use Quill Delta; Thought + others: use plain body
     String body;
     String? bodyFormat;
     if (widget.post.mediaType == MediaType.article) {
@@ -395,7 +396,7 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
   List<Widget> _buildContentFields() {
     switch (widget.post.mediaType) {
       case MediaType.thought:
-        return _buildTextFields(); // thought edit uses same plain text field
+        return _buildThoughtFields();
       case MediaType.article:
         return _buildTextFields();
       case MediaType.image:
@@ -405,6 +406,38 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
       case MediaType.link:
         return _buildLinkFields();
     }
+  }
+
+  List<Widget> _buildThoughtFields() {
+    return [
+      Container(
+        decoration: BoxDecoration(
+          color: colorSurface1,
+          borderRadius: BorderRadius.circular(radiusLg),
+          border: Border.all(color: colorBorder),
+        ),
+        child: TextField(
+          controller: _bodyController,
+          maxLines: 6,
+          maxLength: 280,
+          style: const TextStyle(
+            color: colorTextPrimary,
+            fontSize: fontSizeMd,
+            height: 1.5,
+          ),
+          decoration: const InputDecoration(
+            hintText: "What's on your mind?",
+            hintStyle: TextStyle(color: colorInteractiveMuted),
+            border: InputBorder.none,
+            contentPadding: EdgeInsets.all(spaceLg),
+            counterStyle: TextStyle(
+              color: colorTextMuted,
+              fontSize: fontSizeXs,
+            ),
+          ),
+        ),
+      ),
+    ];
   }
 
   List<Widget> _buildTextFields() {

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -501,6 +501,7 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
       const SizedBox(height: spaceMd),
       // External publish toggle
       _buildExternalPublishToggle(),
+      const SizedBox(height: spaceLg),
     ];
   }
 

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -505,18 +505,6 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
   }
 
   Widget _buildArticleGenrePicker() {
-    const genreLabels = {
-      ArticleGenre.fiction: 'Fiction',
-      ArticleGenre.poetry: 'Poetry',
-      ArticleGenre.essay: 'Essay',
-      ArticleGenre.technical: 'Technical',
-      ArticleGenre.opinion: 'Opinion',
-      ArticleGenre.diary: 'Diary',
-      ArticleGenre.review: 'Review',
-      ArticleGenre.travel: 'Travel',
-      ArticleGenre.other: 'Other',
-    };
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -536,7 +524,7 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
             final isSelected = genre == _articleGenre;
             return ChoiceChip(
               label: Text(
-                genreLabels[genre] ?? genre.name,
+                genre.label,
                 style: TextStyle(
                   fontSize: fontSizeSm,
                   color: isSelected ? colorSurface0 : colorTextSecondary,

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -56,6 +56,8 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
   String? _thumbnailUrl;
   int? _durationSeconds;
   DateTime? _eventAt;
+  ArticleGenre? _articleGenre;
+  late bool _externalPublish;
   // IME-safe FocusNodes — block Tab during composition
   late final FocusNode _titleFocusNode;
   late final FocusNode _bodyFocusNode;
@@ -95,6 +97,8 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
     _thumbnailUrl = widget.post.thumbnailUrl;
     _durationSeconds = widget.post.duration;
     _eventAt = widget.post.eventAt;
+    _articleGenre = widget.post.articleGenre;
+    _externalPublish = widget.post.externalPublish;
   }
 
   @override
@@ -175,6 +179,10 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
             clearEventAt: _eventAt == null && widget.post.eventAt != null,
             importance: _importance,
             visibility: _visibility,
+            articleGenre: _articleGenre?.name,
+            clearArticleGenre:
+                _articleGenre == null && widget.post.articleGenre != null,
+            externalPublish: _externalPublish,
           );
     } else {
       updated = await ref
@@ -196,6 +204,10 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
             clearEventAt: _eventAt == null && widget.post.eventAt != null,
             importance: _importance,
             visibility: _visibility,
+            articleGenre: _articleGenre?.name,
+            clearArticleGenre:
+                _articleGenre == null && widget.post.articleGenre != null,
+            externalPublish: _externalPublish,
           );
     }
 
@@ -483,7 +495,101 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
         ),
       ),
       TextBodyCounter(controller: _quillController),
+      const SizedBox(height: spaceMd),
+      // Article genre picker
+      _buildArticleGenrePicker(),
+      const SizedBox(height: spaceMd),
+      // External publish toggle
+      _buildExternalPublishToggle(),
     ];
+  }
+
+  Widget _buildArticleGenrePicker() {
+    const genreLabels = {
+      ArticleGenre.fiction: 'Fiction',
+      ArticleGenre.poetry: 'Poetry',
+      ArticleGenre.essay: 'Essay',
+      ArticleGenre.technical: 'Technical',
+      ArticleGenre.opinion: 'Opinion',
+      ArticleGenre.diary: 'Diary',
+      ArticleGenre.review: 'Review',
+      ArticleGenre.travel: 'Travel',
+      ArticleGenre.other: 'Other',
+    };
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Genre',
+          style: TextStyle(
+            color: colorTextMuted,
+            fontSize: fontSizeSm,
+            fontWeight: weightSemibold,
+          ),
+        ),
+        const SizedBox(height: spaceXs),
+        Wrap(
+          spacing: spaceSm,
+          runSpacing: spaceXs,
+          children: ArticleGenre.values.map((genre) {
+            final isSelected = genre == _articleGenre;
+            return ChoiceChip(
+              label: Text(
+                genreLabels[genre] ?? genre.name,
+                style: TextStyle(
+                  fontSize: fontSizeSm,
+                  color: isSelected ? colorSurface0 : colorTextSecondary,
+                ),
+              ),
+              selected: isSelected,
+              selectedColor: colorAccentGold,
+              backgroundColor: colorSurface1,
+              side: BorderSide(
+                color: isSelected ? colorAccentGold : colorBorder,
+              ),
+              onSelected: (on) {
+                setState(() => _articleGenre = on ? genre : null);
+              },
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildExternalPublishToggle() {
+    if (_visibility != 'public') return const SizedBox.shrink();
+
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const [
+              Text(
+                'Publish externally',
+                style: TextStyle(
+                  color: colorTextSecondary,
+                  fontSize: fontSizeSm,
+                  fontWeight: weightMedium,
+                ),
+              ),
+              SizedBox(height: spaceXxs),
+              Text(
+                'Make available on the public article site',
+                style: TextStyle(color: colorTextMuted, fontSize: fontSizeXs),
+              ),
+            ],
+          ),
+        ),
+        Switch(
+          value: _externalPublish,
+          activeColor: colorAccentGold,
+          onChanged: (v) => setState(() => _externalPublish = v),
+        ),
+      ],
+    );
   }
 
   List<Widget> _buildMediaFields() {

--- a/frontend/lib/screens/unassigned_posts/unassigned_posts_screen.dart
+++ b/frontend/lib/screens/unassigned_posts/unassigned_posts_screen.dart
@@ -240,7 +240,8 @@ class _PostTile extends StatelessWidget {
 
   static IconData _mediaTypeIcon(MediaType type) {
     return switch (type) {
-      MediaType.text => Icons.article_outlined,
+      MediaType.thought => Icons.chat_bubble_outline,
+      MediaType.article => Icons.description_outlined,
       MediaType.image => Icons.image_outlined,
       MediaType.video => Icons.videocam_outlined,
       MediaType.audio => Icons.headphones_outlined,

--- a/frontend/lib/widgets/common/related_post_picker.dart
+++ b/frontend/lib/widgets/common/related_post_picker.dart
@@ -273,7 +273,8 @@ class _TrackFilterChip extends StatelessWidget {
 
 IconData _mediaTypeIcon(MediaType type) {
   return switch (type) {
-    MediaType.text => Icons.article,
+    MediaType.thought => Icons.chat_bubble_outline,
+    MediaType.article => Icons.description_outlined,
     MediaType.image => Icons.image,
     MediaType.video => Icons.videocam,
     MediaType.audio => Icons.audiotrack,

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -13,7 +13,7 @@ import 'seed_art_painter.dart';
 /// Border radius by media type.
 BorderRadius _borderForType(MediaType type) {
   return switch (type) {
-    MediaType.thought => BorderRadius.circular(radiusFull),
+    MediaType.thought => BorderRadius.circular(radiusXl),
     MediaType.article => BorderRadius.circular(radiusMd),
     MediaType.image => BorderRadius.circular(radiusXl),
     MediaType.video => const BorderRadius.only(
@@ -310,26 +310,73 @@ class _ThoughtContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final post = (node.item as PostItem).post;
     final preview = post.plainTextPreview ?? '';
+    final isLarge = node.nodeSize > 110;
 
-    return Container(
-      padding: const EdgeInsets.all(spaceSm),
-      decoration: BoxDecoration(
-        color: trackColor.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(radiusFull),
-      ),
-      child: Center(
-        child: Text(
-          preview,
-          style: TextStyle(
-            color: colorTextSecondary,
-            fontSize: node.nodeSize > 110 ? fontSizeSm : fontSizeXs,
-            height: 1.3,
+    return Stack(
+      children: [
+        // Bubble body
+        Container(
+          padding: EdgeInsets.all(isLarge ? spaceMd : spaceSm),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                trackColor.withValues(alpha: 0.06),
+                trackColor.withValues(alpha: 0.12),
+              ],
+            ),
+            borderRadius: BorderRadius.circular(radiusXl),
+            border: Border.all(
+              color: trackColor.withValues(alpha: 0.15),
+              width: 0.5,
+            ),
           ),
-          maxLines: node.nodeSize > 110 ? 5 : 3,
-          overflow: TextOverflow.ellipsis,
-          textAlign: TextAlign.center,
+          child: Center(
+            child: Text(
+              preview,
+              style: TextStyle(
+                color: colorTextPrimary.withValues(alpha: 0.85),
+                fontSize: isLarge ? fontSizeSm : fontSizeXs,
+                height: 1.4,
+                fontStyle: FontStyle.italic,
+              ),
+              maxLines: isLarge ? 5 : 3,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+            ),
+          ),
         ),
-      ),
+        // Bubble tail (small circle at bottom-left)
+        Positioned(
+          bottom: 2,
+          left: isLarge ? spaceMd : spaceSm,
+          child: Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(
+              color: trackColor.withValues(alpha: 0.10),
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: trackColor.withValues(alpha: 0.15),
+                width: 0.5,
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          bottom: -2,
+          left: isLarge ? spaceSm : spaceXs,
+          child: Container(
+            width: 4,
+            height: 4,
+            decoration: BoxDecoration(
+              color: trackColor.withValues(alpha: 0.08),
+              shape: BoxShape.circle,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -312,66 +312,99 @@ class _ThoughtContent extends StatelessWidget {
     final preview = post.plainTextPreview ?? '';
     final isLarge = node.nodeSize > 110;
 
-    final bubbleColor = trackColor.withValues(alpha: 0.12);
+    final pad = isLarge ? spaceMd : spaceSm;
+    const tailH = 8.0;
 
-    return CustomPaint(
-      painter: _BubbleTailPainter(color: bubbleColor),
-      child: Container(
-        padding: EdgeInsets.fromLTRB(
-          isLarge ? spaceMd : spaceSm,
-          isLarge ? spaceMd : spaceSm,
-          isLarge ? spaceMd : spaceSm,
-          (isLarge ? spaceMd : spaceSm) + 10,
+    return Container(
+      padding: EdgeInsets.fromLTRB(pad, pad, pad, pad + tailH),
+      decoration: ShapeDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            trackColor.withValues(alpha: 0.06),
+            trackColor.withValues(alpha: 0.12),
+          ],
         ),
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [trackColor.withValues(alpha: 0.06), bubbleColor],
-          ),
-          borderRadius: BorderRadius.circular(radiusXl),
-          border: Border.all(
-            color: trackColor.withValues(alpha: 0.15),
-            width: 0.5,
-          ),
+        shape: _BubbleShapeBorder(
+          borderColor: trackColor.withValues(alpha: 0.15),
+          radius: radiusXl,
+          tailHeight: tailH,
         ),
-        child: Center(
-          child: Text(
-            preview,
-            style: TextStyle(
-              color: colorTextPrimary.withValues(alpha: 0.85),
-              fontSize: isLarge ? fontSizeSm : fontSizeXs,
-              height: 1.4,
-              fontStyle: FontStyle.italic,
-            ),
-            maxLines: isLarge ? 5 : 3,
-            overflow: TextOverflow.ellipsis,
-            textAlign: TextAlign.center,
+      ),
+      child: Center(
+        child: Text(
+          preview,
+          style: TextStyle(
+            color: colorTextPrimary.withValues(alpha: 0.85),
+            fontSize: isLarge ? fontSizeSm : fontSizeXs,
+            height: 1.4,
+            fontStyle: FontStyle.italic,
           ),
+          maxLines: isLarge ? 5 : 3,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.center,
         ),
       ),
     );
   }
 }
 
-/// Paints a small triangular tail at the bottom-left of the thought bubble.
-class _BubbleTailPainter extends CustomPainter {
-  final Color color;
-  const _BubbleTailPainter({required this.color});
+/// Speech-bubble shape: rounded rectangle with a small tail at bottom-left.
+class _BubbleShapeBorder extends ShapeBorder {
+  final Color borderColor;
+  final double radius;
+  final double tailHeight;
+
+  const _BubbleShapeBorder({
+    required this.borderColor,
+    required this.radius,
+    required this.tailHeight,
+  });
 
   @override
-  void paint(Canvas canvas, Size size) {
-    final paint = Paint()..color = color;
+  EdgeInsetsGeometry get dimensions => EdgeInsets.zero;
+
+  Path _buildPath(Rect rect) {
+    final bodyRect = Rect.fromLTRB(
+      rect.left,
+      rect.top,
+      rect.right,
+      rect.bottom - tailHeight,
+    );
     final path = Path()
-      ..moveTo(14, size.height - 10)
-      ..lineTo(8, size.height)
-      ..lineTo(22, size.height - 6)
+      ..addRRect(RRect.fromRectAndRadius(bodyRect, Radius.circular(radius)));
+
+    // Tail: small triangle at bottom-left
+    final tailLeft = rect.left + 16.0;
+    path
+      ..moveTo(tailLeft, bodyRect.bottom)
+      ..lineTo(tailLeft - 2, rect.bottom)
+      ..lineTo(tailLeft + 10, bodyRect.bottom)
       ..close();
-    canvas.drawPath(path, paint);
+
+    return path;
   }
 
   @override
-  bool shouldRepaint(_BubbleTailPainter old) => color != old.color;
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) =>
+      _buildPath(rect);
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) =>
+      _buildPath(rect);
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {
+    final paint = Paint()
+      ..color = borderColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.5;
+    canvas.drawPath(_buildPath(rect), paint);
+  }
+
+  @override
+  ShapeBorder scale(double t) => this;
 }
 
 // --- Text: body preview, no seed art ---

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -313,6 +313,7 @@ class _ThoughtContent extends StatelessWidget {
     final isLarge = node.nodeSize > 110;
 
     return Stack(
+      clipBehavior: Clip.none,
       children: [
         // Bubble body
         Container(
@@ -347,9 +348,9 @@ class _ThoughtContent extends StatelessWidget {
             ),
           ),
         ),
-        // Bubble tail (small circle at bottom-left)
+        // Bubble tail (small circles below bottom-left)
         Positioned(
-          bottom: 2,
+          bottom: -6,
           left: isLarge ? spaceMd : spaceSm,
           child: Container(
             width: 8,
@@ -365,7 +366,7 @@ class _ThoughtContent extends StatelessWidget {
           ),
         ),
         Positioned(
-          bottom: -2,
+          bottom: -12,
           left: isLarge ? spaceSm : spaceXs,
           child: Container(
             width: 4,

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -13,7 +13,8 @@ import 'seed_art_painter.dart';
 /// Border radius by media type.
 BorderRadius _borderForType(MediaType type) {
   return switch (type) {
-    MediaType.text => BorderRadius.circular(radiusMd),
+    MediaType.thought => BorderRadius.circular(radiusFull),
+    MediaType.article => BorderRadius.circular(radiusMd),
     MediaType.image => BorderRadius.circular(radiusXl),
     MediaType.video => const BorderRadius.only(
       topLeft: Radius.circular(radiusLg),
@@ -288,12 +289,48 @@ class _NodeCardState extends State<NodeCard>
 
   Widget _buildContent(PlacedNode node, Color trackColor) {
     return switch ((node.item as PostItem).post.mediaType) {
-      MediaType.text => _TextContent(node: node, trackColor: trackColor),
+      MediaType.thought => _ThoughtContent(node: node, trackColor: trackColor),
+      MediaType.article => _TextContent(node: node, trackColor: trackColor),
       MediaType.image => _ImageContent(node: node, trackColor: trackColor),
       MediaType.video => _VideoContent(node: node, trackColor: trackColor),
       MediaType.audio => _AudioContent(node: node, trackColor: trackColor),
       MediaType.link => _LinkContent(node: node, trackColor: trackColor),
     };
+  }
+}
+
+// --- Thought: bubble with body text, no title ---
+class _ThoughtContent extends StatelessWidget {
+  final PlacedNode node;
+  final Color trackColor;
+
+  const _ThoughtContent({required this.node, required this.trackColor});
+
+  @override
+  Widget build(BuildContext context) {
+    final post = (node.item as PostItem).post;
+    final preview = post.plainTextPreview ?? '';
+
+    return Container(
+      padding: const EdgeInsets.all(spaceSm),
+      decoration: BoxDecoration(
+        color: trackColor.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(radiusFull),
+      ),
+      child: Center(
+        child: Text(
+          preview,
+          style: TextStyle(
+            color: colorTextSecondary,
+            fontSize: node.nodeSize > 110 ? fontSizeSm : fontSizeXs,
+            height: 1.3,
+          ),
+          maxLines: node.nodeSize > 110 ? 5 : 3,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
   }
 }
 

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -313,11 +313,15 @@ class _ThoughtContent extends StatelessWidget {
     final isLarge = node.nodeSize > 110;
 
     return Stack(
-      clipBehavior: Clip.none,
       children: [
-        // Bubble body
+        // Bubble body with extra bottom padding for tail circles
         Container(
-          padding: EdgeInsets.all(isLarge ? spaceMd : spaceSm),
+          padding: EdgeInsets.fromLTRB(
+            isLarge ? spaceMd : spaceSm,
+            isLarge ? spaceMd : spaceSm,
+            isLarge ? spaceMd : spaceSm,
+            (isLarge ? spaceMd : spaceSm) + 14,
+          ),
           decoration: BoxDecoration(
             gradient: LinearGradient(
               begin: Alignment.topLeft,
@@ -348,31 +352,27 @@ class _ThoughtContent extends StatelessWidget {
             ),
           ),
         ),
-        // Bubble tail (small circles below bottom-left)
+        // Bubble tail (small circles inside bottom-left area)
         Positioned(
-          bottom: -6,
+          bottom: 8,
           left: isLarge ? spaceMd : spaceSm,
           child: Container(
-            width: 8,
-            height: 8,
+            width: 7,
+            height: 7,
             decoration: BoxDecoration(
-              color: trackColor.withValues(alpha: 0.10),
+              color: trackColor.withValues(alpha: 0.18),
               shape: BoxShape.circle,
-              border: Border.all(
-                color: trackColor.withValues(alpha: 0.15),
-                width: 0.5,
-              ),
             ),
           ),
         ),
         Positioned(
-          bottom: -12,
+          bottom: 2,
           left: isLarge ? spaceSm : spaceXs,
           child: Container(
             width: 4,
             height: 4,
             decoration: BoxDecoration(
-              color: trackColor.withValues(alpha: 0.08),
+              color: trackColor.withValues(alpha: 0.12),
               shape: BoxShape.circle,
             ),
           ),

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -312,74 +312,66 @@ class _ThoughtContent extends StatelessWidget {
     final preview = post.plainTextPreview ?? '';
     final isLarge = node.nodeSize > 110;
 
-    return Stack(
-      children: [
-        // Bubble body with extra bottom padding for tail circles
-        Container(
-          padding: EdgeInsets.fromLTRB(
-            isLarge ? spaceMd : spaceSm,
-            isLarge ? spaceMd : spaceSm,
-            isLarge ? spaceMd : spaceSm,
-            (isLarge ? spaceMd : spaceSm) + 14,
+    final bubbleColor = trackColor.withValues(alpha: 0.12);
+
+    return CustomPaint(
+      painter: _BubbleTailPainter(color: bubbleColor),
+      child: Container(
+        padding: EdgeInsets.fromLTRB(
+          isLarge ? spaceMd : spaceSm,
+          isLarge ? spaceMd : spaceSm,
+          isLarge ? spaceMd : spaceSm,
+          (isLarge ? spaceMd : spaceSm) + 10,
+        ),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [trackColor.withValues(alpha: 0.06), bubbleColor],
           ),
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-              colors: [
-                trackColor.withValues(alpha: 0.06),
-                trackColor.withValues(alpha: 0.12),
-              ],
-            ),
-            borderRadius: BorderRadius.circular(radiusXl),
-            border: Border.all(
-              color: trackColor.withValues(alpha: 0.15),
-              width: 0.5,
-            ),
-          ),
-          child: Center(
-            child: Text(
-              preview,
-              style: TextStyle(
-                color: colorTextPrimary.withValues(alpha: 0.85),
-                fontSize: isLarge ? fontSizeSm : fontSizeXs,
-                height: 1.4,
-                fontStyle: FontStyle.italic,
-              ),
-              maxLines: isLarge ? 5 : 3,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.center,
-            ),
+          borderRadius: BorderRadius.circular(radiusXl),
+          border: Border.all(
+            color: trackColor.withValues(alpha: 0.15),
+            width: 0.5,
           ),
         ),
-        // Bubble tail (small circles inside bottom-left area)
-        Positioned(
-          bottom: 8,
-          left: isLarge ? spaceMd : spaceSm,
-          child: Container(
-            width: 7,
-            height: 7,
-            decoration: BoxDecoration(
-              color: trackColor.withValues(alpha: 0.18),
-              shape: BoxShape.circle,
+        child: Center(
+          child: Text(
+            preview,
+            style: TextStyle(
+              color: colorTextPrimary.withValues(alpha: 0.85),
+              fontSize: isLarge ? fontSizeSm : fontSizeXs,
+              height: 1.4,
+              fontStyle: FontStyle.italic,
             ),
+            maxLines: isLarge ? 5 : 3,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
           ),
         ),
-        Positioned(
-          bottom: 2,
-          left: isLarge ? spaceSm : spaceXs,
-          child: Container(
-            width: 4,
-            height: 4,
-            decoration: BoxDecoration(
-              color: trackColor.withValues(alpha: 0.12),
-              shape: BoxShape.circle,
-            ),
-          ),
-        ),
-      ],
+      ),
     );
   }
+}
+
+/// Paints a small triangular tail at the bottom-left of the thought bubble.
+class _BubbleTailPainter extends CustomPainter {
+  final Color color;
+  const _BubbleTailPainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = color;
+    final path = Path()
+      ..moveTo(14, size.height - 10)
+      ..lineTo(8, size.height)
+      ..lineTo(22, size.height - 6)
+      ..close();
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(_BubbleTailPainter old) => color != old.color;
 }
 
 // --- Text: body preview, no seed art ---

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -313,11 +313,10 @@ class _ThoughtContent extends StatelessWidget {
     final isLarge = node.nodeSize > 110;
 
     final pad = isLarge ? spaceMd : spaceSm;
-    const tailH = 8.0;
 
     return Container(
-      padding: EdgeInsets.fromLTRB(pad, pad, pad, pad + tailH),
-      decoration: ShapeDecoration(
+      padding: EdgeInsets.all(pad),
+      decoration: BoxDecoration(
         gradient: LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
@@ -326,85 +325,46 @@ class _ThoughtContent extends StatelessWidget {
             trackColor.withValues(alpha: 0.12),
           ],
         ),
-        shape: _BubbleShapeBorder(
-          borderColor: trackColor.withValues(alpha: 0.15),
-          radius: radiusXl,
-          tailHeight: tailH,
+        borderRadius: BorderRadius.circular(radiusXl),
+        border: Border.all(
+          color: trackColor.withValues(alpha: 0.15),
+          width: 0.5,
         ),
       ),
-      child: Center(
-        child: Text(
-          preview,
-          style: TextStyle(
-            color: colorTextPrimary.withValues(alpha: 0.85),
-            fontSize: isLarge ? fontSizeSm : fontSizeXs,
-            height: 1.4,
-            fontStyle: FontStyle.italic,
+      child: Stack(
+        children: [
+          // 💭 icon at top-left
+          Positioned(
+            top: 0,
+            left: 0,
+            child: Icon(
+              Icons.chat_bubble_outline,
+              size: isLarge ? 14 : 10,
+              color: trackColor.withValues(alpha: 0.3),
+            ),
           ),
-          maxLines: isLarge ? 5 : 3,
-          overflow: TextOverflow.ellipsis,
-          textAlign: TextAlign.center,
-        ),
+          // Body text centered
+          Center(
+            child: Padding(
+              padding: EdgeInsets.only(top: isLarge ? 12 : 8),
+              child: Text(
+                preview,
+                style: TextStyle(
+                  color: colorTextPrimary.withValues(alpha: 0.85),
+                  fontSize: isLarge ? fontSizeSm : fontSizeXs,
+                  height: 1.4,
+                  fontStyle: FontStyle.italic,
+                ),
+                maxLines: isLarge ? 5 : 3,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
-}
-
-/// Speech-bubble shape: rounded rectangle with a small tail at bottom-left.
-class _BubbleShapeBorder extends ShapeBorder {
-  final Color borderColor;
-  final double radius;
-  final double tailHeight;
-
-  const _BubbleShapeBorder({
-    required this.borderColor,
-    required this.radius,
-    required this.tailHeight,
-  });
-
-  @override
-  EdgeInsetsGeometry get dimensions => EdgeInsets.zero;
-
-  Path _buildPath(Rect rect) {
-    final bodyRect = Rect.fromLTRB(
-      rect.left,
-      rect.top,
-      rect.right,
-      rect.bottom - tailHeight,
-    );
-    final path = Path()
-      ..addRRect(RRect.fromRectAndRadius(bodyRect, Radius.circular(radius)));
-
-    // Tail: small triangle at bottom-left
-    final tailLeft = rect.left + 16.0;
-    path
-      ..moveTo(tailLeft, bodyRect.bottom)
-      ..lineTo(tailLeft - 2, rect.bottom)
-      ..lineTo(tailLeft + 10, bodyRect.bottom)
-      ..close();
-
-    return path;
-  }
-
-  @override
-  Path getOuterPath(Rect rect, {TextDirection? textDirection}) =>
-      _buildPath(rect);
-
-  @override
-  Path getInnerPath(Rect rect, {TextDirection? textDirection}) =>
-      _buildPath(rect);
-
-  @override
-  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {
-    final paint = Paint()
-      ..color = borderColor
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 0.5;
-    canvas.drawPath(_buildPath(rect), paint);
-  }
-
-  @override
-  ShapeBorder scale(double t) => this;
 }
 
 // --- Text: body preview, no seed art ---

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -331,37 +331,19 @@ class _ThoughtContent extends StatelessWidget {
           width: 0.5,
         ),
       ),
-      child: Stack(
-        children: [
-          // 💭 icon at top-left
-          Positioned(
-            top: 0,
-            left: 0,
-            child: Icon(
-              Icons.chat_bubble_outline,
-              size: isLarge ? 14 : 10,
-              color: trackColor.withValues(alpha: 0.3),
-            ),
+      child: Center(
+        child: Text(
+          preview,
+          style: TextStyle(
+            color: colorTextPrimary.withValues(alpha: 0.85),
+            fontSize: isLarge ? fontSizeSm : fontSizeXs,
+            height: 1.4,
+            fontStyle: FontStyle.italic,
           ),
-          // Body text centered
-          Center(
-            child: Padding(
-              padding: EdgeInsets.only(top: isLarge ? 12 : 8),
-              child: Text(
-                preview,
-                style: TextStyle(
-                  color: colorTextPrimary.withValues(alpha: 0.85),
-                  fontSize: isLarge ? fontSizeSm : fontSizeXs,
-                  height: 1.4,
-                  fontStyle: FontStyle.italic,
-                ),
-                maxLines: isLarge ? 5 : 3,
-                overflow: TextOverflow.ellipsis,
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ),
-        ],
+          maxLines: isLarge ? 5 : 3,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.center,
+        ),
       ),
     );
   }

--- a/frontend/lib/widgets/timeline/post_card.dart
+++ b/frontend/lib/widgets/timeline/post_card.dart
@@ -10,7 +10,8 @@ class PostCard extends StatelessWidget {
   const PostCard({super.key, required this.post, required this.trackColor});
 
   IconData get _mediaIcon => switch (post.mediaType) {
-    MediaType.text => Icons.article_outlined,
+    MediaType.thought => Icons.chat_bubble_outline,
+    MediaType.article => Icons.description_outlined,
     MediaType.image => Icons.image_outlined,
     MediaType.video => Icons.videocam_outlined,
     MediaType.audio => Icons.audiotrack_outlined,

--- a/frontend/lib/widgets/timeline/post_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/post_detail_sheet.dart
@@ -398,7 +398,7 @@ class _PostDetailContentState extends State<PostDetailContent> {
   List<Widget> _buildContentSection(Post post) {
     final isVisual =
         post.mediaType == MediaType.image || post.mediaType == MediaType.video;
-    final isText = post.mediaType == MediaType.text;
+    final isText = post.mediaType == MediaType.article;
 
     final dateRow = _buildDateRow(post);
     final titleWidget = post.title != null
@@ -556,7 +556,7 @@ class _PostDetailContentState extends State<PostDetailContent> {
     if (post.body != null) {
       return Text(
         post.body!,
-        style: post.mediaType == MediaType.text
+        style: post.mediaType == MediaType.article
             ? const TextStyle(
                 color: colorTextSecondary,
                 fontSize: fontSizeMd,
@@ -1102,7 +1102,8 @@ class _PostDetailContentState extends State<PostDetailContent> {
   ) {
     final width = MediaQuery.of(context).size.width;
     return switch (post.mediaType) {
-      MediaType.text => _textMediaArea(post, trackColor),
+      MediaType.thought => _textMediaArea(post, trackColor),
+      MediaType.article => _textMediaArea(post, trackColor),
       MediaType.image => _visualMediaArea(
         context,
         post,
@@ -1893,7 +1894,8 @@ class _PostDetailContentState extends State<PostDetailContent> {
       MediaType.video => '🎬',
       MediaType.audio => '🎵',
       MediaType.link => '🔗',
-      MediaType.text => '📝',
+      MediaType.thought => '💭',
+      MediaType.article => '📝',
     };
     final date = p.createdAt.toLocal();
     final dateStr = '${date.month}/${date.day}';

--- a/frontend/lib/widgets/timeline/post_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/post_detail_sheet.dart
@@ -398,13 +398,14 @@ class _PostDetailContentState extends State<PostDetailContent> {
   List<Widget> _buildContentSection(Post post) {
     final isVisual =
         post.mediaType == MediaType.image || post.mediaType == MediaType.video;
-    final isText = post.mediaType == MediaType.article;
+    final isArticle = post.mediaType == MediaType.article;
+    final isThought = post.mediaType == MediaType.thought;
 
     final dateRow = _buildDateRow(post);
     final titleWidget = post.title != null
         ? Text(
             post.title!,
-            style: isText
+            style: isArticle
                 ? const TextStyle(
                     color: colorTextPrimary,
                     fontSize: 24,
@@ -424,8 +425,31 @@ class _PostDetailContentState extends State<PostDetailContent> {
         : null;
     final bodyWidget = _buildBodyWidget(post);
 
+    // Article genre badge
+    Widget? genreBadge;
+    if (isArticle && post.articleGenre != null) {
+      genreBadge = Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: spaceSm,
+          vertical: spaceXxs,
+        ),
+        decoration: BoxDecoration(
+          color: colorAccentGold.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(radiusSm),
+          border: Border.all(color: colorAccentGold.withValues(alpha: 0.2)),
+        ),
+        child: Text(
+          post.articleGenre!.label,
+          style: const TextStyle(
+            color: colorAccentGold,
+            fontSize: fontSizeXs,
+            fontWeight: weightSemibold,
+          ),
+        ),
+      );
+    }
+
     if (isVisual) {
-      // Image/Video: title → caption → date (compact, media is the hero)
       return [
         if (titleWidget != null) ...[
           titleWidget,
@@ -440,9 +464,18 @@ class _PostDetailContentState extends State<PostDetailContent> {
       ];
     }
 
-    // Audio/Link: title is in media overlay only when visual overlay exists.
-    // Audio: always has overlay when URL present.
-    // Link: only when ogImage is present (fallback card has no overlay).
+    // Thought: date → body (no title, simple layout)
+    if (isThought) {
+      return [
+        dateRow,
+        const SizedBox(height: spaceMd),
+        if (bodyWidget != null) ...[
+          bodyWidget,
+          const SizedBox(height: spaceLg),
+        ],
+      ];
+    }
+
     final isMediaOverlay =
         (post.mediaType == MediaType.audio &&
             post.mediaUrl != null &&
@@ -461,13 +494,14 @@ class _PostDetailContentState extends State<PostDetailContent> {
       ];
     }
 
-    // Text & other types: date → title → body
+    // Article & other types: date → genre → title → reading time → body
     return [
       dateRow,
+      if (genreBadge != null) ...[const SizedBox(height: spaceSm), genreBadge],
       const SizedBox(height: spaceMd),
       if (titleWidget != null) ...[
         titleWidget,
-        if (isText && post.plainTextPreview != null) ...[
+        if (isArticle && post.plainTextPreview != null) ...[
           const SizedBox(height: spaceSm),
           Text(
             '${estimateReadingMinutes(post.plainTextPreview!).clamp(1, 99)} min read',
@@ -477,7 +511,7 @@ class _PostDetailContentState extends State<PostDetailContent> {
             ),
           ),
         ],
-        SizedBox(height: isText ? spaceLg : spaceSm),
+        SizedBox(height: isArticle ? spaceLg : spaceSm),
       ],
       if (bodyWidget != null) ...[bodyWidget, const SizedBox(height: spaceLg)],
     ];
@@ -556,7 +590,9 @@ class _PostDetailContentState extends State<PostDetailContent> {
     if (post.body != null) {
       return Text(
         post.body!,
-        style: post.mediaType == MediaType.article
+        style:
+            (post.mediaType == MediaType.article ||
+                post.mediaType == MediaType.thought)
             ? const TextStyle(
                 color: colorTextSecondary,
                 fontSize: fontSizeMd,

--- a/scripts/seed-test-data.sh
+++ b/scripts/seed-test-data.sh
@@ -114,17 +114,23 @@ fi
 create_post "$PLAY" "Flamenco-session" 1.0 video 55 "$MEDIA_URL/flamenco.mp4"
 create_post "$PLAY" "Chord-melody-practice" 0.6 video 48 "$MEDIA_URL/chord-melody.mp4"
 create_post "$PLAY" "Blues-scale-workout" 0.25 audio 150 "$MEDIA_URL/blues-scale.mp3"
-create_post "$PLAY" "New-rasgueado-pattern" 0.8 text "" "" "Been working on a new rasgueado technique all week. The key insight: instead of fanning all four fingers evenly, I delay the ring finger slightly to create a triplet feel against the strummed bass. It sounds almost like two guitarists playing at once. Still need to clean up the transition back into picado, but the core pattern is solid. Going to try it on the Bulerias piece next."
+create_post "$PLAY" "New-rasgueado-pattern" 0.8 article "" "" "Been working on a new rasgueado technique all week. The key insight: instead of fanning all four fingers evenly, I delay the ring finger slightly to create a triplet feel against the strummed bass. It sounds almost like two guitarists playing at once. Still need to clean up the transition back into picado, but the core pattern is solid. Going to try it on the Bulerias piece next."
 create_post "$PLAY" "Fingerpicking-exercise" 0.15 audio 290 "$MEDIA_URL/fingerpicking.mp3"
-create_post "$PLAY" "Jazz-improv-notes" 0.4 text "" "" "Transcribed the Wes Montgomery solo from Four on Six today. His octave technique is deceptively simple — the real magic is in the rhythmic displacement. He anticipates the chord changes by a half beat, creating this floating feeling over the groove. Tried applying the same concept to my own ii-V-I lines and it immediately made everything sound more musical. Less notes, more intention."
+create_post "$PLAY" "Jazz-improv-notes" 0.4 article "" "" "Transcribed the Wes Montgomery solo from Four on Six today. His octave technique is deceptively simple — the real magic is in the rhythmic displacement. He anticipates the chord changes by a half beat, creating this floating feeling over the groove. Tried applying the same concept to my own ii-V-I lines and it immediately made everything sound more musical. Less notes, more intention."
+# Thought posts (short, no title, max 280 chars)
+create_post "$PLAY" "" 0.2 thought "" "" "Finally nailed that rasgueado pattern. Fingers are sore but the sound is worth it."
+create_post "$COMPOSE" "" 0.15 thought "" "" "3am and the melody won't leave my head. Recording a voice memo before I forget."
+create_post "$LIFE" "" 0.05 thought "" "" "Coffee, guitar, sunrise. Perfect morning."
+create_post "$ENGLISH" "" 0.1 thought "" "" "TIL the word 'serendipity' — finding something good without looking for it. That's basically how I write music."
+
 create_post "$PLAY" "Live-at-open-mic" 0.95 video 58 "$MEDIA_URL/open-mic.mp4"
 
 # Compose track
 create_post "$COMPOSE" "Final-mix-Sunrise" 0.8 audio 222 "$MEDIA_URL/sunrise-final.mp3"
 create_post "$COMPOSE" "Sidechain-experiment" 0.3 audio 48 "$MEDIA_URL/sidechain.mp3"
 create_post "$COMPOSE" "WIP-Sunrise-Protocol" 0.65 audio 107 "$MEDIA_URL/sunrise-wip.mp3"
-create_post "$COMPOSE" "Mix-notes" 0.1 text "" "" "Mixing session notes: The kick and bass are finally sitting right after sidechain compression at 3:1 ratio with 20ms attack. Vocals need more air around 12kHz — shelf boost maybe +2dB. The bridge section still feels empty. Thinking about adding a reversed reverb swell from the guitar hook. Also the snare sounds papery on laptop speakers, need to check the 200Hz region."
-create_post "$COMPOSE" "Lyrics-Digital-Citizen" 0.4 text "" "" "Draft lyrics for Digital Citizen (verse 2):\n\nWe built our homes on borrowed ground\nServers hum where roots should grow\nEvery memory a rented room\nEvery voice an echo of the algorithm\n\nBut I remember the sound of rain on a real window\nAnd the weight of a letter that someone actually wrote\n\nStill working on the chorus. The theme is about reclaiming authenticity in digital spaces — which is literally what this platform is about."
+create_post "$COMPOSE" "Mix-notes" 0.1 article "" "" "Mixing session notes: The kick and bass are finally sitting right after sidechain compression at 3:1 ratio with 20ms attack. Vocals need more air around 12kHz — shelf boost maybe +2dB. The bridge section still feels empty. Thinking about adding a reversed reverb swell from the guitar hook. Also the snare sounds papery on laptop speakers, need to check the 200Hz region."
+create_post "$COMPOSE" "Lyrics-Digital-Citizen" 0.4 article "" "" "Draft lyrics for Digital Citizen (verse 2):\n\nWe built our homes on borrowed ground\nServers hum where roots should grow\nEvery memory a rented room\nEvery voice an echo of the algorithm\n\nBut I remember the sound of rain on a real window\nAnd the weight of a letter that someone actually wrote\n\nStill working on the chorus. The theme is about reclaiming authenticity in digital spaces — which is literally what this platform is about."
 create_post "$COMPOSE" "Beat-tape-vol3" 0.55 audio 295 "$MEDIA_URL/beat-tape-v3.mp3"
 
 # Life track
@@ -137,7 +143,7 @@ create_post "$LIFE" "Birthday" 0.6 image "" "$MEDIA_URL/birthday.jpg"
 # English track
 create_post "$ENGLISH" "1K-followers-thankyou" 0.9 video 42 "$MEDIA_URL/1k-thankyou.mp4"
 create_post "$ENGLISH" "QA-How-I-started" 0.6 video 56 "$MEDIA_URL/qa-how-started.mp4"
-create_post "$ENGLISH" "English-diary-5" 0.15 text "" "" "English diary day 5. Today I tried explaining my music production process in English to a friend from Berlin. I kept mixing up past tense and present tense when talking about the creative process. She said my English is getting much better though. New words I learned: resonance, overtone, sustain (I knew these in a music context but not how to use them in casual conversation). Going to try writing my next song bio in English first instead of translating from Japanese."
+create_post "$ENGLISH" "English-diary-5" 0.15 article "" "" "English diary day 5. Today I tried explaining my music production process in English to a friend from Berlin. I kept mixing up past tense and present tense when talking about the creative process. She said my English is getting much better though. New words I learned: resonance, overtone, sustain (I knew these in a music context but not how to use them in casual conversation). Going to try writing my next song bio in English first instead of translating from Japanese."
 create_post "$ENGLISH" "Studio-tour" 0.55 video 50 "$MEDIA_URL/studio-tour.mp4"
 
 # Live track
@@ -148,26 +154,26 @@ create_post "$LIVE" "Evening-jam-circle" 0.85 audio 280 "$MEDIA_URL/evening-jam.
 
 # Studio track
 create_post "$STUDIO" "Sketch-Neon-Garden" 0.35 audio 72 "$MEDIA_URL/neon-garden.mp3"
-create_post "$STUDIO" "EP-structure" 0.1 text "" "" "EP track listing draft:\n\n1. Glass Ocean (intro, 1:30) — ambient pads + reversed guitar\n2. Neon Garden (3:45) — uptempo, main single candidate\n3. Sunrise Protocol (4:12) — the one with the sidechain experiment\n4. Digital Citizen (3:58) — lyrics almost done\n5. Midnight Drift (outro, 2:15) — stripped back, just guitar + delay\n\nTotal runtime ~15:40. Might be too short? But I like the idea of a tight, focused EP rather than padding it out. Quality over quantity."
+create_post "$STUDIO" "EP-structure" 0.1 article "" "" "EP track listing draft:\n\n1. Glass Ocean (intro, 1:30) — ambient pads + reversed guitar\n2. Neon Garden (3:45) — uptempo, main single candidate\n3. Sunrise Protocol (4:12) — the one with the sidechain experiment\n4. Digital Citizen (3:58) — lyrics almost done\n5. Midnight Drift (outro, 2:15) — stripped back, just guitar + delay\n\nTotal runtime ~15:40. Might be too short? But I like the idea of a tight, focused EP rather than padding it out. Quality over quantity."
 create_post "$STUDIO" "Collab-sketch" 0.7 audio 93 "$MEDIA_URL/collab.mp3"
 create_post "$STUDIO" "Demo-Glass-Ocean" 0.65 audio 178 "$MEDIA_URL/glass-ocean.mp3"
 create_post "$STUDIO" "cool-guitar-lesson" 0.45 link "" "https://www.youtube.com/watch?v=example"
 create_post "$STUDIO" "music-theory-resource" 0.2 link "" "https://musictheory.net"
 
 # Rich text (delta format) posts — blog/essay style
-create_post "$COMPOSE" "Why-I-Chose-Flamenco" 0.75 text "" "" \
+create_post "$COMPOSE" "Why-I-Chose-Flamenco" 0.75 article "" "" \
   '[{"insert":"Why I Chose Flamenco Over Classical\n","attributes":{"header":1}},{"insert":"\nI get asked this a lot. The short answer: "},{"insert":"flamenco chose me","attributes":{"bold":true}},{"insert":".\n\nI spent eight years studying classical guitar. Scales, arpeggios, sight-reading — the whole conservatory path. And I was good at it. But something always felt "},{"insert":"missing","attributes":{"italic":true}},{"insert":".\n\n"},{"insert":"The turning point","attributes":{"header":2}},{"insert":"\nIt was a Tuesday night in Seville. I wandered into a bar where an old man was playing. No sheet music, no fancy technique — just raw emotion flowing through six strings.\n\n"},{"insert":"That moment changed everything.","attributes":{"bold":true}},{"insert":"\n\nHe played one "},{"insert":"falseta","attributes":{"italic":true}},{"insert":" that made the whole room hold its breath. When I asked him how long he had been playing, he laughed and said:\n\n"},{"insert":"You don'\''t play flamenco. You live it.","attributes":{"blockquote":true}},{"insert":"\n\n"},{"insert":"What flamenco taught me","attributes":{"header":2}},{"insert":"\n"},{"insert":"Rhythm is a conversation, not a metronome","attributes":{"list":"bullet"}},{"insert":"\n"},{"insert":"Imperfection is part of the beauty","attributes":{"list":"bullet"}},{"insert":"\n"},{"insert":"Music exists in the silence between notes","attributes":{"list":"bullet"}},{"insert":"\n\nI still practice classical exercises for technique. But when I perform, when I "},{"insert":"create","attributes":{"italic":true}},{"insert":" — it'\''s always flamenco.\n"}]' \
   "delta"
 
-create_post "$LIFE" "Morning-Pages" 0.1 text "" "" \
+create_post "$LIFE" "Morning-Pages" 0.1 article "" "" \
   '[{"insert":"Morning pages — stream of consciousness\n","attributes":{"header":3}},{"insert":"\nWoke up at 5:30 again. The birds outside are getting louder as spring settles in. Made coffee, sat on the balcony.\n\nThree things I'\''m grateful for today:\n"},{"insert":"The new strings I put on yesterday — they ring so bright","attributes":{"list":"ordered"}},{"insert":"\n"},{"insert":"That message from the fan in Brazil who covered my song","attributes":{"list":"ordered"}},{"insert":"\n"},{"insert":"Simple mornings like this one","attributes":{"list":"ordered"}},{"insert":"\n\nToday'\''s plan: finish the bridge section for "},{"insert":"Digital Citizen","attributes":{"bold":true}},{"insert":", then head to the park for some fresh air. Maybe bring the ukulele.\n"}]' \
   "delta"
 
-create_post "$ENGLISH" "Learning-Log-Week12" 0.3 text "" "" \
+create_post "$ENGLISH" "Learning-Log-Week12" 0.3 article "" "" \
   '[{"insert":"English Learning Log — Week 12\n","attributes":{"header":1}},{"insert":"\n"},{"insert":"New vocabulary","attributes":{"header":2}},{"insert":"\n"},{"insert":"resonance","attributes":{"bold":true}},{"insert":" — the quality of being deep and full (used it to describe my guitar tone in a podcast interview)\n"},{"insert":"serendipity","attributes":{"bold":true}},{"insert":" — finding something good without looking for it\n"},{"insert":"ephemeral","attributes":{"bold":true}},{"insert":" — lasting for a very short time (perfect word for live performances)\n\n"},{"insert":"Grammar note","attributes":{"header":2}},{"insert":"\nStill struggling with the present perfect vs past simple:\n\n"},{"insert":"I have played guitar for 15 years","attributes":{"code":true}},{"insert":" (correct — still playing)\n"},{"insert":"I played guitar yesterday","attributes":{"code":true}},{"insert":" (correct — specific past time)\n\nThe trick: if the time period is "},{"insert":"still ongoing","attributes":{"italic":true}},{"insert":", use present perfect.\n\n"},{"insert":"Next week'\''s goal: write a full blog post in English without checking the dictionary more than 3 times.","attributes":{"bold":true}},{"insert":"\n"}]' \
   "delta"
 
-echo "==> 35 posts created (32 plain + 3 rich text)"
+echo "==> 39 posts created (4 thought + 6 article + 3 rich text article + 12 media + 2 link)"
 
 # 7. Spread dates across 2 weeks
 docker exec gleisner-db psql -U gleisner -d gleisner -q -c "


### PR DESCRIPTION
## Summary
- **Thought** (💭): short-form, 280 char limit, no title, no rich text, bubble node design
- **Article** (📝): long-form, rich text editor, article genre selection, external publish flag
- Replaces the single `text` MediaType with two purpose-built types

## Changes

### Backend
- `mediaTypeEnum`: `text` → `thought` + `article`
- New columns: `article_genre` (varchar), `external_publish` (boolean)
- `ArticleGenreEnum`: fiction, poetry, essay, technical, opinion, diary, review, travel, other
- Thought validation: max 280 chars, no title, no delta format
- Article: `externalPublish` only when `visibility=public`
- Migration: existing text posts → article (has title/delta) or thought
- All 317 backend tests passing

### Frontend
- `MediaType` enum: `thought` + `article` replace `text`
- `ArticleGenre` enum + `externalPublish` field on Post model
- Create post: thought type with plain textarea (280 char counter)
- Create post: article type with rich text editor
- Node card: `_ThoughtContent` with bubble design (rounded, centered text)
- All switch expressions updated for exhaustive matching
- Backward compat: JSON `'text'` → `MediaType.article`

### Seed data
- 4 thought posts added (short, no title)
- All titled/delta text posts → article type

## Test plan
- [ ] Create thought post: 280 char limit enforced, no title field
- [ ] Create article post: rich text editor, title optional
- [ ] Existing article posts display correctly (backward compat)
- [ ] Thought nodes show as bubbles on timeline
- [ ] Article nodes show as cards (same as before)
- [ ] Backend: `pnpm test` — 317/317 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)