### PR TITLE
chore: scope implementation rules to matching file paths

### DIFF
--- a/.claude/rules/backend-implementation.md
+++ b/.claude/rules/backend-implementation.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "backend/**/*.ts"
+  - "backend/**/*.sql"
+  - "backend/drizzle/**/*"
+---
+
 ## バックエンド実装ルール
 
 ### UserType vs PublicUserType

--- a/.claude/rules/frontend-implementation.md
+++ b/.claude/rules/frontend-implementation.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "frontend/**/*.dart"
+  - "frontend/**/*.arb"
+  - "frontend/lib/**/*"
+  - "frontend/test/**/*"
+---
+
 ## フロントエンド実装ルール
 
 ### デザイントークンの使用

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,10 +188,12 @@ docker compose down    # PostgreSQL 停止
 
 ## 実装ルール
 
-バックエンド・フロントエンドの詳細な実装ルールは `.claude/rules/` に分離（自動読み込み）。
+バックエンド・フロントエンドの詳細な実装ルールは `.claude/rules/` に **path-scoped** で配置されている（[公式仕様](https://code.claude.com/docs/en/memory#path-specific-rules)）。Claude が該当パスのファイルを読んだ時にのみ自動でコンテキストに注入される。
 
-- `.claude/rules/backend-implementation.md` — UserType 分離、contentHash、認可チェック等
-- `.claude/rules/frontend-implementation.md` — Provider 層ルール、Post フィールド追加チェックリスト等
+- `.claude/rules/backend-implementation.md` — `backend/**/*.{ts,sql}` 系を読んだ時に load。UserType 分離、contentHash、認可チェック等
+- `.claude/rules/frontend-implementation.md` — `frontend/**/*.dart` 系を読んだ時に load。Provider 層ルール、Post フィールド追加チェックリスト等
+
+> **注意**: 既知の制限として、**Read 時のみ rule が発火する**（[#23478](https://github.com/anthropics/claude-code/issues/23478)）。新規ファイルを Write で作成する場合は、関連する既存ファイルを先に Read しておくか、必要に応じて手動で rules ファイルを参照すること。
 
 ## Git ワークフロー
 


### PR DESCRIPTION
## Summary

- Adds `paths:` frontmatter to `.claude/rules/backend-implementation.md` and `frontend-implementation.md`
- Each ruleset now loads only when Claude reads files matching its scope, instead of on every session

## Why

[`.claude/rules/` without `paths:` frontmatter loads at launch with the same priority as `.claude/CLAUDE.md`](https://code.claude.com/docs/en/memory#path-specific-rules). The two rules files together are 1,802 lines, so every session paid that cost regardless of whether the work was backend or frontend. Path-scoping cuts the per-session system prompt down to whichever ruleset is actually relevant.

## Scopes applied

- `backend-implementation.md` → `backend/**/*.{ts,sql}`, `backend/drizzle/**/*`
- `frontend-implementation.md` → `frontend/**/*.dart`, `.arb`, `lib/**`, `test/**`

## Known limitation

Path matching fires when Claude **Reads** a matching file, but not when it **Writes** a new one ([anthropics/claude-code#23478](https://github.com/anthropics/claude-code/issues/23478)). For brand-new files, read a neighboring file first (or pull the rule in by hand) so the ruleset is in context before the Write.

`CLAUDE.md` has been updated to point at the official spec and to call out this caveat.

## Test plan

- [ ] Open a backend `.ts` file in a fresh session, run `/memory`, confirm `backend-implementation.md` appears in the loaded list and `frontend-implementation.md` does not
- [ ] Open a frontend `.dart` file in a fresh session, confirm the inverse
- [ ] Confirm `CLAUDE.md` still mentions both rule files with their new path scopes