### PR TITLE
docs: codify feature-disable pattern and mise wrapper rule

### DIFF
--- a/.claude/rules/backend-implementation.md
+++ b/.claude/rules/backend-implementation.md
@@ -674,3 +674,25 @@ for (const url of removedUrls) {
 ```
 
 PR #211 の教訓: updatePost のトランザクション内で R2 削除を実行し、レビューで Critical 指摘。
+
+### 機能の一時 disable パターン（schema + test の3点セット）
+
+**GraphQL 機能を production schema から一時的に無効化する場合、以下の3点を同時に対応すること。**
+
+1. **schema 登録の停止**: `src/graphql/types/index.ts` の `import "./xxx.js";` をコメントアウト。復帰手順と関連既存課題の Issue 番号をコメント内に明記
+2. **resolver/validation のテストカバレッジ維持**: 該当テストファイル冒頭で `import "../types/xxx.js";` を個別実施。pothos の `builder` はシングルトンだが vitest `isolate: true`（デフォルト）によりテストファイル単位で module scope が独立するため他テストファイルに波及しない旨もコメントで明示
+3. **除外済み機能を参照する他テストの skip**: 該当機能を利用する他テスト（例: `public-user.test.ts` の email 漏洩防止）を `it.skip` にし、復帰時の対応関係（"Issue #N step M と lock-step で戻す"）をコメントで明示
+
+復帰時のチェックリストは専用 Issue として起票し、各ファイルのコメントから Issue 番号で相互参照できるようにする。復帰時に既存のセキュリティ/パフォーマンス課題（認証欠落、N+1、全カラム select 等）が顕在化する場合、その課題も復帰 Issue に含めて復帰 PR でまとめて解消する。
+
+```typescript
+// ✅ types/index.ts
+// Comments are disabled for Phase 0 to avoid 電気通信事業法 "通信の媒介" implications.
+// Re-enable after legal review (Phase 1+) by following the checklist in Issue #221:
+//   1. Uncomment this import
+//   2. Remove the individual `import "../types/comment.js"` from comment.test.ts
+//   3. Change `it.skip` back to `it` in public-user.test.ts
+// import "./comment.js";
+```
+
+PR #219 の教訓: コメント機能を Phase 0 で無効化する際、最初は schema の 1 行コメントアウトのみで対応し、テストカバレッジ維持と他テスト skip が漏れた。レビューで 3 ステップのチェックリストに拡張するよう指摘された。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,13 @@ mise tasks             # 利用可能なタスク一覧を表示
 
 [mise monorepo](https://mise.jdx.dev/tasks/monorepo.html#monorepo-tasks) を有効化しているため、下記のコマンドは [monorepo task syntax](https://mise.jdx.dev/tasks/monorepo.html#task-path-syntax) 指定も可能
 
+> **⚠ mise タスクは wrapper スクリプトを尊重すること**
+> `scripts/dev-start.sh` のように環境変数を設定する wrapper スクリプトが存在する場合、mise タスクは必ずその wrapper を経由すること（`run = "../scripts/dev-start.sh"`）。
+> `pnpm dev` 等を直叩きすると `CORS_ORIGIN=*` などの設定が漏れ、Flutter Web のランダムポートからのアクセスが CORS で弾かれる。
+> 新しく mise タスクを追加する際は、対応する wrapper がないか `scripts/` を先に確認する。
+>
+> PR #220 の教訓: `start_dev` が `pnpm dev` を直叩きしていたため、ログインが CORS で失敗する状態になっていた。
+
 #### バックエンドタスク（`cd backend` で実行）
 
 | タスク | 実行内容 | 自動依存 |


### PR DESCRIPTION
## Summary
PR #219（コメント機能の Phase 0 非表示化）と PR #220（Flutter pin + start_dev 修正）の retrospective で抽出した学びを `.claude/rules/backend-implementation.md` と `CLAUDE.md` に定着させる。コード変更なし。

## 背景
- **PR #219 レビュー指摘**: コメント機能の無効化を最初 `types/index.ts` の 1 行コメントアウトだけで済ませたため、テストカバレッジ維持と他テストの skip が漏れた。最終的に 3 ステップのチェックリストに拡張。同じパターンは将来の機能 disable 時にも再発し得る
- **PR #220 根本原因**: `mise run start_dev` が `pnpm dev` を直叩きしていたため `CORS_ORIGIN=*` を設定する `scripts/dev-start.sh` が bypass され、Flutter Web からのログインが CORS で失敗していた。wrapper の存在意義を明示化しないと再発する

## 変更点
- `.claude/rules/backend-implementation.md`: 「機能の一時 disable パターン（schema + test の3点セット）」セクションを新規追加
  - schema 登録停止 / テスト個別 import / 他テスト skip の 3 点
  - pothos builder singleton + vitest `isolate: true` の注意点も併記
  - 復帰時の Issue 起票とコメント相互参照のベストプラクティス
- `CLAUDE.md`: mise tasks セクションに「wrapper スクリプトを尊重」注記を追加
  - `scripts/dev-start.sh` を mise から bypass すると CORS で login 失敗する再発防止

## 関連
- 親: PR #219 (Phase 0 コメント機能非表示化)、PR #220 (mise fix)
- Retrospective ログ: このセッション

🤖 Generated with [Claude Code](https://claude.com/claude-code)