### PR TITLE
Add i18n retrospective learnings to rules and reviewer

### DIFF
--- a/.claude/agents/flutter-ui-reviewer.md
+++ b/.claude/agents/flutter-ui-reviewer.md
@@ -14,6 +14,7 @@ tools: Read, Grep, Glob
 - 画面遷移の設計（GoRouter パターン）
 - StatefulWidget / StatelessWidget / ConsumerWidget の選択の適切さ
 - デザイントークン（`gleisner_tokens.dart`）の使用（`Color(0xFF...)` ハードコード禁止）
+- i18n: ハードコード英語文字列の残存チェック（`'Cancel'` 等 → `context.l10n.cancel` を使うこと。共通ウィジェット・static リスト・ユーティリティ内も確認）
 - `build()` 内で Disposable オブジェクトを生成しない
 - 表示ウィジェットにナビゲーション（`context.go()`）を混ぜない
 

--- a/.claude/rules/frontend-implementation.md
+++ b/.claude/rules/frontend-implementation.md
@@ -26,7 +26,21 @@
 - バリデーション関数は `lib/utils/validators_l10n.dart` の `xxxL10n(context.l10n)` パターンを使う
 - `debugPrint` やログメッセージは翻訳不要（英語のまま）
 
+翻訳品質:
+- UI ラベル（Cancel, Save 等）は直訳で OK
+- マーケティング・説明文（ヒーローコピー、オンボーディング、機能紹介）は意訳すること。英語の意図を日本語として自然に伝わる表現にする
+- 法的要件テキスト（About ページ等）は正確性を優先
+
 **⚠ ARB にキーを追加したら `flutter gen-l10n` を忘れない。** 生成ファイル（`lib/l10n/app_localizations*.dart`）も git にコミットすること。
+
+**⚠ i18n 大量変更後は残存ハードコード英語を Grep で網羅チェックすること。**
+
+PR #216 の教訓: 4つの並列エージェントで ~170 文字列を置換したが、共通ウィジェット内（`EventAtPicker`, `CoverImage`, `TutorialSpotlight`, `milestone_category.dart` の static リスト等）に多数の未翻訳が残り、11回のコミットで段階的に修正した。エージェントの「完了」報告を過信せず、以下のコマンドで確認すること:
+
+```bash
+# lib/ 内のハードコード英語文字列を検索（debugPrint/import/comment 除外）
+grep -rn "'[A-Z][a-z]" lib/screens/ lib/widgets/ --include="*.dart" | grep -v debugPrint | grep -v import | grep -v "^\s*//"
+```
 
 ### データ操作・ビジネスロジックは Provider/Notifier 層で
 


### PR DESCRIPTION
## Summary
- PR #216 の振り返りから得た学びをルール・エージェントに定着
- `frontend-implementation.md`: 翻訳品質ガイドライン（直訳 vs 意訳）+ 残存ハードコード Grep チェック手順
- `flutter-ui-reviewer.md`: i18n ハードコード文字列チェック観点を追加

## Test plan
- [ ] ルール・エージェントファイルの変更のみ（コード変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)