### PR TITLE
Pin Flutter version and route mise start_dev through dev-start.sh

### DIFF
--- a/backend/mise.toml
+++ b/backend/mise.toml
@@ -13,7 +13,7 @@ setup_new_local = { run = "cp .env.example .env", depends_post = [
   "seed_dev",
   "seed_init_dev",
 ] }
-start_dev = { run = "pnpm dev", depends = "start_db" }
+start_dev = { run = "../scripts/dev-start.sh", depends = "start_db" }
 start_db = { run = "docker compose up -d --wait" }
 stop_db = { run = "docker compose stop" }
 clean_cache_build = { run = ["rm -rf node_modules", "rm -rf dist"] }

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 experimental_monorepo_root = true
 
 [tools]
-flutter = "latest"
+flutter = { version = "3.38.10", platforms = { linux-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_{{ version }}-stable.tar.xz" }, macos-arm64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_{{ version }}-stable.zip" }, macos-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_{{ version }}-stable.zip" }, windows-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_{{ version }}-stable.zip" } }, version_expr = 'fromJSON(body).releases | filter({ #.channel == "stable" }) | map({ replace(#.version, "-stable", "") }) | sortVersions()', version_list_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json" }
 node = "latest"
 "npm:pnpm" = "latest"
 


### PR DESCRIPTION
## Summary
`mise run` を正しいフロント/バックエンド開発エントリーポイントとして機能させるための 2 件の修正。

### 1. Flutter バージョンをピン留め（`mise.toml`）
- `flutter = \"latest\"` が mise の built-in registry の古いキャッシュにより 3.22.1（Dart 3.4.1）に解決され、pubspec.yaml の `^3.10.9` Dart SDK 制約を満たせず \`pub get\` が失敗していた
- stable チャネルのダウンロード URL テンプレートを明示して 3.38.10 を直接指定

### 2. `backend/mise.toml` の `start_dev` を `dev-start.sh` 経由に（`backend/mise.toml`）
- 従来 `pnpm dev` を直叩きしていたため \`CORS_ORIGIN\` がデフォルト (`http://localhost:3000`) になり、Flutter Web のランダムポートからのアクセスが CORS で弾かれて Login が fail していた
- `scripts/dev-start.sh` は `CORS_ORIGIN=*` を明示する既存 wrapper。`mise run start_dev` がこれを経由するよう変更
- README および CLAUDE.md の CORS 注意事項との整合も改善

## 検証
- [x] `mise exec -- flutter --version` で `Flutter 3.38.10 • Dart 3.10.9` を確認
- [x] `../scripts/dev-start.sh` 起動後、任意 Origin からの OPTIONS preflight で `access-control-allow-origin: *` を確認
- [x] seed ユーザーでのログインが通ることを実機確認

## 影響範囲
- 既存の手動ワークフロー（`./scripts/dev-start.sh` 直接実行、`pnpm dev` 直接実行）には影響なし
- mise 経由で開発している全メンバーに Flutter 3.38.10 が配布される（ダウンロード〜1GB、初回のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)