### PR TITLE
Group @aws-sdk/* packages in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    groups:
+      # AWS SDK packages share private types across modules and must be
+      # bumped together. Without grouping, a bump to @aws-sdk/client-s3
+      # alone breaks @aws-sdk/s3-request-presigner's type compatibility.
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
 
   # Frontend: pub (Flutter/Dart)
   - package-ecosystem: "pub"


### PR DESCRIPTION
## Summary
- `@aws-sdk/*` パッケージは private な型（`Client.handlers` 等）を共有しているため、同一バージョンで揃える必要がある
- Dependabot がグループ化なしだと `@aws-sdk/client-s3` だけ単独で PR を出し、`s3-request-presigner` の型不整合で TypeScript ビルドが失敗する
- 以降 `@aws-sdk/*` が 1 つの PR にまとまるよう groups 設定を追加

## Background
PR #233 (\`@aws-sdk/client-s3\` 3.1030 → 3.1033) で以下の型エラーが発生:

\`\`\`
src/storage/r2.ts(143,40): error TS2345: Argument of type 'S3Client' is not
assignable to parameter of type 'Client<any, ServiceInputTypes, MetadataBearer, any>'.
  Types have separate declarations of a private property 'handlers'.
\`\`\`

この PR マージ後に PR #233 を close し、次回 Dependabot 実行でまとまった PR を受け取る運用に切り替える。

## Test plan
- [ ] CI が通る（YAML の文法エラーがない）
- [ ] マージ後、次回 Dependabot 実行で \`@aws-sdk/*\` が 1 つの PR にまとまっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)