### PR TITLE
Ignore .claude/plans and .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ build/
 
 # mise
 .mise/
+
+# Claude Code worktrees & temporary plans
+.claude/worktrees/
+.claude/plans/


### PR DESCRIPTION
Match yatima root's convention — plan files from the `/plan` skill are session-local. Without this rule they stayed permanently untracked, which also made the yatima root's `git status` show the submodule as dirty.