### PR TITLE
docs: codify PR #246 i18n retrospective lessons

### DIFF
--- a/.claude/rules/frontend-implementation.md
+++ b/.claude/rules/frontend-implementation.md
@@ -35,12 +35,124 @@
 
 **⚠ i18n 大量変更後は残存ハードコード英語を Grep で網羅チェックすること。**
 
+**ARB のトラップ集（PR #246 の教訓）**:
+
+- **`"format": "decimal"` は Flutter intl で無効**。`NumberFormat.decimal()` というコンストラクタが存在しないため、gen-l10n が `does not have a corresponding NumberFormat constructor` で落ちる。**`"type": "int"` だけを指定**すれば型安全性は確保できる（引数が `int` として生成される）。数値の表示書式を変えたい時だけ `"format": "compact" | "currency"` 等の有効値を使う。
+
+```json
+// ❌ gen-l10n がエラーで停止
+"@videoTooLong": {
+  "placeholders": { "minutes": { "type": "int", "format": "decimal" } }
+}
+
+// ✅ type のみで十分
+"@videoTooLong": {
+  "placeholders": { "minutes": { "type": "int" } }
+}
+```
+
+- **単複形がある言語は ICU plural 構文で書く**。placeholder 名を `minutes` にして文中を単数 `minute` で固定すると、値が 2 以上になった時に `"must be 5 minute or shorter"` のような文法崩壊が起きる。EN 側は `{minutes, plural, =1{1 minute} other{{minutes} minutes}}` で単複を明示。JA 側は単複区別がないが、**将来の plural 追加・他言語移植に備えて ICU 構文で揃える**（`{minutes, plural, other{{minutes}分}}`）。
+
+```json
+// ❌ 単数固定 — "must be 5 minute" で文法崩壊
+"videoTooLong": "Video must be {minutes} minute or shorter."
+
+// ✅ ICU plural
+"videoTooLong": "Video must be {minutes, plural, =1{1 minute} other{{minutes} minutes}} or shorter."
+```
+
+- **新規キーには必ず `@key` で `description` を書く**。翻訳者（将来の別言語追加、LLM 翻訳レビュー、i18n ベンダー）向けの文脈情報。「どんな状況で表示されるか」を 1 文で明記する。
+
+```json
+"@videoTooLong": {
+  "description": "Shown when the selected video exceeds the duration limit. Pluralizes the minute/minutes noun based on count.",
+  "placeholders": { "minutes": { "type": "int" } }
+}
+```
+
 PR #216 の教訓: 4つの並列エージェントで ~170 文字列を置換したが、共通ウィジェット内（`EventAtPicker`, `CoverImage`, `TutorialSpotlight`, `milestone_category.dart` の static リスト等）に多数の未翻訳が残り、11回のコミットで段階的に修正した。エージェントの「完了」報告を過信せず、以下のコマンドで確認すること:
 
 ```bash
 # lib/ 内のハードコード英語文字列を検索（debugPrint/import/comment 除外）
 grep -rn "'[A-Z][a-z]" lib/screens/ lib/widgets/ --include="*.dart" | grep -v debugPrint | grep -v import | grep -v "^\s*//"
 ```
+
+### enum に対する switch は全ケース明示（ワイルドカード禁止）
+
+**`enum` を switch で扱う時、`_ => ...` のワイルドカードを使わず全バリアントを列挙すること。** ワイルドカードを使うと、将来 enum に値を追加した時にコンパイラが警告を出さず、ヒント表示・バリデーション・認可チェックが静かに壊れる。
+
+```dart
+// ❌ ワイルドカード — MediaType.podcast を追加しても気づかない
+int? maxMinutesFor(MediaType m) => switch (m) {
+  MediaType.video => 1,
+  MediaType.audio => 5,
+  _ => null,
+};
+
+// ✅ 全ケース列挙 — 追加時に "pattern is not exhaustive" でコンパイラ警告
+int? maxMinutesFor(MediaType m) => switch (m) {
+  MediaType.video => 1,
+  MediaType.audio => 5,
+  MediaType.image ||
+  MediaType.thought ||
+  MediaType.article ||
+  MediaType.link => null,
+};
+```
+
+該当箇所: 新規 MediaType 値追加時のチェックリスト（backend-implementation.md「MediaType enum 値の追加/変更チェックリスト」）と対応。**switch の網羅性はコンパイラによる防御線**なので、ワイルドカードで崩さない。
+
+PR #246 の教訓: `uploadHintFor` / `maxMinutesFor` 初回実装でワイルドカードを使い、レビューで指摘されて exhaustive に修正。
+
+### Notifier の error state に解決済み文字列を入れない（i18n 化時の設計判断軸）
+
+**Notifier が発するエラーを i18n 化する時、`state.error: String?` に解決済み文字列を入れる実装は避けること。** `AppLocalizations` を Notifier メソッドに required 引数として渡すパターン（`validators_l10n.dart` 風）は単純だが、以下の設計負債を背負う:
+
+1. **ロケール動的切替で stale**: 日本語でエラー発生 → 言語を英語に切替 → 画面を再描画しても state には日本語の文字列が残ったまま
+2. **レイヤー越境**: Notifier が UI 層型（`AppLocalizations`）に依存 → バックグラウンドジョブ・テスト・AI 自動投稿等から呼びにくくなる
+3. **API 汚染**: ディスパッチ系メソッド（例: `pickByMediaType`）で一部の分岐が l10n を使わない場合でも、required 引数として常に要求される
+
+```dart
+// ❌ AppLocalizations を Notifier に流入（Option B）
+class FooNotifier {
+  Future<void> doSomething({
+    required String input,
+    required AppLocalizations l10n,  // UI 層概念が漏れる
+  }) async {
+    if (input.isEmpty) {
+      state = FooState(error: l10n.invalidInput);  // 解決済み文字列
+    }
+  }
+}
+
+// ✅ error code を state に保持（Option A）
+sealed class FooError {
+  String localize(AppLocalizations l10n);
+}
+
+class InvalidInput extends FooError {
+  const InvalidInput();
+  @override
+  String localize(AppLocalizations l10n) => l10n.invalidInput;
+}
+
+class FooNotifier {
+  Future<void> doSomething({required String input}) async {
+    if (input.isEmpty) {
+      state = const FooState(error: InvalidInput());
+    }
+  }
+}
+
+// UI 側で解決
+Text(state.error!.localize(context.l10n))
+```
+
+**例外（Option B が許容される場合）**:
+- **`validators_l10n.dart` のようなステートレス関数**: 呼び出し都度生成でエラーを返すだけ、state に保持しない。Option B で十分
+- **Phase 0 初期実装で時間が限られ、かつロケール切替 UX が未実装**: トレードオフを明記の上で Option B を採用し、Phase 1 で Option A に移行する Issue を起票する
+
+PR #246 の教訓: `MediaUploadNotifier` を `validators_l10n` パターンに追従して Option B で実装したが、レビュー信頼度 85 で「レイヤー越境 + stale 問題」を指摘され、Issue #248 で Option A 移行を追跡。次回 Notifier の i18n 化では最初から Option A を検討する。
 
 ### データ操作・ビジネスロジックは Provider/Notifier 層で
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,4 +214,13 @@ cd frontend && dart analyze lib/ && dart format --set-exit-if-changed . && flutt
 
 **`pnpm format:check` を忘れない。** `sed` 等でテストファイルを手動編集した後は特に注意。
 
+**`dart format` は PR スコープに限定すること。** `dart format .` や `dart format lib/` を実行するとリポジトリ全体の stale フォーマットを掃除してしまい、触っていないファイル（PR 対象外の `timeline_screen.dart` 等）が変更に含まれてレビュー対象が肥大化する。
+
+- PR 前の確認に `dart format --set-exit-if-changed .` を使うのは可（exit code だけ見て、実変更は commit しない）
+- 実際にフォーマットを適用するときは **変更ファイルを明示指定**: `dart format <file1> <file2> ...`
+- 既に他ファイルが reformat された場合は `git checkout -- <file>` で戻す
+- stale フォーマットを本気で掃除したい場合は、独立した PR（「既存 stale format の一括修正」）を起票して分離する
+
+PR #246 の教訓: `dart format --set-exit-if-changed .` のつもりで実体適用してしまい、無関係な 3 ファイルの reformat を PR から外すために 3 回 revert することになった。
+
 **`flutter test` は `--platform chrome` が必須。** `dart:js_interop` / `package:web/web.dart` を直接・推移的に import するテストは VM 上でコンパイルできず、`package:web` の `toJS`/`jsify` 等が「未定義」エラーになる。`heic_converter.dart` / `web_file_picker.dart` / `image_sanitizer.dart` 等を import する test（直接 import していなくても `media_upload_provider.dart` 経由で推移的に入る）は全て該当。`--platform chrome` なしで実行すると一見「テストが落ちた」ように見えるので、実行方法を疑う前にプラットフォームを確認する。


### PR DESCRIPTION
## Summary

PR #246（メディアアップロード UX ヒント + i18n 化）のレビューと実装過程で得た学びを、CLAUDE.md および `.claude/rules/frontend-implementation.md` に定着させます。

## 反映したルール（4 件）

### i18n 関連（frontend-implementation.md）

1. **ARB トラップ集**
   - \`\"format\": \"decimal\"\` は Flutter intl の無効な NumberFormat で gen-l10n が失敗する。\`\"type\": \"int\"\` だけで型安全性は十分
   - 単複形がある言語は ICU plural 構文で明示（\`{minutes, plural, =1{1 minute} other{{minutes} minutes}}\`）。placeholder 名だけ複数形で文中が単数固定だと \"must be 5 minute\" のような文法崩壊が起きる
   - 新規 \`@key\` には \`description\` を必ず書く（翻訳者向けの文脈情報）

2. **enum に対する switch は全ケース明示**
   - ワイルドカード \`_ => null\` を使わず全バリアントを列挙
   - 将来の enum 追加時にコンパイラ警告が出て静かに壊れることを防ぐ

3. **Notifier の error state に解決済み文字列を入れない**
   - \`validators_l10n.dart\` パターンを Notifier に適用すると、ロケール切替で stale 表示・レイヤー越境・API 汚染の設計負債
   - Option A (error code enum + UI で localize) を推奨、Option B 許容条件も明記

### PR 前チェック（CLAUDE.md）

4. **\`dart format\` は PR スコープに限定**
   - \`dart format .\` / \`dart format lib/\` は PR 外ファイルの stale format を掃除して diff を肥大化させる
   - 実体適用時は変更ファイルを明示指定、他ファイルが reformat されたら \`git checkout -- <file>\` で戻す

## 関連

- PR #246: 元の i18n 化 PR
- Issue #247: 他 21 箇所の i18n 漏れ（本 retrospective の 1, 2 を適用する対象）
- Issue #248: AppLocalizations レイヤー越境リファクタ（retrospective 3 の Option A 移行）

## Test plan

- [x] ドキュメント変更のみ、コード変更なし
- [x] 既存セクションとの重複確認済み（i18n 既存ルール / PR 前チェック / review-policy）

🤖 Generated with [Claude Code](https://claude.com/claude-code)