### PR TITLE
Resolve N+1 author query in post list resolvers (#180)

### DIFF
--- a/backend/src/graphql/__tests__/post.test.ts
+++ b/backend/src/graphql/__tests__/post.test.ts
@@ -1017,6 +1017,233 @@ describe("Post GraphQL integration", () => {
     });
   });
 
+  // Regression tests for Issue #180 — author prefetch via list resolvers.
+  // These verify that the JOIN-based prefetch (_author) is consumed correctly
+  // by PostType.author, and that the fallback SELECT path is not needed for
+  // list queries. All post-list returning paths must include author prefetch.
+  describe("author prefetch via list resolvers (#180)", () => {
+    const POSTS_WITH_AUTHOR_QUERY = `
+      query Posts($trackId: String!) {
+        posts(trackId: $trackId) {
+          id title author { id username displayName }
+        }
+      }
+    `;
+
+    const ARTIST_POSTS_WITH_AUTHOR_QUERY = `
+      query ArtistPosts($artistId: String!) {
+        artistPosts(artistId: $artistId) {
+          id title author { id username displayName }
+        }
+      }
+    `;
+
+    const ARTIST_RECENT_POSTS_QUERY = `
+      query Artist($username: String!) {
+        artist(username: $username) {
+          id
+          recentPosts {
+            id title author { id username displayName }
+          }
+        }
+      }
+    `;
+
+    const TRACK_POSTS_WITH_AUTHOR_QUERY = `
+      query Track($id: String!) {
+        track(id: $id) {
+          id
+          posts {
+            id title author { id username displayName }
+          }
+        }
+      }
+    `;
+
+    const MY_UNASSIGNED_WITH_AUTHOR_QUERY = `
+      query {
+        myUnassignedPosts {
+          id title author { id username displayName }
+        }
+      }
+    `;
+
+    const MY_ARTIST_QUERY = `
+      query {
+        myArtist { id artistUsername }
+      }
+    `;
+
+    async function setupAuthoredPost(
+      email: string,
+      username: string,
+      artistUsername: string,
+      postTitle: string,
+    ) {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        email,
+        username,
+        artistUsername,
+      );
+      await gql(
+        app,
+        CREATE_POST_MUTATION,
+        {
+          trackId,
+          mediaType: "article",
+          title: postTitle,
+          visibility: "public",
+        },
+        token,
+      );
+      const myArtistResult = await gql(app, MY_ARTIST_QUERY, {}, token);
+      const artistId = (myArtistResult.data!.myArtist as { id: string }).id;
+      return { token, trackId, artistId };
+    }
+
+    it("posts(trackId) returns author via JOIN prefetch", async () => {
+      const { trackId } = await setupAuthoredPost(
+        "pa1@example.com",
+        "pauser1",
+        "paartist1",
+        "Posts Query Author",
+      );
+
+      const result = await gql(app, POSTS_WITH_AUTHOR_QUERY, { trackId });
+
+      expect(result.errors).toBeUndefined();
+      const list = result.data!.posts as Array<Record<string, unknown>>;
+      expect(list).toHaveLength(1);
+      const author = list[0].author as Record<string, unknown>;
+      expect(author.username).toBe("pauser1");
+      expect(author.id).toBeTruthy();
+    });
+
+    it("artistPosts returns author via JOIN prefetch", async () => {
+      const { artistId } = await setupAuthoredPost(
+        "pa2@example.com",
+        "pauser2",
+        "paartist2",
+        "Artist Posts Author",
+      );
+
+      const result = await gql(app, ARTIST_POSTS_WITH_AUTHOR_QUERY, {
+        artistId,
+      });
+
+      expect(result.errors).toBeUndefined();
+      const list = result.data!.artistPosts as Array<Record<string, unknown>>;
+      expect(list).toHaveLength(1);
+      const author = list[0].author as Record<string, unknown>;
+      expect(author.username).toBe("pauser2");
+    });
+
+    it("artist.recentPosts returns author via JOIN prefetch", async () => {
+      await setupAuthoredPost(
+        "pa3@example.com",
+        "pauser3",
+        "paartist3",
+        "Recent Posts Author",
+      );
+
+      const result = await gql(app, ARTIST_RECENT_POSTS_QUERY, {
+        username: "paartist3",
+      });
+
+      expect(result.errors).toBeUndefined();
+      const artist = result.data!.artist as Record<string, unknown>;
+      const list = artist.recentPosts as Array<Record<string, unknown>>;
+      expect(list).toHaveLength(1);
+      const author = list[0].author as Record<string, unknown>;
+      expect(author.username).toBe("pauser3");
+    });
+
+    it("track.posts returns author via JOIN prefetch", async () => {
+      const { trackId } = await setupAuthoredPost(
+        "pa4@example.com",
+        "pauser4",
+        "paartist4",
+        "Track Posts Author",
+      );
+
+      const result = await gql(app, TRACK_POSTS_WITH_AUTHOR_QUERY, {
+        id: trackId,
+      });
+
+      expect(result.errors).toBeUndefined();
+      const track = result.data!.track as Record<string, unknown>;
+      const list = track.posts as Array<Record<string, unknown>>;
+      expect(list).toHaveLength(1);
+      const author = list[0].author as Record<string, unknown>;
+      expect(author.username).toBe("pauser4");
+    });
+
+    it("myUnassignedPosts returns author via JOIN prefetch", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "pa5@example.com",
+        "pauser5",
+        "paartist5",
+      );
+      await gql(
+        app,
+        CREATE_POST_MUTATION,
+        {
+          trackId,
+          mediaType: "article",
+          title: "Unassigned Author",
+          visibility: "public",
+        },
+        token,
+      );
+      // Deleting the track makes the post trackId=NULL (unassigned)
+      await gql(
+        app,
+        `mutation ($id: String!) { deleteTrack(id: $id) { id } }`,
+        { id: trackId },
+        token,
+      );
+
+      const result = await gql(app, MY_UNASSIGNED_WITH_AUTHOR_QUERY, {}, token);
+
+      expect(result.errors).toBeUndefined();
+      const list = result.data!.myUnassignedPosts as Array<
+        Record<string, unknown>
+      >;
+      expect(list).toHaveLength(1);
+      const author = list[0].author as Record<string, unknown>;
+      expect(author.username).toBe("pauser5");
+    });
+
+    it("list resolver preserves author across multiple posts by same author", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "pa6@example.com",
+        "pauser6",
+        "paartist6",
+      );
+      for (const title of ["P1", "P2", "P3"]) {
+        await gql(
+          app,
+          CREATE_POST_MUTATION,
+          { trackId, mediaType: "article", title, visibility: "public" },
+          token,
+        );
+      }
+
+      const result = await gql(app, POSTS_WITH_AUTHOR_QUERY, { trackId });
+
+      expect(result.errors).toBeUndefined();
+      const list = result.data!.posts as Array<Record<string, unknown>>;
+      expect(list).toHaveLength(3);
+      for (const post of list) {
+        const author = post.author as Record<string, unknown>;
+        expect(author.username).toBe("pauser6");
+      }
+    });
+  });
+
   describe("myUnassignedPosts", () => {
     const MY_UNASSIGNED_POSTS_QUERY = `
       query {

--- a/backend/src/graphql/__tests__/post.test.ts
+++ b/backend/src/graphql/__tests__/post.test.ts
@@ -20,6 +20,10 @@ import { authMiddleware, type AuthUser } from "../../auth/middleware.js";
 
 import { builder } from "../builder.js";
 import "../types/index.js";
+// Shared app db + publicUserColumns are imported to spy on the fallback
+// SELECT path in the N+1 regression test below (#180).
+import { db as appDb } from "../../db/index.js";
+import { publicUserColumns } from "../types/user.js";
 
 const DATABASE_URL = process.env.DATABASE_URL;
 if (!DATABASE_URL)
@@ -1240,6 +1244,51 @@ describe("Post GraphQL integration", () => {
       for (const post of list) {
         const author = post.author as Record<string, unknown>;
         expect(author.username).toBe("pauser6");
+        // Boundary check: publicUserColumns must not leak sensitive fields
+        expect(author).not.toHaveProperty("email");
+        expect(author).not.toHaveProperty("passwordHash");
+        expect(author).not.toHaveProperty("publicKey");
+      }
+    });
+
+    // Regression guard: if someone removes `post._author` usage from
+    // PostType.author (or drops the users JOIN from a list resolver),
+    // this test fails because the fallback SELECT (identified by reference
+    // equality against publicUserColumns) must never run during list queries.
+    it("list resolvers never hit the fallback author SELECT", async () => {
+      const { token, trackId } = await signupRegisterArtistAndCreateTrack(
+        app,
+        "pa7@example.com",
+        "pauser7",
+        "paartist7",
+      );
+      for (const title of ["R1", "R2", "R3"]) {
+        await gql(
+          app,
+          CREATE_POST_MUTATION,
+          { trackId, mediaType: "article", title, visibility: "public" },
+          token,
+        );
+      }
+
+      const selectSpy = vi.spyOn(appDb, "select");
+      try {
+        const result = await gql(app, POSTS_WITH_AUTHOR_QUERY, { trackId });
+        expect(result.errors).toBeUndefined();
+        expect(
+          (result.data!.posts as Array<Record<string, unknown>>).length,
+        ).toBe(3);
+
+        // Fallback path in PostType.author passes publicUserColumns as the
+        // direct argument to db.select. The JOIN helpers wrap it inside a
+        // new projection object `{ post, [track,] author }`, so reference
+        // equality cleanly separates the two paths.
+        const fallbackCalls = selectSpy.mock.calls.filter(
+          (call) => call[0] === publicUserColumns,
+        );
+        expect(fallbackCalls.length).toBe(0);
+      } finally {
+        selectSpy.mockRestore();
       }
     });
   });

--- a/backend/src/graphql/types/post.ts
+++ b/backend/src/graphql/types/post.ts
@@ -11,6 +11,7 @@ import {
 import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { ArtistType } from "./artist.js";
 import { TrackType } from "./track.js";
+import type { PublicUserShape } from "./user.js";
 import { PublicUserType, publicUserColumns } from "./user.js";
 import { computeContentHash, verifySignature } from "../../auth/signing.js";
 import {
@@ -115,6 +116,11 @@ type PostShape = {
     updatedAt: Date;
   } | null;
   _media?: { id: string; mediaUrl: string; position: number }[];
+  // Prefetched via INNER JOIN in list resolvers to eliminate N+1 (#180).
+  // INNER JOIN is safe: authorId is NOT NULL with ON DELETE CASCADE,
+  // so orphan posts cannot exist. Always uses publicUserColumns projection
+  // to avoid leaking passwordHash / email / publicKey on JOIN.
+  _author?: PublicUserShape;
 };
 
 type PostMediaShape = {
@@ -245,6 +251,11 @@ PostType.implement({
     author: t.field({
       type: PublicUserType,
       resolve: async (post) => {
+        // Use pre-fetched author from JOIN if available (N+1 prevention)
+        if (post._author) return post._author;
+        // Fallback for mutation return paths (createPost/updatePost/deletePost)
+        // where the post is fetched without a users JOIN. authorId is NOT NULL
+        // with ON DELETE CASCADE, so orphan rows are not expected in practice.
         const [user] = await db
           .select(publicUserColumns)
           .from(users)
@@ -1288,11 +1299,16 @@ builder.queryFields((t) => ({
         : eq(posts.visibility, "public");
 
       const rows = await db
-        .select({ post: posts, track: tracks })
+        .select({ post: posts, track: tracks, author: publicUserColumns })
         .from(posts)
         .innerJoin(tracks, sql`${posts.trackId} = ${tracks.id}`)
+        .innerJoin(users, eq(posts.authorId, users.id))
         .where(and(eq(tracks.id, args.trackId), visibilityFilter));
-      const results = rows.map((r) => ({ ...r.post, _track: r.track }));
+      const results = rows.map((r) => ({
+        ...r.post,
+        _track: r.track,
+        _author: r.author,
+      }));
       await attachPostMedia(results);
       return results;
     },
@@ -1311,16 +1327,21 @@ builder.queryFields((t) => ({
       }
 
       const limit = Math.max(1, Math.min(args.limit ?? 50, 100));
+      // Explicit projection + users JOIN. authorId always equals ctx.authUser
+      // so _author could be built from ctx, but keeping the JOIN for
+      // consistency with other list resolvers and future co-author support.
       const rows = await db
-        .select()
+        .select({ post: posts, author: publicUserColumns })
         .from(posts)
+        .innerJoin(users, eq(posts.authorId, users.id))
         .where(
           and(eq(posts.authorId, ctx.authUser.userId), isNull(posts.trackId)),
         )
         .orderBy(desc(posts.createdAt))
         .limit(limit);
-      await attachPostMedia(rows);
-      return rows;
+      const results = rows.map((r) => ({ ...r.post, _author: r.author }));
+      await attachPostMedia(results);
+      return results;
     },
   }),
 
@@ -1343,13 +1364,18 @@ builder.queryFields((t) => ({
 
       const limit = Math.max(1, Math.min(args.limit ?? 5, 10));
       const rows = await db
-        .select({ post: posts, track: tracks })
+        .select({ post: posts, track: tracks, author: publicUserColumns })
         .from(posts)
         .innerJoin(tracks, sql`${posts.trackId} = ${tracks.id}`)
+        .innerJoin(users, eq(posts.authorId, users.id))
         .where(and(eq(tracks.artistId, args.artistId), visibilityFilter))
         .orderBy(desc(posts.createdAt))
         .limit(limit);
-      const results = rows.map((r) => ({ ...r.post, _track: r.track }));
+      const results = rows.map((r) => ({
+        ...r.post,
+        _track: r.track,
+        _author: r.author,
+      }));
       await attachPostMedia(results);
       return results;
     },
@@ -1372,13 +1398,18 @@ builder.objectFields(ArtistType, (t) => ({
 
       const limit = Math.max(1, Math.min(args.limit ?? 5, 10));
       const rows = await db
-        .select({ post: posts, track: tracks })
+        .select({ post: posts, track: tracks, author: publicUserColumns })
         .from(posts)
         .innerJoin(tracks, sql`${posts.trackId} = ${tracks.id}`)
+        .innerJoin(users, eq(posts.authorId, users.id))
         .where(and(eq(tracks.artistId, artist.id), visibilityFilter))
         .orderBy(desc(posts.createdAt))
         .limit(limit);
-      const results = rows.map((r) => ({ ...r.post, _track: r.track }));
+      const results = rows.map((r) => ({
+        ...r.post,
+        _track: r.track,
+        _author: r.author,
+      }));
       await attachPostMedia(results);
       return results;
     },
@@ -1397,10 +1428,15 @@ builder.objectFields(TrackType, (t) => ({
         : eq(posts.visibility, "public");
 
       const rows = await db
-        .select()
+        .select({ post: posts, author: publicUserColumns })
         .from(posts)
+        .innerJoin(users, eq(posts.authorId, users.id))
         .where(and(sql`${posts.trackId} = ${track.id}`, visibilityFilter));
-      const results = rows.map((r) => ({ ...r, _track: track }));
+      const results = rows.map((r) => ({
+        ...r.post,
+        _track: track,
+        _author: r.author,
+      }));
       await attachPostMedia(results);
       return results;
     },

--- a/backend/src/graphql/types/post.ts
+++ b/backend/src/graphql/types/post.ts
@@ -80,6 +80,9 @@ async function verifyPostSignature(
   }
 }
 
+// Fields prefixed with `_` are resolver-internal prefetch slots and must
+// never be exposed via the GraphQL schema. They carry JOIN/batch-loaded
+// relations so child resolvers can serve them without triggering N+1.
 type PostShape = {
   id: string;
   trackId: string | null;
@@ -177,6 +180,35 @@ async function attachPostMedia(results: PostShape[]): Promise<void> {
   for (const post of results) {
     post._media = mediaMap.get(post.id) ?? [];
   }
+}
+
+/**
+ * Base query for post list resolvers that need author prefetch (#180).
+ * Projects `posts` + `publicUserColumns` only, so passwordHash / email /
+ * publicKey can never leak through list paths. Callers chain `.where(...)`
+ * and friends, then map `(r) => ({ ...r.post, _author: r.author })`.
+ */
+function selectPostsWithAuthor() {
+  return db
+    .select({ post: posts, author: publicUserColumns })
+    .from(posts)
+    .innerJoin(users, eq(posts.authorId, users.id));
+}
+
+/**
+ * Same as `selectPostsWithAuthor` but also joins `tracks` for resolvers
+ * that return track-bound posts. Kept separate from the track-less variant
+ * to preserve row-shape typing on the Drizzle builder.
+ *
+ * `posts.trackId` is nullable, so the tracks join uses `sql` templating
+ * rather than `eq()` (see backend-implementation.md Drizzle rule).
+ */
+function selectPostsWithTrackAndAuthor() {
+  return db
+    .select({ post: posts, track: tracks, author: publicUserColumns })
+    .from(posts)
+    .innerJoin(tracks, sql`${posts.trackId} = ${tracks.id}`)
+    .innerJoin(users, eq(posts.authorId, users.id));
 }
 
 export const PostType = builder.objectRef<PostShape>("Post");
@@ -1298,12 +1330,9 @@ builder.queryFields((t) => ({
         ? undefined
         : eq(posts.visibility, "public");
 
-      const rows = await db
-        .select({ post: posts, track: tracks, author: publicUserColumns })
-        .from(posts)
-        .innerJoin(tracks, sql`${posts.trackId} = ${tracks.id}`)
-        .innerJoin(users, eq(posts.authorId, users.id))
-        .where(and(eq(tracks.id, args.trackId), visibilityFilter));
+      const rows = await selectPostsWithTrackAndAuthor().where(
+        and(eq(tracks.id, args.trackId), visibilityFilter),
+      );
       const results = rows.map((r) => ({
         ...r.post,
         _track: r.track,
@@ -1327,13 +1356,7 @@ builder.queryFields((t) => ({
       }
 
       const limit = Math.max(1, Math.min(args.limit ?? 50, 100));
-      // Explicit projection + users JOIN. authorId always equals ctx.authUser
-      // so _author could be built from ctx, but keeping the JOIN for
-      // consistency with other list resolvers and future co-author support.
-      const rows = await db
-        .select({ post: posts, author: publicUserColumns })
-        .from(posts)
-        .innerJoin(users, eq(posts.authorId, users.id))
+      const rows = await selectPostsWithAuthor()
         .where(
           and(eq(posts.authorId, ctx.authUser.userId), isNull(posts.trackId)),
         )
@@ -1363,11 +1386,7 @@ builder.queryFields((t) => ({
         : eq(posts.visibility, "public");
 
       const limit = Math.max(1, Math.min(args.limit ?? 5, 10));
-      const rows = await db
-        .select({ post: posts, track: tracks, author: publicUserColumns })
-        .from(posts)
-        .innerJoin(tracks, sql`${posts.trackId} = ${tracks.id}`)
-        .innerJoin(users, eq(posts.authorId, users.id))
+      const rows = await selectPostsWithTrackAndAuthor()
         .where(and(eq(tracks.artistId, args.artistId), visibilityFilter))
         .orderBy(desc(posts.createdAt))
         .limit(limit);
@@ -1397,11 +1416,7 @@ builder.objectFields(ArtistType, (t) => ({
         : eq(posts.visibility, "public");
 
       const limit = Math.max(1, Math.min(args.limit ?? 5, 10));
-      const rows = await db
-        .select({ post: posts, track: tracks, author: publicUserColumns })
-        .from(posts)
-        .innerJoin(tracks, sql`${posts.trackId} = ${tracks.id}`)
-        .innerJoin(users, eq(posts.authorId, users.id))
+      const rows = await selectPostsWithTrackAndAuthor()
         .where(and(eq(tracks.artistId, artist.id), visibilityFilter))
         .orderBy(desc(posts.createdAt))
         .limit(limit);
@@ -1427,11 +1442,9 @@ builder.objectFields(TrackType, (t) => ({
         ? undefined
         : eq(posts.visibility, "public");
 
-      const rows = await db
-        .select({ post: posts, author: publicUserColumns })
-        .from(posts)
-        .innerJoin(users, eq(posts.authorId, users.id))
-        .where(and(sql`${posts.trackId} = ${track.id}`, visibilityFilter));
+      const rows = await selectPostsWithAuthor().where(
+        and(sql`${posts.trackId} = ${track.id}`, visibilityFilter),
+      );
       const results = rows.map((r) => ({
         ...r.post,
         _track: track,


### PR DESCRIPTION
## Summary
- Add `_author` prefetch slot to `PostShape` and JOIN `users` in all five post list resolvers, so `PostType.author` is served from the prefetch instead of a per-post SELECT.
- Keep a fallback individual SELECT for mutation return paths where no JOIN is performed.
- Rewrite `TrackType.posts` and `myUnassignedPosts` from `db.select()` to explicit `{ post: posts, author: publicUserColumns }` projections; every JOIN now limits user columns to `publicUserColumns` to avoid leaking `passwordHash` / `email` / `publicKey`.

## Scope

Covered list resolvers:
- `queryFields.posts` (trackId)
- `queryFields.artistPosts` (artistId)
- `queryFields.myUnassignedPosts`
- `ArtistType.recentPosts`
- `TrackType.posts`

Out of scope (by design):
- `queryFields.post` (single), mutation return paths — one SELECT each, not N+1.
- `ConnectionObjectType.source/target`, `Comment.post` — not list resolvers; tracked by Issue #180 follow-ups if needed later.

## Tests
- 6 new regression tests under `author prefetch via list resolvers (#180)` covering all five list paths plus a multi-post same-author cache case.
- Full suite: 355 passed / 1 skipped.

## Residual / Related
- **#250** (Out of scope, tracked separately): `PublicUser` resolver does not filter by `profileVisibility` / `guardianId`, so child account authors can be exposed through any post-returning path. Pre-existing behaviour — this PR does not change it and does not introduce new exposure. ADR 019 Phase 1 work.

Fixes #180

## Test plan
- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test` (355 passed)
- [x] Security review (pre-existing child-account concern split to #250)
- [x] GraphQL reviewer approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)