### PR TITLE
fix(frontend/test): refresh stale references to MediaType.text and User.birthYearMonth

### DIFF
--- a/frontend/test/models/post_copyWith_test.dart
+++ b/frontend/test/models/post_copyWith_test.dart
@@ -5,7 +5,7 @@ Post _makeTestPost() {
   final now = DateTime(2026, 1, 1);
   return Post(
     id: 'p1',
-    mediaType: MediaType.text,
+    mediaType: MediaType.thought,
     title: 'Original Title',
     body: 'Original Body',
     mediaUrl: 'https://example.com',

--- a/frontend/test/models/post_test.dart
+++ b/frontend/test/models/post_test.dart
@@ -5,7 +5,7 @@ import 'package:gleisner_web/models/post.dart';
 void main() {
   final validJson = {
     'id': 'post-1',
-    'mediaType': 'text',
+    'mediaType': 'article',
     'title': 'Hello',
     'body': 'World',
     'mediaUrl': null,
@@ -28,7 +28,7 @@ void main() {
       final post = Post.fromJson(validJson);
 
       expect(post.id, 'post-1');
-      expect(post.mediaType, MediaType.text);
+      expect(post.mediaType, MediaType.article);
       expect(post.title, 'Hello');
       expect(post.body, 'World');
       expect(post.importance, 0.5);
@@ -67,10 +67,10 @@ void main() {
       }
     });
 
-    test('falls back to text on unknown mediaType', () {
+    test('falls back to article on unknown mediaType', () {
       final json = {...validJson, 'mediaType': 'unknown'};
       final post = Post.fromJson(json);
-      expect(post.mediaType, MediaType.text);
+      expect(post.mediaType, MediaType.article);
     });
 
     test('parses duration', () {

--- a/frontend/test/providers/auth_provider_test.dart
+++ b/frontend/test/providers/auth_provider_test.dart
@@ -275,6 +275,7 @@ void main() {
             email: 'test@test.com',
             password: 'password123',
             username: 'testuser',
+            birthYearMonth: '2000-01',
             inviteCode: 'abc123',
           );
 
@@ -288,6 +289,7 @@ void main() {
             email: 'test@test.com',
             password: 'password123',
             username: 'testuser',
+            birthYearMonth: '2000-01',
           );
 
       expect(link.lastVariables?.containsKey('inviteCode'), isFalse);

--- a/frontend/test/providers/create_post_provider_test.dart
+++ b/frontend/test/providers/create_post_provider_test.dart
@@ -119,11 +119,11 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
 
       final state = container.read(createPostProvider);
       expect(state.step, 2);
-      expect(state.selectedMediaType, MediaType.text);
+      expect(state.selectedMediaType, MediaType.thought);
     });
 
     test('goBack decrements step', () {
@@ -132,7 +132,7 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
       expect(container.read(createPostProvider).step, 2);
 
       notifier.goBack();
@@ -151,7 +151,7 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
       notifier.setImportance(0.8);
       notifier.reset();
 
@@ -169,7 +169,7 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
 
       // Capture isSubmitting during the mutation
       final states = <bool>[];
@@ -206,7 +206,7 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
 
       final result = await notifier.submit(
         title: 'Hello',
@@ -228,7 +228,7 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
 
       final result = await notifier.submit(
         title: 'Hello',
@@ -258,7 +258,7 @@ void main() {
     group('addConnection / removeConnection', () {
       Post _fakePost(String id) => Post(
         id: id,
-        mediaType: MediaType.text,
+        mediaType: MediaType.article,
         title: 'Post $id',
         importance: 0.5,
         createdAt: DateTime(2026),

--- a/frontend/test/utils/constellation_graph_test.dart
+++ b/frontend/test/utils/constellation_graph_test.dart
@@ -9,7 +9,7 @@ Post _makePost({
 }) {
   return Post(
     id: id,
-    mediaType: MediaType.text,
+    mediaType: MediaType.thought,
     title: 'Post $id',
     importance: 0.5,
     createdAt: DateTime(2026, 1, 1),

--- a/frontend/test/utils/constellation_layout_test.dart
+++ b/frontend/test/utils/constellation_layout_test.dart
@@ -8,7 +8,7 @@ Post _makePost({
   required String id,
   required DateTime createdAt,
   double importance = 0.5,
-  MediaType mediaType = MediaType.text,
+  MediaType mediaType = MediaType.thought,
   String? trackId,
   String? trackName,
   String? trackColor,
@@ -465,7 +465,7 @@ void main() {
           id: 'text',
           createdAt: now.subtract(const Duration(hours: 1)),
           importance: 0.5,
-          mediaType: MediaType.text,
+          mediaType: MediaType.thought,
         ),
       ];
       final result = ConstellationLayout.compute(


### PR DESCRIPTION
## Summary

Frontend tests still referenced enum values and constructor arguments that were retired in earlier PRs but never propagated to the test suite. The umbrella's session-end `lint_check` hook surfaced these as compile errors on every recent run; this PR cleans them up.

### `MediaType.text` (PR #246 split it into `thought` and `article`)

- `test/models/post_test.dart` — `validJson.mediaType` and the unknown-fallback expectation now use `article`, matching `_parseMediaType`'s `text → article` backward-compat branch.
- `test/providers/create_post_provider_test.dart` — 7 `selectMediaType(...)` callsites become `thought` (no title needed); the `addConnection` fake post (which carries a title) becomes `article`.
- `test/utils/constellation_graph_test.dart`, `test/utils/constellation_layout_test.dart`, `test/models/post_copyWith_test.dart` — fakes use `thought`.

### `User.birthYearMonth` (made required earlier; tests omitted it)

- `test/providers/auth_provider_test.dart` — both `signup(...)` calls in the `inviteCode handling` group now pass `birthYearMonth: '2000-01'`.

## Out of scope

- Pre-existing `flutter analyze` warnings/infos on main (74 issues, unchanged by this PR) — separate cleanup.
- Suite-level `setUpAll`/`tearDownAll` failures under `--platform chrome` caused by `Directory.systemTemp.createTempSync` (`dart:io`, unsupported on Web). The individual test bodies in those suites pass; only the lifecycle hooks fail. Not introduced by this PR.

## Test plan

- [x] `mise run -C frontend lint_check` reports 0 errors (down from 16 errors before this PR)
- [x] Each modified test file passes `flutter test --platform chrome <file>` for non-lifecycle tests
- [ ] Reviewer sanity-checks the thought-vs-article mapping against test intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)