### PR TITLE
docs: Cloudflare Pages Functions header preservation rule (retrospective #224)

### DIFF
--- a/.claude/rules/frontend-implementation.md
+++ b/.claude/rules/frontend-implementation.md
@@ -566,6 +566,39 @@ R2 ダッシュボード → バケット → Settings → CORS Policy で以下
 - `GET`: `Image.network` での画像表示用
 - カスタムドメイン（`media-dev.gleisner.app` 等）で CORS が効かない場合は、Cloudflare **Transform Rules** → **Modify Response Header** で `Access-Control-Allow-Origin: *` を追加
 
+### Cloudflare Pages Functions でバックエンドレスポンスをプロキシする際のヘッダー保全
+
+`return new Response(upstream.body, { headers: {...} })` は指定したヘッダーだけを返す。upstream.headers は引き継がれず、バックエンドが設定した `X-Robots-Tag` / `Set-Cookie` / 独自ヘッダー等が全部消える。
+
+- ヘッダー不変で中継: `return upstream;`（最もシンプル）
+- ヘッダーを一部追加・上書きしたい場合: `new Response(upstream.body, upstream)` で継承したうえで上書きするか、`upstream.headers.get(...)` で必要なものを明示転送する
+- HTTP ヘッダーは case-insensitive だが、Fetch API の慣習に合わせ `get()` には小文字を使う
+
+```ts
+// ❌ ヘッダー全消し — X-Robots-Tag や Set-Cookie が届かない
+return new Response(upstream.body, {
+  status: 200,
+  headers: {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "public, max-age=300",
+  },
+});
+
+// ✅ 必要なものだけ明示転送
+return new Response(upstream.body, {
+  status: 200,
+  headers: {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "public, max-age=300",
+    "X-Robots-Tag":
+      upstream.headers.get("x-robots-tag") ??
+      "noindex, nofollow, noarchive, nosnippet",
+  },
+});
+```
+
+PR #224 の教訓: OGP プロキシで `Content-Type` と `Cache-Control` だけ指定した結果、バックエンドの `X-Robots-Tag: noindex` が SNS bot に届かず、クローラー対策が実質無効化されていた。レビューで Critical 指摘。
+
 ### UI コンポーネント置換チェックリスト
 
 **共有ウィジェットを新規作成して既存の private ウィジェットを置き換える場合、全使用箇所を一括で置換すること。**

--- a/backend/src/routes/__tests__/ogp.test.ts
+++ b/backend/src/routes/__tests__/ogp.test.ts
@@ -139,7 +139,11 @@ describe("OGP endpoint", () => {
     const res = await app.request("/ogp/@noindexartist");
 
     expect(res.status).toBe(200);
-    expect(res.headers.get("x-robots-tag")).toContain("noindex");
+    const xRobotsTag = res.headers.get("x-robots-tag") ?? "";
+    expect(xRobotsTag).toContain("noindex");
+    expect(xRobotsTag).toContain("nofollow");
+    expect(xRobotsTag).toContain("noarchive");
+    expect(xRobotsTag).toContain("nosnippet");
     const html = await res.text();
     expect(html).toMatch(
       /<meta\s+name="robots"\s+content="noindex,nofollow,noarchive,nosnippet">/,

--- a/backend/src/routes/__tests__/ogp.test.ts
+++ b/backend/src/routes/__tests__/ogp.test.ts
@@ -122,6 +122,30 @@ describe("OGP endpoint", () => {
     expect(html).toContain("twitter:card");
   });
 
+  // PHASE_0_REVERT: この 1 ケースを Phase 1 移行時に削除または調整
+  it("includes Phase 0 noindex meta and X-Robots-Tag header", async () => {
+    const token = await signupAndGetToken(
+      app,
+      "noindex@test.com",
+      "noindexuser",
+    );
+    await gql(
+      app,
+      REGISTER_ARTIST_MUTATION,
+      { artistUsername: "noindexartist", displayName: "NoIndex Artist" },
+      token,
+    );
+
+    const res = await app.request("/ogp/@noindexartist");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-robots-tag")).toContain("noindex");
+    const html = await res.text();
+    expect(html).toMatch(
+      /<meta\s+name="robots"\s+content="noindex,nofollow,noarchive,nosnippet">/,
+    );
+  });
+
   it("returns 404 for private artist", async () => {
     const token = await signupAndGetToken(app, "priv@test.com", "privuser");
     await gql(

--- a/backend/src/routes/ogp.ts
+++ b/backend/src/routes/ogp.ts
@@ -58,6 +58,8 @@ ogp.get("/:atUsername", async (c) => {
 <html>
 <head>
 <meta charset="utf-8">
+<!-- PHASE_0_REVERT: Phase 1 移行時にこの noindex meta と X-Robots-Tag ヘッダーを削除。docs/phase1-revert-checklist.md 参照 -->
+<meta name="robots" content="noindex,nofollow,noarchive,nosnippet">
 <meta property="og:type" content="profile">
 <meta property="og:title" content="${title}">
 <meta property="og:description" content="${description}">
@@ -71,6 +73,8 @@ ${image ? `<meta name="twitter:image" content="${escapeHtml(image)}">` : ""}
 <body></body>
 </html>`;
 
+  // PHASE_0_REVERT: Phase 1 移行時に X-Robots-Tag ヘッダーを削除
+  c.header("X-Robots-Tag", "noindex, nofollow, noarchive");
   return c.html(html);
 });
 

--- a/backend/src/routes/ogp.ts
+++ b/backend/src/routes/ogp.ts
@@ -74,7 +74,7 @@ ${image ? `<meta name="twitter:image" content="${escapeHtml(image)}">` : ""}
 </html>`;
 
   // PHASE_0_REVERT: Phase 1 移行時に X-Robots-Tag ヘッダーを削除
-  c.header("X-Robots-Tag", "noindex, nofollow, noarchive");
+  c.header("X-Robots-Tag", "noindex, nofollow, noarchive, nosnippet");
   return c.html(html);
 });
 

--- a/docs/ideas/022-pre-launch-checklist.md
+++ b/docs/ideas/022-pre-launch-checklist.md
@@ -43,6 +43,9 @@ Phase 0 では:
   - 簡単な文章でサイト上に掲載すれば足りる（正式なポリシーページ不要）
 - [ ] **HTTPS 有効確認**: Cloudflare Pages / Railway で TLS が有効であること
 - [ ] **管理者認証の基本セキュリティ**: 家族アカウントのパスワード強度、JWT の基本的な保護
+- [ ] **クロール拒否**（一時対策）: `robots.txt` で全拒否 + 主要 LLM クローラー個別明示、SPA / OGP レスポンスに `noindex` meta と `X-Robots-Tag` ヘッダー、Cloudflare Bot Fight Mode を有効化。Phase 1 解除手順は `docs/phase1-revert-checklist.md` を参照
+  - 目的: 家族ライフログ段階での検索エンジン / LLM 学習データ混入を防ぐ、クローラートラフィックのコスト暴走を防ぐ
+  - Phase 1 で一般公開時に robots.txt と meta の `Disallow: /` / noindex を解除
 
 ### Recommended (Phase 0)
 

--- a/docs/phase0-public-exposure-audit.md
+++ b/docs/phase0-public-exposure-audit.md
@@ -1,0 +1,99 @@
+# Phase 0 Public Exposure Audit
+
+> 最終更新: 2026-04-17
+> 対象: Phase 0 リリース直前の「未ログインで何が見えるか」の確認
+
+Phase 0 の戦略（Idea 022）は**「家族数名のライフログ + 閲覧のみ一般公開」**。
+したがって `/@username` や `/discover` を未ログインで閲覧できること自体は意図的な仕様。
+本監査の目的は、その前提のもとで **想定外の情報が漏れていないか** を確認すること。
+
+## スコープ
+
+- フロントエンド: Flutter Web SPA (Cloudflare Pages)
+- バックエンド: Hono API (Railway)
+- クローラー対策: `/robots.txt` + `<meta name="robots">` + OGP レスポンスの `X-Robots-Tag`（本 PR で導入）
+
+## 1. フロントエンド公開ルート（Flutter GoRouter）
+
+`frontend/lib/router.dart` の `redirect` ロジックで、未ログインでもアクセス可能なパスは以下:
+
+| パス | 画面 | 露出内容 |
+|------|------|---------|
+| `/splash` | SplashScreen | ブランド表示のみ |
+| `/login` | LoginScreen | ログインフォーム |
+| `/signup` | SignupScreen | 新規登録フォーム（`?invite=` クエリ受け付け） |
+| `/about` | AboutScreen | 運営者・連絡先・外部送信開示（Idea 022 Required） |
+| `/discover` | DiscoverScreen | 公開アーティスト一覧（`profileVisibility = 'public'` のみ） |
+| `/@:username` | PublicTimelineScreen | 公開アーティストのタイムライン（`profileVisibility = 'public'` のみ） |
+| `/onboarding` | OnboardingScreen | サインアップ後フロー（認証必須だが redirect 経路として allow） |
+
+**備考**:
+- `/@:username` の `username` は正規表現 `^[a-zA-Z0-9_]{1,39}$` で厳格バリデーション済み（SSRF / オープンリダイレクト対策）
+- `/discover` は PR #215 で意図的に未ログイン解放（Phase 0 の「閲覧のみ公開」戦略の一環）
+
+## 2. バックエンド公開エンドポイント（Hono）
+
+`backend/src/index.ts` で `authMiddleware` は全ルートに適用されるが、**失敗しても通す（soft auth）** 仕様。resolver 層で `ctx.authUser` を見て認可する。
+
+| エンドポイント | 認証 | 露出内容 |
+|--------------|------|---------|
+| `GET /health` | 不要 | `{ status: "ok" / "error", db: "connected" / "disconnected" }`。内部 IP やバージョン情報なし |
+| `GET /ogp/:atUsername` | 不要 | 公開アーティストの `displayName` / `bio` / `tagline` / `avatarUrl` / 正規 URL。OGP/Twitter Card 用 HTML。本 PR で `<meta name="robots" content="noindex,...">` + `X-Robots-Tag` ヘッダーを追加 |
+| `GET/POST /graphql` | soft | resolver 層で個別認可 |
+
+## 3. GraphQL 未認証クエリ面
+
+`ctx.authUser` が `null` でも実行可能なクエリ一覧と、返却フィールド（公開データのみ）:
+
+| クエリ | 返却対象 | 認可条件 |
+|--------|---------|---------|
+| `featuredArtist` | フィーチャー済み公開アーティスト 1 件 | `profileVisibility = 'public'` |
+| `artist(username)` | 指定アーティスト | `checkArtistAccess()` で `public` のみ通過、private は `null` 返却 |
+| `discoverArtists` | 公開アーティスト一覧（検索・ジャンル・ランキング） | `profileVisibility = 'public'` のみ |
+| `genres` | ジャンル一覧（マスタデータ） | 制限なし（マスタのため OK） |
+| `post(id)` / `posts` / `artistPosts` | 公開投稿（`visibility = 'public'`） | 認可フィルタ経路で private は除外 |
+| `reactions(postId)` | 公開投稿のリアクション | 投稿の visibility に準拠 |
+| `comments(postId)` | — | **Phase 0 では schema から除外済み（PR #219）** |
+
+### 未認証で得られる付帯情報
+
+- `tunedInCount`（そのアーティストの Tune In 数）
+- `followersCount`（フォロワー数）
+- `avatarUrl`、`bio`、`tagline`、`displayName`
+- 公開投稿のリアクション・メディア URL
+
+**Phase 0 戦略判断**: これらは Phase 0 の「閲覧のみ公開」の意図どおり。`robots.txt + noindex + X-Robots-Tag` でクローラー経由のスケール露出を防ぐ方針。
+
+## 4. クローラー対策（本 PR で導入）
+
+### 防御層
+
+| 層 | 対策 | ファイル |
+|----|------|---------|
+| 静的 SPA | `frontend/web/robots.txt` で `Disallow: /` + LLM クローラー個別明示 | 新規作成 |
+| 静的 SPA | `frontend/web/index.html` の `<meta name="robots" content="noindex,nofollow,noarchive,nosnippet">` | 編集 |
+| OGP HTML | `<meta name="robots" content="noindex,...">` + `X-Robots-Tag` HTTP ヘッダー | `backend/src/routes/ogp.ts` |
+| ネットワーク層 | Cloudflare Bot Fight Mode（Free tier）+ WAF rate limiting | Preflight メモリ参照（手動設定） |
+
+### 対応しないもの（判断と根拠）
+
+- **未認証 GraphQL フィールドレベルの隠蔽（tunedInCount 等）**: `/discover` のランキング順が壊れる。防御多重化より robots.txt + noindex の方針を優先
+- **成人サインアップ時の `profileVisibility` デフォルトを `private` に変更**: `/discover` が空になり Phase 0 の「閲覧のみ公開」戦略と矛盾
+- **`frontend/functions/[[path]].ts` の bot 検出を `/@username` 以外にも拡張**: `/manifest.json` や `/icons/*` の露出は低影響。Cloudflare Bot Fight Mode で対応
+
+## 5. 既知の留意点
+
+- `manifest.json` / `icons/*` / `flutter_bootstrap.js` は Cloudflare Pages の静的配信レイヤーから直接返されるため、SPA の `<meta name="robots">` は当たらない。`robots.txt` で `Disallow: /` を指定しているため well-behaved なクローラーはアクセスしない想定だが、Bot Fight Mode で多層防御
+- OGP レスポンスは `Cache-Control: public, max-age=300` で Cloudflare CDN にキャッシュされる。Phase 1 リバート時はキャッシュパージが必要（`docs/phase1-revert-checklist.md` 参照）
+- GraphQL introspection は本番で `useDisableIntrospection` プラグインにより無効化済み（`backend/src/graphql/index.ts`）
+
+## 6. 関連 ADR / Idea
+
+- **Idea 022**: Phase 0 Pre-launch Checklist（戦略の土台）
+- **ADR 022**: 電気通信事業法届出（Phase 0 は不要扱い）
+- **ADR 019**: Age Policy（未成年者データ保護）— 本監査と直接競合なし
+- **ADR 020**: Security Architecture — Phase 1 Immediate/Short-term タスクは別スコープ
+
+## 7. Phase 1 リバート時の参考
+
+クロール拒否・露出監査に関する Phase 0 マーカーを `grep -rn PHASE_0_REVERT: gleisner/` で一括検出可能。手順は `docs/phase1-revert-checklist.md` を参照。

--- a/docs/phase1-revert-checklist.md
+++ b/docs/phase1-revert-checklist.md
@@ -11,7 +11,7 @@ Phase 0 の位置づけと対策の背景は以下を参照:
 全ての PHASE_0_REVERT マーカーを検出:
 
 ```bash
-grep -rn "PHASE_0_REVERT" gleisner/ --include="*.ts" --include="*.dart" --include="*.html" --include="*.txt"
+grep -rn "PHASE_0_REVERT" gleisner/ --include="*.ts" --include="*.dart" --include="*.html" --include="*.txt" --include="*.sh"
 ```
 
 Cloudflare ダッシュボードや環境変数の変更は grep では検出できないため、本チェックリストで補完する。

--- a/docs/phase1-revert-checklist.md
+++ b/docs/phase1-revert-checklist.md
@@ -34,10 +34,14 @@ Cloudflare ダッシュボードや環境変数の変更は grep では検出で
 
 ### 1.3 OGP レスポンスの noindex 削除
 
-- [ ] `gleisner/backend/src/routes/ogp.ts` の以下を削除:
-  - 生成 HTML 内の `<meta name="robots" content="noindex,...">`
-  - `c.header("X-Robots-Tag", "noindex, nofollow, noarchive");`
+- [ ] `gleisner/backend/src/routes/ogp.ts` の PHASE_0_REVERT マーカー付き箇所を削除:
+  - 生成 HTML 内の `<meta name="robots" ...>` 行
+  - `c.header("X-Robots-Tag", ...)` 行
+- [ ] `gleisner/frontend/functions/[[path]].ts` の PHASE_0_REVERT マーカー付き箇所を削除:
+  - Pages Function が OGP レスポンスをプロキシする際の `X-Robots-Tag` 転送ロジック
 - [ ] 対応するテスト `backend/src/routes/__tests__/ogp.test.ts` の `"includes Phase 0 noindex meta and X-Robots-Tag header"` ケースを削除または調整
+
+> 各ファイルの正確な削除対象は `grep -n "PHASE_0_REVERT" <file>` で特定する（1.3 セクションに具体的な文字列を書かないのは、実装が進化したときにドキュメントと実コードの乖離を避けるため）
 
 ### 1.4 CDN キャッシュパージ
 

--- a/docs/phase1-revert-checklist.md
+++ b/docs/phase1-revert-checklist.md
@@ -85,3 +85,18 @@ Phase 1 移行 PR マージ後:
 - [ ] Google Search Console で "site:gleisner.app" が徐々にインデックスされ始めるか（数日〜週単位）
 - [ ] Twitter Card Validator / Facebook Debugger で OGP プレビューが正常表示
 - [ ] Cloudflare Analytics でクローラートラフィックが急増しても従量課金アラートが出ないこと
+
+### Phase 0 時点の逆向き検証
+
+Phase 0 リリース直後・リリース後定期的に実行:
+
+```bash
+./scripts/verify-phase0-deploy.sh                    # default: https://gleisner.app
+./scripts/verify-phase0-deploy.sh https://staging.gleisner.app  # ステージング向け
+SEED_USER=myartist ./scripts/verify-phase0-deploy.sh            # 確認対象のアーティストを指定
+```
+
+- 全パス = Phase 0 状態が正しく反映されている
+- 失敗 = robots.txt / noindex meta / X-Robots-Tag / OGP プロキシのいずれかが本番で壊れている
+
+Phase 1 移行時はスクリプト自体を削除するか、検証項目を反転させる。

--- a/docs/phase1-revert-checklist.md
+++ b/docs/phase1-revert-checklist.md
@@ -1,0 +1,87 @@
+# Phase 1 Revert Checklist
+
+Phase 0 で一時的に導入した制限を、Phase 1（クローズドベータ）移行時に解除するためのチェックリスト。
+
+Phase 0 の位置づけと対策の背景は以下を参照:
+- `docs/ideas/022-pre-launch-checklist.md`（Phase 戦略全体）
+- `docs/phase0-public-exposure-audit.md`（未ログイン露出の監査）
+
+## 一括検出コマンド
+
+全ての PHASE_0_REVERT マーカーを検出:
+
+```bash
+grep -rn "PHASE_0_REVERT" gleisner/ --include="*.ts" --include="*.dart" --include="*.html" --include="*.txt"
+```
+
+Cloudflare ダッシュボードや環境変数の変更は grep では検出できないため、本チェックリストで補完する。
+
+## 1. クロール拒否の解除
+
+### 1.1 robots.txt の更新
+
+- [ ] `gleisner/frontend/web/robots.txt` の `Disallow: /` を削除または調整
+- [ ] LLM クローラーについては Phase 1 方針を再決定（継続拒否 / 一部許可 / 全許可）
+- [ ] **6 ヶ月ごとに LLM クローラー UA リストを見直す**（2026-04 時点で最新。UA 名・robots.txt 尊重状況は変動が速い）
+
+### 1.2 SPA meta タグの削除
+
+- [ ] `gleisner/frontend/web/index.html` の以下 2 行を削除:
+  ```html
+  <meta name="robots" content="noindex,nofollow,noarchive,nosnippet">
+  <meta name="googlebot" content="noindex,nofollow">
+  ```
+
+### 1.3 OGP レスポンスの noindex 削除
+
+- [ ] `gleisner/backend/src/routes/ogp.ts` の以下を削除:
+  - 生成 HTML 内の `<meta name="robots" content="noindex,...">`
+  - `c.header("X-Robots-Tag", "noindex, nofollow, noarchive");`
+- [ ] 対応するテスト `backend/src/routes/__tests__/ogp.test.ts` の `"includes Phase 0 noindex meta and X-Robots-Tag header"` ケースを削除または調整
+
+### 1.4 CDN キャッシュパージ
+
+- [ ] Cloudflare Pages / OGP エンドポイントのキャッシュをパージ
+  - 理由: OGP レスポンスは `Cache-Control: public, max-age=300` でキャッシュ済み
+  - 方法: Cloudflare Dashboard → Caching → Purge Everything（または URL 指定）
+
+## 2. Cloudflare Bot 対策の緩和
+
+Phase 1 で招待制ベータを開始する際、クローラー拒否の強度を緩和:
+
+- [ ] Bot Fight Mode の設定を見直し（特に Turnstile を導入した場合は要整合性確認）
+- [ ] WAF Rate Limiting ルールを一般公開時に合わせてチューニング
+- [ ] Phase 1 時点で Preflight メモリを更新（`project_phase0_preflight.md`）
+
+## 3. コメント機能の復帰（PR #219）
+
+別 Issue: **#221** で追跡中。
+
+- [ ] `backend/src/graphql/types/index.ts` の `import "./comment.js";` アンコメント
+- [ ] `backend/src/graphql/__tests__/comment.test.ts` 冒頭の個別 `import "../types/comment.js"` を削除
+- [ ] `backend/src/graphql/__tests__/public-user.test.ts` の `"comments query user does not expose email"` の `it.skip` → `it` に戻す
+- [ ] コメント関連のフロント UI を表示に戻す
+- [ ] 電気通信事業法（ADR 022）観点で弁護士相談が完了していることを確認
+
+## 4. その他の Phase 1 対応（参考）
+
+本チェックリスト外だが、Phase 1 移行時に同時検討すべき項目:
+
+- [ ] セキュリティ Immediate タスク（ADR 020）: CORS 本番設定、CSP/X-Frame-Options、アカウント列挙防止
+- [ ] 利用規約・プライバシーポリシー・AI 利用ポリシーのドラフト作成（Idea 022 Phase 1 Required）
+- [ ] 弁護士初回相談完了
+- [ ] 商標登録出願の開始
+- [ ] メール送信基盤（SPF/DKIM/DMARC）
+
+詳細は `docs/ideas/022-pre-launch-checklist.md` の Phase 1 セクション参照。
+
+## 5. 検証手順
+
+Phase 1 移行 PR マージ後:
+
+- [ ] `curl https://gleisner.app/robots.txt` が Phase 1 設定を返すか
+- [ ] `curl -I https://gleisner.app/` に noindex ヘッダーがないか
+- [ ] `curl -I https://gleisner.app/ogp/@seeduser` に X-Robots-Tag がないか
+- [ ] Google Search Console で "site:gleisner.app" が徐々にインデックスされ始めるか（数日〜週単位）
+- [ ] Twitter Card Validator / Facebook Debugger で OGP プレビューが正常表示
+- [ ] Cloudflare Analytics でクローラートラフィックが急増しても従量課金アラートが出ないこと

--- a/frontend/functions/[[path]].ts
+++ b/frontend/functions/[[path]].ts
@@ -71,6 +71,12 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       headers: {
         "Content-Type": "text/html; charset=utf-8",
         "Cache-Control": "public, max-age=300",
+        // PHASE_0_REVERT: Forward the backend's X-Robots-Tag so SNS bots
+        // see noindex. Without this, reconstructing the Response drops
+        // the header and the OGP path loses its noindex signal.
+        "X-Robots-Tag":
+          ogpResponse.headers.get("X-Robots-Tag") ??
+          "noindex, nofollow, noarchive, nosnippet",
       },
     });
   } catch {

--- a/frontend/functions/[[path]].ts
+++ b/frontend/functions/[[path]].ts
@@ -74,8 +74,9 @@ export const onRequest: PagesFunction<Env> = async (context) => {
         // PHASE_0_REVERT: Forward the backend's X-Robots-Tag so SNS bots
         // see noindex. Without this, reconstructing the Response drops
         // the header and the OGP path loses its noindex signal.
+        // Headers.get() is case-insensitive per Fetch spec.
         "X-Robots-Tag":
-          ogpResponse.headers.get("X-Robots-Tag") ??
+          ogpResponse.headers.get("x-robots-tag") ??
           "noindex, nofollow, noarchive, nosnippet",
       },
     });

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -20,6 +20,10 @@
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Gleisner — Your creative journey, your universe">
 
+  <!-- PHASE_0_REVERT: Phase 1 (public launch) 移行時に以下 2 行を削除。docs/phase1-revert-checklist.md 参照 -->
+  <meta name="robots" content="noindex,nofollow,noarchive,nosnippet">
+  <meta name="googlebot" content="noindex,nofollow">
+
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">

--- a/frontend/web/robots.txt
+++ b/frontend/web/robots.txt
@@ -1,0 +1,70 @@
+# PHASE_0_REVERT: This file blocks all crawlers during Phase 0 (family lifelog stage).
+# Phase 1 (closed beta) 移行時に削除または Disallow を調整すること。
+# 解除手順は docs/phase1-revert-checklist.md を参照。
+
+User-agent: *
+Disallow: /
+
+# LLM training / AI crawlers (2026-04 時点の主要リスト、6ヶ月ごとに見直し)
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: YouBot
+Disallow: /
+
+User-agent: AI2Bot
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /

--- a/scripts/verify-phase0-deploy.sh
+++ b/scripts/verify-phase0-deploy.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# PHASE_0_REVERT: このスクリプトは Phase 0 のクロール拒否対策が本番で機能しているかを検証する。
+# Phase 1 一般公開時は検証項目を反転させるか、スクリプトごと削除すること。
+# 参照: docs/phase1-revert-checklist.md
+
+set -uo pipefail
+
+BASE_URL="${1:-https://gleisner.app}"
+SEED_USER="${SEED_USER:-seeduser}"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# Colors (無効な環境 = plain)
+if [[ -t 1 ]]; then
+  G=$'\e[32m'; R=$'\e[31m'; Y=$'\e[33m'; B=$'\e[1m'; N=$'\e[0m'
+else
+  G=""; R=""; Y=""; B=""; N=""
+fi
+
+pass() { echo "${G}✓${N} $1"; PASS=$((PASS + 1)); }
+fail() { echo "${R}✗${N} $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "${Y}- ${N}$1 (skipped: $2)"; SKIP=$((SKIP + 1)); }
+
+section() { echo; echo "${B}==> $1${N}"; }
+
+check_contains() {
+  local label="$1" body="$2" needle="$3"
+  if grep -qi -- "$needle" <<< "$body"; then
+    pass "$label"
+  else
+    fail "$label — expected to find: $needle"
+  fi
+}
+
+check_header_contains() {
+  local label="$1" headers="$2" header_name="$3" needle="$4"
+  local line
+  line=$(grep -i "^${header_name}:" <<< "$headers" || true)
+  if [[ -z "$line" ]]; then
+    fail "$label — header '${header_name}' not present"
+    return
+  fi
+  if grep -qi -- "$needle" <<< "$line"; then
+    pass "$label"
+  else
+    fail "$label — header '${header_name}' missing value: $needle (got: ${line})"
+  fi
+}
+
+echo "${B}Phase 0 deploy verification${N}"
+echo "Target: $BASE_URL"
+echo "Seed user: $SEED_USER"
+
+# ----------------------------------------------------------------------
+section "1. robots.txt"
+# ----------------------------------------------------------------------
+ROBOTS_RESPONSE=$(curl -fsSL -w "\n%{http_code}" "$BASE_URL/robots.txt" 2>/dev/null || echo -e "\n000")
+ROBOTS_STATUS=$(tail -n1 <<< "$ROBOTS_RESPONSE")
+ROBOTS_BODY=$(sed '$d' <<< "$ROBOTS_RESPONSE")
+
+if [[ "$ROBOTS_STATUS" == "200" ]]; then
+  pass "GET /robots.txt returns 200"
+  check_contains "robots.txt contains 'Disallow: /'" "$ROBOTS_BODY" "Disallow: /"
+  check_contains "robots.txt blocks GPTBot" "$ROBOTS_BODY" "User-agent: GPTBot"
+  check_contains "robots.txt blocks ClaudeBot" "$ROBOTS_BODY" "User-agent: ClaudeBot"
+  check_contains "robots.txt blocks Google-Extended" "$ROBOTS_BODY" "User-agent: Google-Extended"
+  check_contains "robots.txt blocks PerplexityBot" "$ROBOTS_BODY" "User-agent: PerplexityBot"
+  check_contains "robots.txt blocks CCBot" "$ROBOTS_BODY" "User-agent: CCBot"
+else
+  fail "GET /robots.txt returned status $ROBOTS_STATUS (expected 200)"
+fi
+
+# ----------------------------------------------------------------------
+section "2. SPA index.html"
+# ----------------------------------------------------------------------
+INDEX_RESPONSE=$(curl -fsSL -w "\n%{http_code}" "$BASE_URL/" 2>/dev/null || echo -e "\n000")
+INDEX_STATUS=$(tail -n1 <<< "$INDEX_RESPONSE")
+INDEX_BODY=$(sed '$d' <<< "$INDEX_RESPONSE")
+
+if [[ "$INDEX_STATUS" == "200" ]]; then
+  pass "GET / returns 200"
+  check_contains "SPA has <meta name=\"robots\" noindex>" "$INDEX_BODY" 'name="robots".*noindex'
+  check_contains "SPA has <meta name=\"googlebot\" noindex>" "$INDEX_BODY" 'name="googlebot".*noindex'
+else
+  fail "GET / returned status $INDEX_STATUS (expected 200)"
+fi
+
+# ----------------------------------------------------------------------
+section "3. OGP endpoint (simulated Twitter/Facebook bot)"
+# ----------------------------------------------------------------------
+# Twitterbot simulation → Cloudflare Pages Function が OGP にプロキシする経路を確認
+OGP_HEADERS=$(curl -fsSL -D - -o /dev/null \
+  -A "Mozilla/5.0 (compatible; Twitterbot/1.0)" \
+  "$BASE_URL/@$SEED_USER" 2>/dev/null || true)
+OGP_BODY=$(curl -fsSL \
+  -A "Mozilla/5.0 (compatible; Twitterbot/1.0)" \
+  "$BASE_URL/@$SEED_USER" 2>/dev/null || true)
+
+if [[ -z "$OGP_BODY" ]]; then
+  skip "OGP endpoint check" "seed user '$SEED_USER' may not exist or not public — set SEED_USER env var to a known public artist"
+else
+  # OGP response or SPA response (Pages Function が bot 判定した場合のみ OGP HTML)
+  if grep -qi 'og:title' <<< "$OGP_BODY"; then
+    pass "Twitterbot UA receives OGP HTML (Pages Function proxy working)"
+    check_contains "OGP HTML contains noindex meta" "$OGP_BODY" 'name="robots".*noindex'
+    check_header_contains "OGP response has X-Robots-Tag: noindex" "$OGP_HEADERS" "x-robots-tag" "noindex"
+  else
+    skip "OGP HTML check" "Twitterbot UA got SPA response — check Pages Function deployed and seed user is public"
+  fi
+fi
+
+# ----------------------------------------------------------------------
+section "4. /discover returns SPA (not OGP) for browsers"
+# ----------------------------------------------------------------------
+# 通常ブラウザ UA で /discover を取得 → Flutter SPA が返ることを確認
+DISCOVER_BODY=$(curl -fsSL \
+  -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36" \
+  "$BASE_URL/discover" 2>/dev/null || true)
+
+if [[ -n "$DISCOVER_BODY" ]]; then
+  check_contains "/discover returns Flutter SPA" "$DISCOVER_BODY" "flutter_bootstrap.js"
+  check_contains "/discover has noindex meta" "$DISCOVER_BODY" 'name="robots".*noindex'
+else
+  fail "GET /discover returned empty body"
+fi
+
+# ----------------------------------------------------------------------
+section "5. Cloudflare Bot Fight Mode (手動確認項目)"
+# ----------------------------------------------------------------------
+# 注: Bot Fight Mode の ON/OFF は API でも取得できるが、API Token が必要。
+# 手動確認を促すのみ。
+echo "${Y}- 手動確認: Cloudflare Dashboard → Security → Bots → Bot Fight Mode が ON${N}"
+echo "  URL: https://dash.cloudflare.com/?to=/:account/:zone/security/bots"
+SKIP=$((SKIP + 1))
+
+# ----------------------------------------------------------------------
+section "6. OGP プレビュー検証（外部ツール）"
+# ----------------------------------------------------------------------
+echo "${Y}- 手動確認: 以下のツールで /@$SEED_USER のプレビューが正常表示されるか${N}"
+echo "  Twitter:  https://cards-dev.twitter.com/validator"
+echo "  Facebook: https://developers.facebook.com/tools/debug/?q=$BASE_URL/@$SEED_USER"
+SKIP=$((SKIP + 1))
+
+# ----------------------------------------------------------------------
+echo
+echo "${B}Summary${N}: ${G}${PASS} passed${N}, ${R}${FAIL} failed${N}, ${Y}${SKIP} skipped/manual${N}"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/verify-phase0-deploy.sh
+++ b/scripts/verify-phase0-deploy.sh
@@ -3,10 +3,28 @@
 # Phase 1 一般公開時は検証項目を反転させるか、スクリプトごと削除すること。
 # 参照: docs/phase1-revert-checklist.md
 
+# -e は意図的に付けない: 各 check_* ヘルパーが独立して fail カウンタを加算する設計のため、
+# 途中の失敗でスクリプト全体を中断しない。pass/fail の集計後に exit コードで結果を返す。
 set -uo pipefail
 
-BASE_URL="${1:-https://gleisner.app}"
-SEED_USER="${SEED_USER:-seeduser}"
+if [[ "${1:-}" == "" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  cat <<USAGE
+Usage: $0 <base_url> [seed_user]
+
+  <base_url>   検証対象の URL（必須）。例: https://staging.gleisner.app
+  [seed_user]  OGP 検証に使う公開アーティスト username（デフォルト: seeduser、
+               環境変数 SEED_USER でも指定可）
+
+例:
+  $0 https://staging.gleisner.app
+  $0 https://gleisner.app myartist
+  SEED_USER=myartist $0 https://gleisner.app
+USAGE
+  exit 64
+fi
+
+BASE_URL="$1"
+SEED_USER="${2:-${SEED_USER:-seeduser}}"
 
 PASS=0
 FAIL=0
@@ -63,11 +81,13 @@ ROBOTS_BODY=$(sed '$d' <<< "$ROBOTS_RESPONSE")
 if [[ "$ROBOTS_STATUS" == "200" ]]; then
   pass "GET /robots.txt returns 200"
   check_contains "robots.txt contains 'Disallow: /'" "$ROBOTS_BODY" "Disallow: /"
-  check_contains "robots.txt blocks GPTBot" "$ROBOTS_BODY" "User-agent: GPTBot"
-  check_contains "robots.txt blocks ClaudeBot" "$ROBOTS_BODY" "User-agent: ClaudeBot"
-  check_contains "robots.txt blocks Google-Extended" "$ROBOTS_BODY" "User-agent: Google-Extended"
-  check_contains "robots.txt blocks PerplexityBot" "$ROBOTS_BODY" "User-agent: PerplexityBot"
-  check_contains "robots.txt blocks CCBot" "$ROBOTS_BODY" "User-agent: CCBot"
+  # 主要な LLM/AI クローラーが個別ブロックされているかのサンプル検証。
+  # robots.txt の全エントリを検査する代わりに、代表的な UA を確認する。
+  # 全リストは frontend/web/robots.txt を参照。
+  REQUIRED_LLM_BOTS=(GPTBot ClaudeBot Google-Extended PerplexityBot CCBot)
+  for bot in "${REQUIRED_LLM_BOTS[@]}"; do
+    check_contains "robots.txt blocks $bot" "$ROBOTS_BODY" "User-agent: $bot"
+  done
 else
   fail "GET /robots.txt returned status $ROBOTS_STATUS (expected 200)"
 fi
@@ -90,13 +110,16 @@ fi
 # ----------------------------------------------------------------------
 section "3. OGP endpoint (simulated Twitter/Facebook bot)"
 # ----------------------------------------------------------------------
-# Twitterbot simulation → Cloudflare Pages Function が OGP にプロキシする経路を確認
-OGP_HEADERS=$(curl -fsSL -D - -o /dev/null \
+# Twitterbot simulation → Cloudflare Pages Function が OGP にプロキシする経路を確認。
+# ヘッダーと本文は 1 回の curl で同時取得する（CDN キャッシュ世代差でヘッダーと本文が
+# 不整合になる事故を防ぐ）。
+OGP_DUMP=$(curl -fsSL -D - \
   -A "Mozilla/5.0 (compatible; Twitterbot/1.0)" \
   "$BASE_URL/@$SEED_USER" 2>/dev/null || true)
-OGP_BODY=$(curl -fsSL \
-  -A "Mozilla/5.0 (compatible; Twitterbot/1.0)" \
-  "$BASE_URL/@$SEED_USER" 2>/dev/null || true)
+
+# ヘッダーと本文を空行で分割（HTTP/1.1 200 OK ... \r\n\r\n <body>）
+OGP_HEADERS=$(awk 'BEGIN{RS="\r\n\r\n"} NR==1{print; exit}' <<< "$OGP_DUMP")
+OGP_BODY=$(awk 'BEGIN{RS="\r\n\r\n"} NR>=2{print}' <<< "$OGP_DUMP")
 
 if [[ -z "$OGP_BODY" ]]; then
   skip "OGP endpoint check" "seed user '$SEED_USER' may not exist or not public — set SEED_USER env var to a known public artist"
@@ -106,6 +129,7 @@ else
     pass "Twitterbot UA receives OGP HTML (Pages Function proxy working)"
     check_contains "OGP HTML contains noindex meta" "$OGP_BODY" 'name="robots".*noindex'
     check_header_contains "OGP response has X-Robots-Tag: noindex" "$OGP_HEADERS" "x-robots-tag" "noindex"
+    check_header_contains "OGP response X-Robots-Tag includes nosnippet" "$OGP_HEADERS" "x-robots-tag" "nosnippet"
   else
     skip "OGP HTML check" "Twitterbot UA got SPA response — check Pages Function deployed and seed user is public"
   fi

--- a/scripts/verify-phase0-deploy.sh
+++ b/scripts/verify-phase0-deploy.sh
@@ -112,14 +112,15 @@ section "3. OGP endpoint (simulated Twitter/Facebook bot)"
 # ----------------------------------------------------------------------
 # Twitterbot simulation → Cloudflare Pages Function が OGP にプロキシする経路を確認。
 # ヘッダーと本文は 1 回の curl で同時取得する（CDN キャッシュ世代差でヘッダーと本文が
-# 不整合になる事故を防ぐ）。
-OGP_DUMP=$(curl -fsSL -D - \
+# 不整合になる事故を防ぐ）。ヘッダーは一時ファイル経由で受け取る（macOS BSD awk は
+# 複数文字 RS を扱えないため、awk での分割は避ける）。
+OGP_HEADERS_FILE=$(mktemp)
+# shellcheck disable=SC2064  # 現在の OGP_HEADERS_FILE 値を trap で固定したい
+trap "rm -f '$OGP_HEADERS_FILE'" EXIT
+OGP_BODY=$(curl -fsSL -D "$OGP_HEADERS_FILE" \
   -A "Mozilla/5.0 (compatible; Twitterbot/1.0)" \
   "$BASE_URL/@$SEED_USER" 2>/dev/null || true)
-
-# ヘッダーと本文を空行で分割（HTTP/1.1 200 OK ... \r\n\r\n <body>）
-OGP_HEADERS=$(awk 'BEGIN{RS="\r\n\r\n"} NR==1{print; exit}' <<< "$OGP_DUMP")
-OGP_BODY=$(awk 'BEGIN{RS="\r\n\r\n"} NR>=2{print}' <<< "$OGP_DUMP")
+OGP_HEADERS=$(cat "$OGP_HEADERS_FILE")
 
 if [[ -z "$OGP_BODY" ]]; then
   skip "OGP endpoint check" "seed user '$SEED_USER' may not exist or not public — set SEED_USER env var to a known public artist"


### PR DESCRIPTION
## Summary

PR #224 の振り返りで得られた学びを `.claude/rules/frontend-implementation.md` に定着させる。

Cloudflare Pages Functions で `return new Response(upstream.body, { headers: {...} })` を使うと、バックエンドが設定したヘッダー（`X-Robots-Tag` / `Set-Cookie` / 独自ヘッダー）が全部消える。PR #224 では OGP プロキシでこれをやってしまい、noindex 対策が実質無効化されていた（セキュリティレビュー Critical）。

## Rule added

R2 CORS 設定セクションの直後に配置（Cloudflare インフラ関連の隣接配置）。

- 3 つの安全パターン（pass-through / inherit / explicit forward）を提示
- コード例で ❌/✅ を対比
- `headers.get()` は case-insensitive だが Fetch API 慣習で小文字を使う点も併記
- PR #224 の具体症状を残して後のメンテナへの参照に

## Test plan

- [x] 既存 frontend-implementation.md の形式（セクション見出し、コードブロック、教訓記述）と整合
- [x] ドキュメント追加のみで動作変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)