### PR TITLE
Make Discover page accessible without authentication

### DIFF
--- a/frontend/lib/router.dart
+++ b/frontend/lib/router.dart
@@ -51,7 +51,7 @@ final routerProvider = Provider<GoRouter>((ref) {
 
       final isAuthRoute = path == '/login' || path == '/signup';
       final isPublicProfile = _publicProfilePattern.hasMatch(path);
-      final isPublicPage = path == '/about';
+      final isPublicPage = path == '/about' || path == '/discover';
       final isOnboarding = path == '/onboarding';
 
       if (status == AuthStatus.unauthenticated) {

--- a/frontend/lib/screens/discover/discover_screen.dart
+++ b/frontend/lib/screens/discover/discover_screen.dart
@@ -42,6 +42,10 @@ class _DiscoverScreenState extends ConsumerState<DiscoverScreen> {
     // If auth is still loading (e.g. JWT user landing on /discover directly),
     // wait for auth to resolve before loading tune-ins.
     ref.listenManual(authProvider, (prev, next) {
+      // Reset on logout so a subsequent login reloads tune-ins.
+      if (next.status == AuthStatus.unauthenticated) {
+        _tuneInsLoaded = false;
+      }
       if (!_tuneInsLoaded && next.status == AuthStatus.authenticated) {
         _tryLoadTuneIns();
       }

--- a/frontend/lib/screens/discover/discover_screen.dart
+++ b/frontend/lib/screens/discover/discover_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../providers/analytics_provider.dart';
+import '../../providers/auth_provider.dart';
 
 import '../../models/artist.dart';
 import '../../models/genre.dart';
@@ -34,8 +35,11 @@ class _DiscoverScreenState extends ConsumerState<DiscoverScreen> {
       if (!_initialized && context.mounted) {
         _initialized = true;
         ref.read(discoverProvider.notifier).loadInitial();
-        // Ensure tune-in state is loaded before user can tap Tune In buttons
-        ref.read(tuneInProvider.notifier).loadMyTuneIns();
+        // Tune-in state is only relevant for authenticated users
+        final authStatus = ref.read(authProvider).status;
+        if (authStatus == AuthStatus.authenticated) {
+          ref.read(tuneInProvider.notifier).loadMyTuneIns();
+        }
       }
     });
   }
@@ -52,6 +56,15 @@ class _DiscoverScreenState extends ConsumerState<DiscoverScreen> {
     _debounceTimer = Timer(const Duration(milliseconds: 400), () {
       ref.read(discoverProvider.notifier).search(query);
     });
+  }
+
+  void _onArtistTap(String username) {
+    final authStatus = ref.read(authProvider).status;
+    if (authStatus == AuthStatus.authenticated) {
+      context.push('/artist/$username');
+    } else {
+      context.push('/@$username');
+    }
   }
 
   @override
@@ -189,9 +202,8 @@ class _DiscoverScreenState extends ConsumerState<DiscoverScreen> {
                         final artist = state.artists[index];
                         return _ArtistCard(
                           artist: artist,
-                          onTap: () {
-                            context.push('/artist/${artist.artistUsername}');
-                          },
+                          onTap: () =>
+                              _onArtistTap(artist.artistUsername),
                         );
                       }, childCount: state.artists.length),
                     ),

--- a/frontend/lib/screens/discover/discover_screen.dart
+++ b/frontend/lib/screens/discover/discover_screen.dart
@@ -25,6 +25,7 @@ class _DiscoverScreenState extends ConsumerState<DiscoverScreen> {
   final _searchController = TextEditingController();
   Timer? _debounceTimer;
   bool _initialized = false;
+  bool _tuneInsLoaded = false;
 
   @override
   void initState() {
@@ -35,13 +36,25 @@ class _DiscoverScreenState extends ConsumerState<DiscoverScreen> {
       if (!_initialized && context.mounted) {
         _initialized = true;
         ref.read(discoverProvider.notifier).loadInitial();
-        // Tune-in state is only relevant for authenticated users
-        final authStatus = ref.read(authProvider).status;
-        if (authStatus == AuthStatus.authenticated) {
-          ref.read(tuneInProvider.notifier).loadMyTuneIns();
-        }
+        _tryLoadTuneIns();
       }
     });
+    // If auth is still loading (e.g. JWT user landing on /discover directly),
+    // wait for auth to resolve before loading tune-ins.
+    ref.listenManual(authProvider, (prev, next) {
+      if (!_tuneInsLoaded && next.status == AuthStatus.authenticated) {
+        _tryLoadTuneIns();
+      }
+    });
+  }
+
+  void _tryLoadTuneIns() {
+    if (_tuneInsLoaded) return;
+    final authStatus = ref.read(authProvider).status;
+    if (authStatus == AuthStatus.authenticated) {
+      _tuneInsLoaded = true;
+      ref.read(tuneInProvider.notifier).loadMyTuneIns();
+    }
   }
 
   @override

--- a/frontend/lib/widgets/common/bottom_nav_shell.dart
+++ b/frontend/lib/widgets/common/bottom_nav_shell.dart
@@ -18,15 +18,19 @@ import '../../utils/account_switch_helper.dart';
 /// is displayed above all tab content to prevent accidental actions
 /// on the wrong account.
 class BottomNavShell extends ConsumerWidget {
+  /// Branch index for the Discover tab in StatefulShellRoute.
+  static const _discoverBranchIndex = 1;
+
   final StatefulNavigationShell navigationShell;
 
   const BottomNavShell({super.key, required this.navigationShell});
 
   void _onDestinationSelected(BuildContext context, WidgetRef ref, int index) {
-    // Unauthenticated users can only use Discover (index 1).
+    // Unauthenticated users can only use Discover.
     // Tapping Timeline or Profile redirects to login.
     final status = ref.read(authProvider).status;
-    if (status == AuthStatus.unauthenticated && index != 1) {
+    if (status == AuthStatus.unauthenticated &&
+        index != _discoverBranchIndex) {
       GoRouter.of(context).go('/login');
       return;
     }

--- a/frontend/lib/widgets/common/bottom_nav_shell.dart
+++ b/frontend/lib/widgets/common/bottom_nav_shell.dart
@@ -22,7 +22,14 @@ class BottomNavShell extends ConsumerWidget {
 
   const BottomNavShell({super.key, required this.navigationShell});
 
-  void _onDestinationSelected(int index) {
+  void _onDestinationSelected(BuildContext context, WidgetRef ref, int index) {
+    // Unauthenticated users can only use Discover (index 1).
+    // Tapping Timeline or Profile redirects to login.
+    final status = ref.read(authProvider).status;
+    if (status == AuthStatus.unauthenticated && index != 1) {
+      GoRouter.of(context).go('/login');
+      return;
+    }
     navigationShell.goBranch(
       index,
       initialLocation: index == navigationShell.currentIndex,
@@ -65,7 +72,8 @@ class BottomNavShell extends ConsumerWidget {
             NavigationRail(
               backgroundColor: colorSurface1,
               selectedIndex: navigationShell.currentIndex,
-              onDestinationSelected: _onDestinationSelected,
+              onDestinationSelected: (i) =>
+                  _onDestinationSelected(context, ref, i),
               labelType: NavigationRailLabelType.all,
               indicatorColor: Colors.transparent,
               minWidth: navRailWidth,
@@ -124,7 +132,7 @@ class BottomNavShell extends ConsumerWidget {
         backgroundColor: colorSurface1,
         indicatorColor: Colors.transparent,
         selectedIndex: navigationShell.currentIndex,
-        onDestinationSelected: _onDestinationSelected,
+        onDestinationSelected: (i) => _onDestinationSelected(context, ref, i),
         destinations: const [
           NavigationDestination(
             icon: Icon(Icons.grid_view_outlined, color: colorInteractiveMuted),

--- a/frontend/test/router_redirect_test.dart
+++ b/frontend/test/router_redirect_test.dart
@@ -93,6 +93,10 @@ void main() {
       expect(redirect(path: '/discover', status: 'unauthenticated'), isNull);
     });
 
+    test('loading redirects /discover to splash', () {
+      expect(redirect(path: '/discover', status: 'loading'), '/splash');
+    });
+
     test('unauthenticated cannot access protected routes', () {
       expect(redirect(path: '/timeline', status: 'unauthenticated'), '/login');
       expect(

--- a/frontend/test/router_redirect_test.dart
+++ b/frontend/test/router_redirect_test.dart
@@ -57,7 +57,7 @@ void main() {
 
       final isAuthRoute = path == '/login' || path == '/signup';
       final isPublicProfile = RegExp(r'^/@[^/]+$').hasMatch(path);
-      final isPublicPage = path == '/about';
+      final isPublicPage = path == '/about' || path == '/discover';
 
       if (status == 'unauthenticated') {
         return (isAuthRoute || isPublicProfile || isPublicPage)
@@ -87,6 +87,10 @@ void main() {
 
     test('unauthenticated can access /about', () {
       expect(redirect(path: '/about', status: 'unauthenticated'), isNull);
+    });
+
+    test('unauthenticated can access /discover', () {
+      expect(redirect(path: '/discover', status: 'unauthenticated'), isNull);
     });
 
     test('unauthenticated cannot access protected routes', () {


### PR DESCRIPTION
## Summary
- `/discover` を未認証ユーザーにも公開（バックエンドの `discoverArtists`/`genres` クエリは元々認証不要）
- 未認証時はアーティストカードが `/@username`（公開タイムライン）に遷移
- BottomNavShell で Timeline/Profile タブは未認証時にログイン画面へリダイレクト

## Changes
- `router.dart`: `/discover` を公開ルートのホワイトリストに追加
- `discover_screen.dart`: 認証状態に応じて `tuneInProvider` の読み込みとナビゲーション先を分岐
- `bottom_nav_shell.dart`: 未認証ユーザーの Timeline/Profile タブタップをインターセプト

## Test plan
- [ ] 未認証で `/#/discover` にアクセス → アーティスト一覧が表示される
- [ ] ジャンルチップ・検索が動作する
- [ ] アーティストカードタップ → `/@username` に遷移
- [ ] Timeline/Profile タブタップ → `/login` にリダイレクト
- [ ] 認証済みで Discover → 従来通り `/artist/:username` に遷移
- [ ] 認証済みで Timeline/Profile タブ → 通常遷移

🤖 Generated with [Claude Code](https://claude.com/claude-code)