### PR TITLE
chore(mise): add lint_check task for read-only validation

### DIFF
--- a/backend/mise.toml
+++ b/backend/mise.toml
@@ -4,6 +4,7 @@ pnpm = "latest"
 
 [tasks]
 lint = { run = ["pnpm format", "pnpm lint:fix", ] }
+lint_check = { run = ["pnpm format:check", "pnpm lint", "pnpm build"] }
 build = { run = "pnpm build" }
 test = { run = "pnpm test", depends = "build" }
 seed_dev = { run = "pnpm db:push", depends = "build" }

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -3,6 +3,7 @@ flutter = "latest"
 
 [tasks]
 lint = { run = ["dart format lib test", "flutter analyze", ], depends = "pub_get" } # dart fmt にpub_getが必要
+lint_check = { run = ["flutter analyze", "dart format --set-exit-if-changed lib test"], depends = "pub_get" } # 書き換えなしチェック（Stop Hook 用）
 run_web = { run = "flutter run" }
 build = { run = "flutter build web", depends = "clean" }
 pub_get = { run = "flutter pub get" }


### PR DESCRIPTION
## Summary

- Both `backend/` and `frontend/` already had a `lint` task, but each one **rewrites files** (`pnpm format` + `pnpm lint:fix` / `dart format lib test`). That makes them unsafe for automated checks.
- Add a sibling `lint_check` task that runs the same tools in verification-only mode, so a Claude Code Stop Hook (configured in the umbrella `yatima` repo) can validate the working tree without mutating it.
- The existing `lint` task is preserved unchanged.

### Diff

- `backend/mise.toml`: `lint_check = ["pnpm format:check", "pnpm lint", "pnpm build"]`
- `frontend/mise.toml`: `lint_check = ["flutter analyze", "dart format --set-exit-if-changed lib test"]` (depends on `pub_get`)

## Test plan

- [x] `mise tasks` lists `//backend:lint_check` and `//frontend:lint_check`
- [ ] Reviewer confirms the existing `lint` task is untouched and still mutates files (intended)
- [ ] Reviewer runs `mise run -C backend lint_check` and `mise run -C frontend lint_check` locally to confirm the commands match the project's existing PR-prep checks documented in `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)