### PR TITLE
Auto-refresh OGP after link post creation (#191)

### DIFF
--- a/frontend/lib/graphql/mutations/post.dart
+++ b/frontend/lib/graphql/mutations/post.dart
@@ -88,11 +88,18 @@ const deletePostMutation = r'''
   }
 ''';
 
-const fetchOgpMutation =
-    '''
-  mutation FetchOgp(\$postId: String!) {
-    fetchOgp(postId: \$postId) {
-      $postFields
+/// Slim variant of fetchOgp used by the deferred auto-refresh in
+/// TimelineNotifier. Only the OGP fields (and id, for matching) are
+/// merged into local state, so requesting the full Post fragment would
+/// waste bandwidth, parsing, and GC for every newly created link post.
+const fetchOgpMutation = r'''
+  mutation FetchOgp($postId: String!) {
+    fetchOgp(postId: $postId) {
+      id
+      ogTitle
+      ogDescription
+      ogImage
+      ogSiteName
     }
   }
 ''';

--- a/frontend/lib/providers/timeline_provider.dart
+++ b/frontend/lib/providers/timeline_provider.dart
@@ -667,6 +667,84 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
         state = state.copyWith(highlightPostId: null);
       }
     });
+    _scheduleOgpRefreshIfNeeded(post);
+  }
+
+  /// Schedule a deferred OGP refresh for a freshly created link post when
+  /// the backend's fire-and-forget fetch hadn't completed by the time
+  /// createPost returned (#191). Fast sites (Instagram etc.) usually
+  /// populate OGP before the mutation response, so we only refresh when
+  /// every og* field is still null. A single attempt after 3s covers the
+  /// majority case; users can manually reload for slower sites.
+  @visibleForTesting
+  Future<void> scheduleOgpRefreshForTesting(
+    Post post, {
+    Duration delay = Duration.zero,
+  }) => _scheduleOgpRefreshIfNeeded(post, delay: delay);
+
+  Future<void> _scheduleOgpRefreshIfNeeded(
+    Post post, {
+    Duration delay = const Duration(milliseconds: 3000),
+  }) async {
+    if (post.mediaType != MediaType.link) return;
+    if (_hasAnyOgp(post)) return;
+
+    await Future.delayed(delay);
+    if (disposed) return;
+
+    final current = state.posts.firstWhereOrNull((p) => p.id == post.id);
+    // Post left the timeline (deletion / track switch) — drop the refresh.
+    if (current == null) return;
+    // Something populated OGP in the meantime (e.g. user manually reloaded).
+    if (_hasAnyOgp(current)) return;
+
+    try {
+      final result = await _client.mutate(
+        MutationOptions(
+          document: gql(fetchOgpMutation),
+          variables: {'postId': post.id},
+          fetchPolicy: FetchPolicy.networkOnly,
+        ),
+      );
+      if (disposed) return;
+      if (result.hasException) {
+        debugPrint(
+          '[TimelineNotifier] OGP auto-refresh failed for ${post.id}: '
+          '${result.exception}',
+        );
+        return;
+      }
+      final data = result.data?['fetchOgp'] as Map<String, dynamic>?;
+      if (data == null) return;
+      final refreshed = Post.fromJson(data);
+      _mergeOgpFields(refreshed);
+    } catch (e) {
+      debugPrint(
+        '[TimelineNotifier] OGP auto-refresh error for ${post.id}: $e',
+      );
+    }
+  }
+
+  static bool _hasAnyOgp(Post p) =>
+      p.ogTitle != null ||
+      p.ogDescription != null ||
+      p.ogImage != null ||
+      p.ogSiteName != null;
+
+  /// Merge OGP fields from a refreshed post into the matching timeline entry.
+  /// Does NOT touch reactions / connections / layout — OGP is render-only
+  /// and recomputing layout would jitter the node.
+  void _mergeOgpFields(Post refreshed) {
+    final posts = state.posts.map((p) {
+      if (p.id != refreshed.id) return p;
+      return p.copyWith(
+        ogTitle: refreshed.ogTitle,
+        ogDescription: refreshed.ogDescription,
+        ogImage: refreshed.ogImage,
+        ogSiteName: refreshed.ogSiteName,
+      );
+    }).toList();
+    state = state.copyWith(posts: posts);
   }
 
   /// Add a track ID to selectedTrackIds without fetching (sync).

--- a/frontend/lib/providers/timeline_provider.dart
+++ b/frontend/lib/providers/timeline_provider.dart
@@ -666,12 +666,15 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
     final posts = [...state.posts, post];
     state = state.copyWith(posts: posts, highlightPostId: post.id);
     _recomputeLayout();
-    // Clear highlight after animation completes
-    Future.delayed(const Duration(milliseconds: 3000), () {
-      if (!disposed && state.highlightPostId == post.id) {
-        state = state.copyWith(highlightPostId: null);
-      }
-    });
+    // Clear highlight after animation completes. Fire-and-forget; the
+    // disposed guard inside the closure makes this safe to ignore.
+    unawaited(
+      Future.delayed(const Duration(milliseconds: 3000), () {
+        if (!disposed && state.highlightPostId == post.id) {
+          state = state.copyWith(highlightPostId: null);
+        }
+      }),
+    );
     // Fire-and-forget: refresh handles its own errors via try/catch and
     // the disposed guard, so awaiting here would only block addPost on a
     // 3 s timer.
@@ -728,8 +731,28 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
       }
       final data = result.data?['fetchOgp'] as Map<String, dynamic>?;
       if (data == null) return;
-      final refreshed = Post.fromJson(data);
-      _mergeOgpFields(refreshed);
+      final ogTitle = data['ogTitle'] as String?;
+      final ogDescription = data['ogDescription'] as String?;
+      final ogImage = data['ogImage'] as String?;
+      final ogSiteName = data['ogSiteName'] as String?;
+      // Site exposed no OGP tags — backend returned a Post with all four
+      // og* fields null. Don't merge: we'd just overwrite whatever was
+      // there with the same nulls, but a blind copyWith could clobber
+      // values that were populated concurrently (e.g. user manually
+      // reloaded between the disposed-check and now).
+      if (ogTitle == null &&
+          ogDescription == null &&
+          ogImage == null &&
+          ogSiteName == null) {
+        return;
+      }
+      _mergeOgpFields(
+        postId: post.id,
+        ogTitle: ogTitle,
+        ogDescription: ogDescription,
+        ogImage: ogImage,
+        ogSiteName: ogSiteName,
+      );
     } catch (e) {
       debugPrint(
         '[TimelineNotifier] OGP auto-refresh error for ${post.id}: $e',
@@ -743,17 +766,23 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
       p.ogImage != null ||
       p.ogSiteName != null;
 
-  /// Merge OGP fields from a refreshed post into the matching timeline entry.
-  /// Does NOT touch reactions / connections / layout — OGP is render-only
-  /// and recomputing layout would jitter the node.
-  void _mergeOgpFields(Post refreshed) {
-    final idx = state.posts.indexWhere((p) => p.id == refreshed.id);
+  /// Merge OGP fields into the matching timeline entry. Does NOT touch
+  /// reactions / connections / layout — OGP is render-only and
+  /// recomputing layout would jitter the node.
+  void _mergeOgpFields({
+    required String postId,
+    required String? ogTitle,
+    required String? ogDescription,
+    required String? ogImage,
+    required String? ogSiteName,
+  }) {
+    final idx = state.posts.indexWhere((p) => p.id == postId);
     if (idx == -1) return;
     final merged = state.posts[idx].copyWith(
-      ogTitle: refreshed.ogTitle,
-      ogDescription: refreshed.ogDescription,
-      ogImage: refreshed.ogImage,
-      ogSiteName: refreshed.ogSiteName,
+      ogTitle: ogTitle,
+      ogDescription: ogDescription,
+      ogImage: ogImage,
+      ogSiteName: ogSiteName,
     );
     final posts = List<Post>.of(state.posts)..[idx] = merged;
     state = state.copyWith(posts: posts);

--- a/frontend/lib/providers/timeline_provider.dart
+++ b/frontend/lib/providers/timeline_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
@@ -657,6 +658,10 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
     }
   }
 
+  /// Add a single post to the timeline. NOT designed for bulk loads —
+  /// the OGP auto-refresh schedules one fetchOgp per call, so feeding a
+  /// loop of N link posts here would fire N parallel mutations after the
+  /// 3 s delay. Bulk paths should use `_loadSelectedPosts` instead.
   void addPost(Post post) {
     final posts = [...state.posts, post];
     state = state.copyWith(posts: posts, highlightPostId: post.id);
@@ -667,7 +672,10 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
         state = state.copyWith(highlightPostId: null);
       }
     });
-    _scheduleOgpRefreshIfNeeded(post);
+    // Fire-and-forget: refresh handles its own errors via try/catch and
+    // the disposed guard, so awaiting here would only block addPost on a
+    // 3 s timer.
+    unawaited(_scheduleOgpRefreshIfNeeded(post));
   }
 
   /// Schedule a deferred OGP refresh for a freshly created link post when
@@ -708,6 +716,10 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
       );
       if (disposed) return;
       if (result.hasException) {
+        // OGP is best-effort: no retry on failure. Retrying could spam the
+        // backend for posts that will never get OGP metadata (private URLs,
+        // 4xx responses, sites with no og: tags). The user can manually
+        // reload to retry.
         debugPrint(
           '[TimelineNotifier] OGP auto-refresh failed for ${post.id}: '
           '${result.exception}',
@@ -735,15 +747,15 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
   /// Does NOT touch reactions / connections / layout — OGP is render-only
   /// and recomputing layout would jitter the node.
   void _mergeOgpFields(Post refreshed) {
-    final posts = state.posts.map((p) {
-      if (p.id != refreshed.id) return p;
-      return p.copyWith(
-        ogTitle: refreshed.ogTitle,
-        ogDescription: refreshed.ogDescription,
-        ogImage: refreshed.ogImage,
-        ogSiteName: refreshed.ogSiteName,
-      );
-    }).toList();
+    final idx = state.posts.indexWhere((p) => p.id == refreshed.id);
+    if (idx == -1) return;
+    final merged = state.posts[idx].copyWith(
+      ogTitle: refreshed.ogTitle,
+      ogDescription: refreshed.ogDescription,
+      ogImage: refreshed.ogImage,
+      ogSiteName: refreshed.ogSiteName,
+    );
+    final posts = List<Post>.of(state.posts)..[idx] = merged;
     state = state.copyWith(posts: posts);
   }
 

--- a/frontend/test/providers/timeline_provider_test.dart
+++ b/frontend/test/providers/timeline_provider_test.dart
@@ -350,9 +350,17 @@ void main() {
         expect(refreshed.ogDescription, 'Example Description');
         expect(refreshed.ogImage, 'https://example.com/og.png');
         expect(refreshed.ogSiteName, 'example.com');
-        // Other fields must be untouched
+        // Non-OGP fields must be preserved verbatim from the original post.
+        // Listed individually so future copyWith arg changes (additions /
+        // removals) can be caught as regressions.
         expect(refreshed.id, post.id);
         expect(refreshed.mediaType, MediaType.link);
+        expect(refreshed.mediaUrl, post.mediaUrl);
+        expect(refreshed.importance, post.importance);
+        expect(refreshed.createdAt, post.createdAt);
+        expect(refreshed.updatedAt, post.updatedAt);
+        expect(refreshed.author.id, post.author.id);
+        expect(refreshed.author.username, post.author.username);
       },
     );
 
@@ -432,5 +440,33 @@ void main() {
       expect(after.ogImage, isNull);
       expect(after.ogSiteName, isNull);
     });
+
+    test(
+      'refresh bails out cleanly when notifier is disposed mid-delay',
+      () async {
+        final pair = _clientAndLinkWith(data: _fetchOgpResponse());
+        final container = _createContainer(client: pair.client);
+
+        final notifier = container.read(timelineProvider.notifier);
+        final post = _linkPost();
+        notifier.debugSetState(
+          container.read(timelineProvider).copyWith(posts: [post]),
+        );
+
+        // Kick off a refresh with a non-zero delay so we have a window in
+        // which to dispose the container.
+        final pending = notifier.scheduleOgpRefreshForTesting(
+          post,
+          delay: const Duration(milliseconds: 50),
+        );
+        // Dispose during the delay — simulates user navigating away while
+        // the 3 s timer is pending.
+        container.dispose();
+
+        // Should resolve without throwing and without firing a request.
+        await pending;
+        expect(pair.link.requests, isEmpty);
+      },
+    );
   });
 }

--- a/frontend/test/providers/timeline_provider_test.dart
+++ b/frontend/test/providers/timeline_provider_test.dart
@@ -24,17 +24,6 @@ class _MockLink extends Link {
   }
 }
 
-GraphQLClient _clientWith({
-  Map<String, dynamic>? data,
-  List<GraphQLError>? errors,
-  Exception? exception,
-}) {
-  return GraphQLClient(
-    link: _MockLink(data: data, errors: errors, exception: exception),
-    cache: GraphQLCache(store: InMemoryStore()),
-  );
-}
-
 ({GraphQLClient client, _MockLink link}) _clientAndLinkWith({
   Map<String, dynamic>? data,
   List<GraphQLError>? errors,
@@ -49,6 +38,13 @@ GraphQLClient _clientWith({
     link: link,
   );
 }
+
+GraphQLClient _clientWith({
+  Map<String, dynamic>? data,
+  List<GraphQLError>? errors,
+  Exception? exception,
+}) =>
+    _clientAndLinkWith(data: data, errors: errors, exception: exception).client;
 
 /// Minimal Post factory for OGP refresh tests.
 Post _linkPost({
@@ -74,9 +70,11 @@ Post _linkPost({
   );
 }
 
+/// Mocks the slim FetchOgp mutation shape (id + 4 OGP fields).
+/// All fields nullable so tests can simulate "site has no OGP" responses.
 Map<String, dynamic> _fetchOgpResponse({
   String id = 'p1',
-  String ogTitle = 'Example Title',
+  String? ogTitle = 'Example Title',
   String? ogDescription = 'Example Description',
   String? ogImage = 'https://example.com/og.png',
   String? ogSiteName = 'example.com',
@@ -91,37 +89,6 @@ Map<String, dynamic> _fetchOgpResponse({
     'fetchOgp': {
       '__typename': 'Post',
       'id': id,
-      'mediaType': 'link',
-      'title': null,
-      'body': null,
-      'bodyFormat': 'plain',
-      'mediaUrl': 'https://example.com',
-      'thumbnailUrl': null,
-      'duration': null,
-      'importance': 1.0,
-      'visibility': 'public',
-      'eventAt': null,
-      'layoutX': null,
-      'layoutY': null,
-      'contentHash': null,
-      'createdAt': '2026-01-01T00:00:00.000Z',
-      'updatedAt': '2026-01-01T00:00:00.000Z',
-      'author': {
-        '__typename': 'PublicUser',
-        'id': 'u1',
-        'username': 'alice',
-        'displayName': null,
-        'avatarUrl': null,
-      },
-      'track': null,
-      'reactionCounts': const [],
-      'myReactions': const [],
-      'outgoingConnections': const [],
-      'incomingConnections': const [],
-      'constellation': null,
-      'media': const [],
-      'articleGenre': null,
-      'externalPublish': false,
       'ogTitle': ogTitle,
       'ogDescription': ogDescription,
       'ogImage': ogImage,
@@ -446,6 +413,10 @@ void main() {
       () async {
         final pair = _clientAndLinkWith(data: _fetchOgpResponse());
         final container = _createContainer(client: pair.client);
+        // Best-effort cleanup if the test throws before the explicit
+        // dispose — ProviderContainer.dispose() is idempotent and safe to
+        // call twice.
+        addTearDown(container.dispose);
 
         final notifier = container.read(timelineProvider.notifier);
         final post = _linkPost();
@@ -466,6 +437,43 @@ void main() {
         // Should resolve without throwing and without firing a request.
         await pending;
         expect(pair.link.requests, isEmpty);
+      },
+    );
+
+    test(
+      'all-null fetchOgp response leaves existing state untouched',
+      () async {
+        // Backend returned a Post with every og* field null (site has no
+        // OGP tags). Refresh should bail rather than overwriting state
+        // with the same nulls.
+        final pair = _clientAndLinkWith(
+          data: _fetchOgpResponse(
+            ogTitle: null,
+            ogDescription: null,
+            ogImage: null,
+            ogSiteName: null,
+          ),
+        );
+        final container = _createContainer(client: pair.client);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(timelineProvider.notifier);
+        final post = _linkPost();
+        notifier.debugSetState(
+          container.read(timelineProvider).copyWith(posts: [post]),
+        );
+
+        // Capture state reference to confirm it isn't replaced when the
+        // response carries no actual OGP data.
+        final beforePosts = container.read(timelineProvider).posts;
+        await notifier.scheduleOgpRefreshForTesting(post);
+
+        expect(pair.link.requests, hasLength(1));
+        // Same list instance — _mergeOgpFields was never called.
+        expect(
+          identical(container.read(timelineProvider).posts, beforePosts),
+          isTrue,
+        );
       },
     );
   });

--- a/frontend/test/providers/timeline_provider_test.dart
+++ b/frontend/test/providers/timeline_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'package:gleisner_web/graphql/client.dart';
 import 'package:gleisner_web/models/artist.dart';
+import 'package:gleisner_web/models/post.dart';
 import 'package:gleisner_web/models/track.dart';
 import 'package:gleisner_web/providers/timeline_provider.dart';
 
@@ -11,11 +12,13 @@ class _MockLink extends Link {
   final Map<String, dynamic>? data;
   final List<GraphQLError>? errors;
   final Exception? exception;
+  final List<Request> requests = [];
 
   _MockLink({this.data, this.errors, this.exception});
 
   @override
   Stream<Response> request(Request request, [NextLink? forward]) {
+    requests.add(request);
     if (exception != null) return Stream.error(exception!);
     return Stream.value(Response(data: data, errors: errors, response: {}));
   }
@@ -30,6 +33,101 @@ GraphQLClient _clientWith({
     link: _MockLink(data: data, errors: errors, exception: exception),
     cache: GraphQLCache(store: InMemoryStore()),
   );
+}
+
+({GraphQLClient client, _MockLink link}) _clientAndLinkWith({
+  Map<String, dynamic>? data,
+  List<GraphQLError>? errors,
+  Exception? exception,
+}) {
+  final link = _MockLink(data: data, errors: errors, exception: exception);
+  return (
+    client: GraphQLClient(
+      link: link,
+      cache: GraphQLCache(store: InMemoryStore()),
+    ),
+    link: link,
+  );
+}
+
+/// Minimal Post factory for OGP refresh tests.
+Post _linkPost({
+  String id = 'p1',
+  String? ogTitle,
+  String? ogDescription,
+  String? ogImage,
+  String? ogSiteName,
+}) {
+  final now = DateTime.utc(2026, 1, 1);
+  return Post(
+    id: id,
+    mediaType: MediaType.link,
+    mediaUrl: 'https://example.com',
+    importance: 1.0,
+    createdAt: now,
+    updatedAt: now,
+    author: const PostAuthor(id: 'u1', username: 'alice'),
+    ogTitle: ogTitle,
+    ogDescription: ogDescription,
+    ogImage: ogImage,
+    ogSiteName: ogSiteName,
+  );
+}
+
+Map<String, dynamic> _fetchOgpResponse({
+  String id = 'p1',
+  String ogTitle = 'Example Title',
+  String? ogDescription = 'Example Description',
+  String? ogImage = 'https://example.com/og.png',
+  String? ogSiteName = 'example.com',
+}) {
+  // `__typename` is required at every object level so that the graphql
+  // client's normalizing cache (used by default via FetchPolicy.networkOnly)
+  // can ingest the mocked response without throwing
+  // UnexpectedResponseStructureException. Mirrors the pattern in
+  // tune_in_provider_test.dart.
+  return {
+    '__typename': 'Mutation',
+    'fetchOgp': {
+      '__typename': 'Post',
+      'id': id,
+      'mediaType': 'link',
+      'title': null,
+      'body': null,
+      'bodyFormat': 'plain',
+      'mediaUrl': 'https://example.com',
+      'thumbnailUrl': null,
+      'duration': null,
+      'importance': 1.0,
+      'visibility': 'public',
+      'eventAt': null,
+      'layoutX': null,
+      'layoutY': null,
+      'contentHash': null,
+      'createdAt': '2026-01-01T00:00:00.000Z',
+      'updatedAt': '2026-01-01T00:00:00.000Z',
+      'author': {
+        '__typename': 'PublicUser',
+        'id': 'u1',
+        'username': 'alice',
+        'displayName': null,
+        'avatarUrl': null,
+      },
+      'track': null,
+      'reactionCounts': const [],
+      'myReactions': const [],
+      'outgoingConnections': const [],
+      'incomingConnections': const [],
+      'constellation': null,
+      'media': const [],
+      'articleGenre': null,
+      'externalPublish': false,
+      'ogTitle': ogTitle,
+      'ogDescription': ogDescription,
+      'ogImage': ogImage,
+      'ogSiteName': ogSiteName,
+    },
+  };
 }
 
 ProviderContainer _createContainer({required GraphQLClient client}) {
@@ -223,6 +321,116 @@ void main() {
         't1',
         't2',
       });
+    });
+  });
+
+  // Regression tests for Issue #191. The backend fires OGP fetch
+  // fire-and-forget after createPost, so a freshly added link post often
+  // lands in the timeline with every og* field still null. TimelineNotifier
+  // schedules a deferred fetchOgp after addPost to populate them.
+  group('TimelineNotifier OGP auto-refresh (#191)', () {
+    test(
+      'link post with null OGP triggers fetchOgp and merges result',
+      () async {
+        final pair = _clientAndLinkWith(data: _fetchOgpResponse());
+        final container = _createContainer(client: pair.client);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(timelineProvider.notifier);
+        final post = _linkPost();
+        notifier.debugSetState(
+          container.read(timelineProvider).copyWith(posts: [post]),
+        );
+
+        await notifier.scheduleOgpRefreshForTesting(post);
+
+        expect(pair.link.requests, hasLength(1));
+        final refreshed = container.read(timelineProvider).posts.single;
+        expect(refreshed.ogTitle, 'Example Title');
+        expect(refreshed.ogDescription, 'Example Description');
+        expect(refreshed.ogImage, 'https://example.com/og.png');
+        expect(refreshed.ogSiteName, 'example.com');
+        // Other fields must be untouched
+        expect(refreshed.id, post.id);
+        expect(refreshed.mediaType, MediaType.link);
+      },
+    );
+
+    test('non-link post skips refresh entirely', () async {
+      final pair = _clientAndLinkWith(data: _fetchOgpResponse());
+      final container = _createContainer(client: pair.client);
+      addTearDown(container.dispose);
+
+      final now = DateTime.utc(2026, 1, 1);
+      final imagePost = Post(
+        id: 'p2',
+        mediaType: MediaType.image,
+        importance: 1.0,
+        createdAt: now,
+        updatedAt: now,
+        author: const PostAuthor(id: 'u1', username: 'alice'),
+      );
+
+      await container
+          .read(timelineProvider.notifier)
+          .scheduleOgpRefreshForTesting(imagePost);
+
+      expect(pair.link.requests, isEmpty);
+    });
+
+    test('link post with existing OGP skips refresh', () async {
+      final pair = _clientAndLinkWith(data: _fetchOgpResponse());
+      final container = _createContainer(client: pair.client);
+      addTearDown(container.dispose);
+
+      final post = _linkPost(ogTitle: 'Already Fetched');
+
+      await container
+          .read(timelineProvider.notifier)
+          .scheduleOgpRefreshForTesting(post);
+
+      expect(pair.link.requests, isEmpty);
+    });
+
+    test('refresh is dropped when the post has left the timeline', () async {
+      final pair = _clientAndLinkWith(data: _fetchOgpResponse());
+      final container = _createContainer(client: pair.client);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(timelineProvider.notifier);
+      final post = _linkPost();
+      // Start with post absent — simulates deletion between scheduling and
+      // the delay elapsing.
+      notifier.debugSetState(
+        container.read(timelineProvider).copyWith(posts: const []),
+      );
+
+      await notifier.scheduleOgpRefreshForTesting(post);
+
+      expect(pair.link.requests, isEmpty);
+      expect(container.read(timelineProvider).posts, isEmpty);
+    });
+
+    test('GraphQL errors during refresh leave state unchanged', () async {
+      final pair = _clientAndLinkWith(
+        errors: [const GraphQLError(message: 'Rate limited')],
+      );
+      final container = _createContainer(client: pair.client);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(timelineProvider.notifier);
+      final post = _linkPost();
+      notifier.debugSetState(
+        container.read(timelineProvider).copyWith(posts: [post]),
+      );
+
+      await notifier.scheduleOgpRefreshForTesting(post);
+
+      final after = container.read(timelineProvider).posts.single;
+      expect(after.ogTitle, isNull);
+      expect(after.ogDescription, isNull);
+      expect(after.ogImage, isNull);
+      expect(after.ogSiteName, isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary
The backend runs OGP fetch as fire-and-forget after `createPost`, so fast origins (Instagram) land with OGP populated but slow ones (YouTube) leave every `og*` field null until the user manually reloads. `TimelineNotifier` now schedules a single deferred `fetchOgp` to close that gap.

## Behavior
- `addPost()` calls `_scheduleOgpRefreshIfNeeded(post)`.
- Waits **3 s** (the backend fetcher is capped at 5 s, so by 3 s most fetches have landed) and re-checks state before firing.
- On response, merges only `ogTitle` / `ogDescription` / `ogImage` / `ogSiteName` into the existing Post via `copyWith` — reactions, connections, and layout are untouched so the node doesn't jitter.
- **Single attempt**, not polling. Matches Issue #191 "投稿後の遅延再取得" (Option 1).

## Skips / guards
| Condition | Behavior |
|-----------|----------|
| `mediaType != link` | Skip immediately |
| OGP already populated on `addPost` | Skip immediately |
| Post left state (delete / track switch) | Drop refresh |
| OGP populated after delay but before fetch | Drop refresh |
| GraphQL error / rate limit | `debugPrint`, no state change |
| Notifier disposed | Bail out |

## Test plan
- [x] `dart format --set-exit-if-changed lib/providers/timeline_provider.dart test/providers/timeline_provider_test.dart`
- [x] `dart analyze lib/providers/timeline_provider.dart test/providers/timeline_provider_test.dart` — only pre-existing `use_null_aware_elements` info warnings in untouched code
- [x] `flutter test test/providers/timeline_provider_test.dart` — 16/16 pass (5 new)
  - `link post with null OGP triggers fetchOgp and merges result`
  - `non-link post skips refresh entirely`
  - `link post with existing OGP skips refresh`
  - `refresh is dropped when the post has left the timeline`
  - `GraphQL errors during refresh leave state unchanged`

> `timeline_provider_test.dart` runs under the VM (uses `Directory.systemTemp` + Hive on disk). `--platform chrome` was already broken on `main` for this file; no regression introduced.

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)