### PR TITLE
chore(env): align .env.example with actual env.ts usage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,40 @@
+# --- Required ---
+
+# PostgreSQL connection (the dev value works with docker-compose.yml)
 DATABASE_URL=postgresql://gleisner:gleisner@localhost:5433/gleisner
+
+# Server port
 PORT=4000
-JWT_SECRET=change-me-in-production
+
+
+# --- Optional in development, configure for production ---
+
+# Runtime environment. Defaults to "development".
+# NODE_ENV=production
+
+# CORS allowed origins (comma-separated, or "*" for all). Defaults to "http://localhost:3000".
+# In dev, scripts/dev-start.sh forces "*" so Flutter Web's random port works.
+# In production, set this to your frontend's origin explicitly.
+# CORS_ORIGIN=https://your-frontend.example.com
+
+# Require invite codes on signup. Defaults to false.
+# REQUIRE_INVITE=true
+
+
+# --- JWT EdDSA keys (Ed25519) ---
+# - Development: leave unset. Keys auto-generate on every server startup.
+# - Production: REQUIRED. Generate once with: tsx backend/scripts/generate-jwt-keys.ts
+#   Embed newlines as `\n` in the values below.
+# JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+# JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
+
+
+# --- Cloudflare R2 storage (image / video / audio uploads) ---
+# - Required to use media features (avatar, cover, post media). Without these,
+#   the server starts fine but any upload mutation throws "R2 storage is not configured".
+# - Production: REQUIRED.
+# R2_ACCOUNT_ID=
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_BUCKET_NAME=gleisner-media
+# R2_PUBLIC_URL=https://media.example.com


### PR DESCRIPTION
## Summary

The previous `.env.example` was out of sync with the codebase:

- `JWT_SECRET` was listed but **not referenced anywhere** — auth uses Ed25519 key pairs (`JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY`)
- Every variable required for media features (R2) and production deployment (JWT keys, NODE_ENV, CORS_ORIGIN, REQUIRE_INVITE) was missing

This PR rewrites the template to match `src/env.ts`:

- Drops the dead `JWT_SECRET` key
- Adds commented placeholders for `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` with a note that dev auto-generates and prod requires `tsx backend/scripts/generate-jwt-keys.ts`
- Adds commented placeholders for the five `R2_*` variables, noting that media uploads will fail at runtime when missing
- Adds commented placeholders for `NODE_ENV`, `CORS_ORIGIN`, `REQUIRE_INVITE` with their default behavior

Local-only text-post development still works with just `DATABASE_URL` and `PORT` uncommented (current behavior). The new commented sections only need to be filled in for media features or production deploys.

## Test plan

- [ ] `cp backend/.env.example backend/.env` and run `pnpm dev` from `backend/` — server boots
- [ ] Run `pnpm test` from `backend/` — tests pass with the trimmed `.env`
- [ ] Verify R2 upload mutation surfaces "R2 storage is not configured" (not a silent failure) when R2 vars stay commented
- [ ] Production deploy checklist will reference this template after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)