### PR TITLE
docs: Cloudflare Pages Functions header preservation rule (retrospective #224)

### DIFF
--- a/.claude/rules/frontend-implementation.md
+++ b/.claude/rules/frontend-implementation.md
@@ -566,6 +566,39 @@ R2 ダッシュボード → バケット → Settings → CORS Policy で以下
 - `GET`: `Image.network` での画像表示用
 - カスタムドメイン（`media-dev.gleisner.app` 等）で CORS が効かない場合は、Cloudflare **Transform Rules** → **Modify Response Header** で `Access-Control-Allow-Origin: *` を追加
 
+### Cloudflare Pages Functions でバックエンドレスポンスをプロキシする際のヘッダー保全
+
+`return new Response(upstream.body, { headers: {...} })` は指定したヘッダーだけを返す。upstream.headers は引き継がれず、バックエンドが設定した `X-Robots-Tag` / `Set-Cookie` / 独自ヘッダー等が全部消える。
+
+- ヘッダー不変で中継: `return upstream;`（最もシンプル）
+- ヘッダーを一部追加・上書きしたい場合: `new Response(upstream.body, upstream)` で継承したうえで上書きするか、`upstream.headers.get(...)` で必要なものを明示転送する
+- HTTP ヘッダーは case-insensitive だが、Fetch API の慣習に合わせ `get()` には小文字を使う
+
+```ts
+// ❌ ヘッダー全消し — X-Robots-Tag や Set-Cookie が届かない
+return new Response(upstream.body, {
+  status: 200,
+  headers: {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "public, max-age=300",
+  },
+});
+
+// ✅ 必要なものだけ明示転送
+return new Response(upstream.body, {
+  status: 200,
+  headers: {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "public, max-age=300",
+    "X-Robots-Tag":
+      upstream.headers.get("x-robots-tag") ??
+      "noindex, nofollow, noarchive, nosnippet",
+  },
+});
+```
+
+PR #224 の教訓: OGP プロキシで `Content-Type` と `Cache-Control` だけ指定した結果、バックエンドの `X-Robots-Tag: noindex` が SNS bot に届かず、クローラー対策が実質無効化されていた。レビューで Critical 指摘。
+
 ### UI コンポーネント置換チェックリスト
 
 **共有ウィジェットを新規作成して既存の private ウィジェットを置き換える場合、全使用箇所を一括で置換すること。**


### PR DESCRIPTION
## Summary

PR #224 の振り返りで得られた学びを `.claude/rules/frontend-implementation.md` に定着させる。

Cloudflare Pages Functions で `return new Response(upstream.body, { headers: {...} })` を使うと、バックエンドが設定したヘッダー（`X-Robots-Tag` / `Set-Cookie` / 独自ヘッダー）が全部消える。PR #224 では OGP プロキシでこれをやってしまい、noindex 対策が実質無効化されていた（セキュリティレビュー Critical）。

## Rule added

R2 CORS 設定セクションの直後に配置（Cloudflare インフラ関連の隣接配置）。

- 3 つの安全パターン（pass-through / inherit / explicit forward）を提示
- コード例で ❌/✅ を対比
- `headers.get()` は case-insensitive だが Fetch API 慣習で小文字を使う点も併記
- PR #224 の具体症状を残して後のメンテナへの参照に

## Test plan

- [x] 既存 frontend-implementation.md の形式（セクション見出し、コードブロック、教訓記述）と整合
- [x] ドキュメント追加のみで動作変更なし

## Note

このブランチは PR #225 の再作成（#225 はブランチ元が誤って未マージの #224 に向いていて diff 膨張）。#225 は close 予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)