### PR TITLE
chore(i18n): localize remaining hardcoded English strings in screens and widgets

### DIFF
--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -425,5 +425,148 @@
   "imageProcessingFailed": "Could not process image. Please try another file.",
   "@imageProcessingFailed": {
     "description": "Shown when the EXIF/XMP sanitizer fails on a selected image."
-  }
+  },
+
+  "mediaTypeMedia": "Media",
+  "@mediaTypeMedia": { "description": "Fallback media type label shown in the upload area when media type is not image, video, or audio" },
+
+  "artistRegisterAddAtLeastOneTrack": "Add at least one track.",
+  "@artistRegisterAddAtLeastOneTrack": { "description": "Error shown when artist registration is submitted with zero tracks" },
+  "registrationFailed": "Registration failed. Please try again.",
+  "@registrationFailed": { "description": "Generic registration failure message shown on the artist registration screen" },
+  "unexpectedResponse": "Unexpected response.",
+  "@unexpectedResponse": { "description": "Shown when the server returns an unexpected payload during artist registration" },
+  "somethingWentWrong": "Something went wrong. Please try again.",
+  "@somethingWentWrong": { "description": "Generic fallback error shown when an unhandled exception occurs" },
+  "failedTracks": "Tracks: {names}",
+  "@failedTracks": {
+    "description": "Lists the names of tracks that failed to be created during artist registration",
+    "placeholders": { "names": { "type": "String" } }
+  },
+  "failedGenres": "Genres: {names}",
+  "@failedGenres": {
+    "description": "Lists the names of genres that failed to be saved during artist registration",
+    "placeholders": { "names": { "type": "String" } }
+  },
+  "someItemsFailed": "Some items failed: {items}. You can update them later.",
+  "@someItemsFailed": {
+    "description": "Shown after artist registration when some tracks/genres failed to save. Items is a semicolon-separated list.",
+    "placeholders": { "items": { "type": "String" } }
+  },
+
+  "validatorRequired": "Required",
+  "@validatorRequired": { "description": "Generic required field validation message" },
+  "validatorAtLeast2Chars": "At least 2 characters",
+  "@validatorAtLeast2Chars": { "description": "Validation message when a field requires at least 2 characters" },
+  "validatorMax30Chars": "Max 30 characters",
+  "@validatorMax30Chars": { "description": "Validation message when a field exceeds 30 characters" },
+  "validatorMax50Chars": "Max 50 characters",
+  "@validatorMax50Chars": { "description": "Validation message when a field exceeds 50 characters" },
+  "validatorLettersNumbersUnderscoresOnly": "Letters, numbers, and underscores only",
+  "@validatorLettersNumbersUnderscoresOnly": { "description": "Validation message for username-style fields" },
+  "validatorEnterValidYear": "Enter a valid year",
+  "@validatorEnterValidYear": { "description": "Validation message when a year field has an invalid value" },
+  "validatorYearRange": "Must be between 1900 and {maxYear}",
+  "@validatorYearRange": {
+    "description": "Validation message for the active-since year field, where maxYear is the current year",
+    "placeholders": { "maxYear": { "type": "int" } }
+  },
+
+  "failedUpdateProfile": "Failed to update profile. Please try again.",
+  "@failedUpdateProfile": { "description": "Shown when a profile update API call fails" },
+
+  "titleIsRequired": "Title is required",
+  "@titleIsRequired": { "description": "Validation message shown when milestone title is empty" },
+  "failedAddMilestone": "Failed to add milestone",
+  "@failedAddMilestone": { "description": "Shown when the add-milestone API call fails" },
+
+  "failedAddLink": "Failed to add link. Please try again.",
+  "@failedAddLink": { "description": "Shown when the add-link API call fails on the artist links sheet" },
+  "platformNameRequired": "Platform name is required",
+  "@platformNameRequired": { "description": "Validation message when the platform name field is empty on the add-link form" },
+
+  "failedCreateTrackRetry": "Failed to create track. Please try again.",
+  "@failedCreateTrackRetry": { "description": "Shown when the create-track API call fails on the manage-tracks sheet" },
+  "trackNameRequired": "Track name is required",
+  "@trackNameRequired": { "description": "Validation message when track name field is empty" },
+  "trackNameAlreadyExists": "Track name already exists",
+  "@trackNameAlreadyExists": { "description": "Validation message when the entered track name already exists for this artist" },
+
+  "activeSince": "Active since {year}",
+  "@activeSince": {
+    "description": "Label shown on the artist page below the artist name, indicating the year the artist started",
+    "placeholders": { "year": { "type": "int" } }
+  },
+  "enterDisplayName": "Enter display name",
+  "@enterDisplayName": { "description": "Hint text for the constellation display name input field" },
+
+  "failedUpdateArtist": "Failed to update. Please try again.",
+  "@failedUpdateArtist": { "description": "Shown when an artist-about update API call fails" },
+  "enterValidYear": "Enter a valid year (1900-{maxYear})",
+  "@enterValidYear": {
+    "description": "Validation message for the active-since year in the edit-artist-about sheet",
+    "placeholders": { "maxYear": { "type": "int" } }
+  },
+
+  "connectionTypeReference": "Reference",
+  "@connectionTypeReference": { "description": "Label for the 'Reference' connection type in the connection type picker" },
+  "connectionTypeEvolution": "Evolution",
+  "@connectionTypeEvolution": { "description": "Label for the 'Evolution' connection type in the connection type picker" },
+  "connectionTypeRemix": "Remix",
+  "@connectionTypeRemix": { "description": "Label for the 'Remix' connection type in the connection type picker" },
+  "connectionTypeReply": "Reply",
+  "@connectionTypeReply": { "description": "Label for the 'Reply' connection type in the connection type picker" },
+  "connectionTypeReferenceDesc": "Inspired by or related to",
+  "@connectionTypeReferenceDesc": { "description": "Short description of the Reference connection type" },
+  "connectionTypeEvolutionDesc": "Next version of this piece",
+  "@connectionTypeEvolutionDesc": { "description": "Short description of the Evolution connection type" },
+  "connectionTypeRemixDesc": "A remix or reinterpretation",
+  "@connectionTypeRemixDesc": { "description": "Short description of the Remix connection type" },
+  "connectionTypeReplyDesc": "A response to this post",
+  "@connectionTypeReplyDesc": { "description": "Short description of the Reply connection type" },
+  "connectionType": "Connection Type",
+  "@connectionType": { "description": "Section header label for the connection type picker widget" },
+
+  "aboutExternal": "About / External Services",
+  "@aboutExternal": { "description": "Footer link label that opens the About / External Services page" },
+
+  "selectRelatedPost": "Select related post",
+  "@selectRelatedPost": { "description": "Title shown at the top of the related-post picker bottom sheet" },
+  "searchPosts": "Search posts...",
+  "@searchPosts": { "description": "Hint text for the search field in the related-post picker" },
+  "unknown": "Unknown",
+  "@unknown": { "description": "Fallback label used when a track name is null or unavailable" },
+  "noPostsFound": "No posts found",
+  "@noPostsFound": { "description": "Shown in the related-post picker when no posts match the current filter/search" },
+
+  "you": "You",
+  "@you": { "description": "Label used in the avatar rail to represent the logged-in user's own avatar" },
+
+  "milestone": "Milestone",
+  "@milestone": { "description": "Section header label in the milestone detail sheet" },
+
+  "monthJanuary": "January",
+  "@monthJanuary": { "description": "Full name of the first month of the year" },
+  "monthFebruary": "February",
+  "@monthFebruary": { "description": "Full name of the second month of the year" },
+  "monthMarch": "March",
+  "@monthMarch": { "description": "Full name of the third month of the year" },
+  "monthApril": "April",
+  "@monthApril": { "description": "Full name of the fourth month of the year" },
+  "monthMay": "May",
+  "@monthMay": { "description": "Full name of the fifth month of the year" },
+  "monthJune": "June",
+  "@monthJune": { "description": "Full name of the sixth month of the year" },
+  "monthJuly": "July",
+  "@monthJuly": { "description": "Full name of the seventh month of the year" },
+  "monthAugust": "August",
+  "@monthAugust": { "description": "Full name of the eighth month of the year" },
+  "monthSeptember": "September",
+  "@monthSeptember": { "description": "Full name of the ninth month of the year" },
+  "monthOctober": "October",
+  "@monthOctober": { "description": "Full name of the tenth month of the year" },
+  "monthNovember": "November",
+  "@monthNovember": { "description": "Full name of the eleventh month of the year" },
+  "monthDecember": "December",
+  "@monthDecember": { "description": "Full name of the twelfth month of the year" }
 }

--- a/frontend/lib/l10n/app_ja.arb
+++ b/frontend/lib/l10n/app_ja.arb
@@ -344,5 +344,75 @@
   "audioDurationUnknown": "音声の長さを確認できませんでした。別のファイルをお試しください。",
   "heicNotSupported": "HEIC 形式には対応していません。JPEG または PNG を選択してください。",
   "heicConversionFailed": "HEIC 画像を変換できませんでした。Safari で再度お試しいただくか、先に JPEG に変換してください。",
-  "imageProcessingFailed": "画像を処理できませんでした。別のファイルをお試しください。"
+  "imageProcessingFailed": "画像を処理できませんでした。別のファイルをお試しください。",
+
+  "mediaTypeMedia": "メディア",
+
+  "artistRegisterAddAtLeastOneTrack": "トラックを1つ以上追加してください。",
+  "registrationFailed": "登録に失敗しました。再試行してください。",
+  "unexpectedResponse": "予期しないレスポンスが返されました。",
+  "somethingWentWrong": "エラーが発生しました。再試行してください。",
+  "failedTracks": "トラック: {names}",
+  "failedGenres": "ジャンル: {names}",
+  "someItemsFailed": "一部の項目に失敗しました: {items}。後から更新できます。",
+
+  "validatorRequired": "必須項目です",
+  "validatorAtLeast2Chars": "2文字以上で入力してください",
+  "validatorMax30Chars": "30文字以内で入力してください",
+  "validatorMax50Chars": "50文字以内で入力してください",
+  "validatorLettersNumbersUnderscoresOnly": "英数字とアンダースコアのみ使用できます",
+  "validatorEnterValidYear": "有効な年を入力してください",
+  "validatorYearRange": "1900〜{maxYear}の間で入力してください",
+
+  "failedUpdateProfile": "プロフィールの更新に失敗しました。再試行してください。",
+
+  "titleIsRequired": "タイトルは必須です",
+  "failedAddMilestone": "マイルストーンの追加に失敗しました",
+
+  "failedAddLink": "リンクの追加に失敗しました。再試行してください。",
+  "platformNameRequired": "プラットフォーム名は必須です",
+
+  "failedCreateTrackRetry": "トラックの作成に失敗しました。再試行してください。",
+  "trackNameRequired": "トラック名は必須です",
+  "trackNameAlreadyExists": "このトラック名は既に存在します",
+
+  "activeSince": "{year}年から活動",
+  "enterDisplayName": "表示名を入力",
+
+  "failedUpdateArtist": "更新に失敗しました。再試行してください。",
+  "enterValidYear": "有効な年を入力してください（1900〜{maxYear}）",
+
+  "connectionTypeReference": "リファレンス",
+  "connectionTypeEvolution": "進化",
+  "connectionTypeRemix": "リミックス",
+  "connectionTypeReply": "返答",
+  "connectionTypeReferenceDesc": "インスピレーション元・関連作品",
+  "connectionTypeEvolutionDesc": "この作品の次バージョン",
+  "connectionTypeRemixDesc": "リミックスまたは再解釈",
+  "connectionTypeReplyDesc": "この投稿への返答",
+  "connectionType": "接続タイプ",
+
+  "aboutExternal": "概要 / 外部サービス",
+
+  "selectRelatedPost": "関連投稿を選択",
+  "searchPosts": "投稿を検索...",
+  "unknown": "不明",
+  "noPostsFound": "投稿が見つかりません",
+
+  "you": "自分",
+
+  "milestone": "マイルストーン",
+
+  "monthJanuary": "1月",
+  "monthFebruary": "2月",
+  "monthMarch": "3月",
+  "monthApril": "4月",
+  "monthMay": "5月",
+  "monthJune": "6月",
+  "monthJuly": "7月",
+  "monthAugust": "8月",
+  "monthSeptember": "9月",
+  "monthOctober": "10月",
+  "monthNovember": "11月",
+  "monthDecember": "12月"
 }

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -1999,6 +1999,336 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not process image. Please try another file.'**
   String get imageProcessingFailed;
+
+  /// Fallback media type label shown in the upload area when media type is not image, video, or audio
+  ///
+  /// In en, this message translates to:
+  /// **'Media'**
+  String get mediaTypeMedia;
+
+  /// Error shown when artist registration is submitted with zero tracks
+  ///
+  /// In en, this message translates to:
+  /// **'Add at least one track.'**
+  String get artistRegisterAddAtLeastOneTrack;
+
+  /// Generic registration failure message shown on the artist registration screen
+  ///
+  /// In en, this message translates to:
+  /// **'Registration failed. Please try again.'**
+  String get registrationFailed;
+
+  /// Shown when the server returns an unexpected payload during artist registration
+  ///
+  /// In en, this message translates to:
+  /// **'Unexpected response.'**
+  String get unexpectedResponse;
+
+  /// Generic fallback error shown when an unhandled exception occurs
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong. Please try again.'**
+  String get somethingWentWrong;
+
+  /// Lists the names of tracks that failed to be created during artist registration
+  ///
+  /// In en, this message translates to:
+  /// **'Tracks: {names}'**
+  String failedTracks(String names);
+
+  /// Lists the names of genres that failed to be saved during artist registration
+  ///
+  /// In en, this message translates to:
+  /// **'Genres: {names}'**
+  String failedGenres(String names);
+
+  /// Shown after artist registration when some tracks/genres failed to save. Items is a semicolon-separated list.
+  ///
+  /// In en, this message translates to:
+  /// **'Some items failed: {items}. You can update them later.'**
+  String someItemsFailed(String items);
+
+  /// Generic required field validation message
+  ///
+  /// In en, this message translates to:
+  /// **'Required'**
+  String get validatorRequired;
+
+  /// Validation message when a field requires at least 2 characters
+  ///
+  /// In en, this message translates to:
+  /// **'At least 2 characters'**
+  String get validatorAtLeast2Chars;
+
+  /// Validation message when a field exceeds 30 characters
+  ///
+  /// In en, this message translates to:
+  /// **'Max 30 characters'**
+  String get validatorMax30Chars;
+
+  /// Validation message when a field exceeds 50 characters
+  ///
+  /// In en, this message translates to:
+  /// **'Max 50 characters'**
+  String get validatorMax50Chars;
+
+  /// Validation message for username-style fields
+  ///
+  /// In en, this message translates to:
+  /// **'Letters, numbers, and underscores only'**
+  String get validatorLettersNumbersUnderscoresOnly;
+
+  /// Validation message when a year field has an invalid value
+  ///
+  /// In en, this message translates to:
+  /// **'Enter a valid year'**
+  String get validatorEnterValidYear;
+
+  /// Validation message for the active-since year field, where maxYear is the current year
+  ///
+  /// In en, this message translates to:
+  /// **'Must be between 1900 and {maxYear}'**
+  String validatorYearRange(int maxYear);
+
+  /// Shown when a profile update API call fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to update profile. Please try again.'**
+  String get failedUpdateProfile;
+
+  /// Validation message shown when milestone title is empty
+  ///
+  /// In en, this message translates to:
+  /// **'Title is required'**
+  String get titleIsRequired;
+
+  /// Shown when the add-milestone API call fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to add milestone'**
+  String get failedAddMilestone;
+
+  /// Shown when the add-link API call fails on the artist links sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to add link. Please try again.'**
+  String get failedAddLink;
+
+  /// Validation message when the platform name field is empty on the add-link form
+  ///
+  /// In en, this message translates to:
+  /// **'Platform name is required'**
+  String get platformNameRequired;
+
+  /// Shown when the create-track API call fails on the manage-tracks sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to create track. Please try again.'**
+  String get failedCreateTrackRetry;
+
+  /// Validation message when track name field is empty
+  ///
+  /// In en, this message translates to:
+  /// **'Track name is required'**
+  String get trackNameRequired;
+
+  /// Validation message when the entered track name already exists for this artist
+  ///
+  /// In en, this message translates to:
+  /// **'Track name already exists'**
+  String get trackNameAlreadyExists;
+
+  /// Label shown on the artist page below the artist name, indicating the year the artist started
+  ///
+  /// In en, this message translates to:
+  /// **'Active since {year}'**
+  String activeSince(int year);
+
+  /// Hint text for the constellation display name input field
+  ///
+  /// In en, this message translates to:
+  /// **'Enter display name'**
+  String get enterDisplayName;
+
+  /// Shown when an artist-about update API call fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to update. Please try again.'**
+  String get failedUpdateArtist;
+
+  /// Validation message for the active-since year in the edit-artist-about sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Enter a valid year (1900-{maxYear})'**
+  String enterValidYear(int maxYear);
+
+  /// Label for the 'Reference' connection type in the connection type picker
+  ///
+  /// In en, this message translates to:
+  /// **'Reference'**
+  String get connectionTypeReference;
+
+  /// Label for the 'Evolution' connection type in the connection type picker
+  ///
+  /// In en, this message translates to:
+  /// **'Evolution'**
+  String get connectionTypeEvolution;
+
+  /// Label for the 'Remix' connection type in the connection type picker
+  ///
+  /// In en, this message translates to:
+  /// **'Remix'**
+  String get connectionTypeRemix;
+
+  /// Label for the 'Reply' connection type in the connection type picker
+  ///
+  /// In en, this message translates to:
+  /// **'Reply'**
+  String get connectionTypeReply;
+
+  /// Short description of the Reference connection type
+  ///
+  /// In en, this message translates to:
+  /// **'Inspired by or related to'**
+  String get connectionTypeReferenceDesc;
+
+  /// Short description of the Evolution connection type
+  ///
+  /// In en, this message translates to:
+  /// **'Next version of this piece'**
+  String get connectionTypeEvolutionDesc;
+
+  /// Short description of the Remix connection type
+  ///
+  /// In en, this message translates to:
+  /// **'A remix or reinterpretation'**
+  String get connectionTypeRemixDesc;
+
+  /// Short description of the Reply connection type
+  ///
+  /// In en, this message translates to:
+  /// **'A response to this post'**
+  String get connectionTypeReplyDesc;
+
+  /// Section header label for the connection type picker widget
+  ///
+  /// In en, this message translates to:
+  /// **'Connection Type'**
+  String get connectionType;
+
+  /// Footer link label that opens the About / External Services page
+  ///
+  /// In en, this message translates to:
+  /// **'About / External Services'**
+  String get aboutExternal;
+
+  /// Title shown at the top of the related-post picker bottom sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Select related post'**
+  String get selectRelatedPost;
+
+  /// Hint text for the search field in the related-post picker
+  ///
+  /// In en, this message translates to:
+  /// **'Search posts...'**
+  String get searchPosts;
+
+  /// Fallback label used when a track name is null or unavailable
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get unknown;
+
+  /// Shown in the related-post picker when no posts match the current filter/search
+  ///
+  /// In en, this message translates to:
+  /// **'No posts found'**
+  String get noPostsFound;
+
+  /// Label used in the avatar rail to represent the logged-in user's own avatar
+  ///
+  /// In en, this message translates to:
+  /// **'You'**
+  String get you;
+
+  /// Section header label in the milestone detail sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Milestone'**
+  String get milestone;
+
+  /// Full name of the first month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'January'**
+  String get monthJanuary;
+
+  /// Full name of the second month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'February'**
+  String get monthFebruary;
+
+  /// Full name of the third month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'March'**
+  String get monthMarch;
+
+  /// Full name of the fourth month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'April'**
+  String get monthApril;
+
+  /// Full name of the fifth month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'May'**
+  String get monthMay;
+
+  /// Full name of the sixth month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'June'**
+  String get monthJune;
+
+  /// Full name of the seventh month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'July'**
+  String get monthJuly;
+
+  /// Full name of the eighth month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'August'**
+  String get monthAugust;
+
+  /// Full name of the ninth month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'September'**
+  String get monthSeptember;
+
+  /// Full name of the tenth month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'October'**
+  String get monthOctober;
+
+  /// Full name of the eleventh month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'November'**
+  String get monthNovember;
+
+  /// Full name of the twelfth month of the year
+  ///
+  /// In en, this message translates to:
+  /// **'December'**
+  String get monthDecember;
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -1073,4 +1073,184 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get imageProcessingFailed =>
       'Could not process image. Please try another file.';
+
+  @override
+  String get mediaTypeMedia => 'Media';
+
+  @override
+  String get artistRegisterAddAtLeastOneTrack => 'Add at least one track.';
+
+  @override
+  String get registrationFailed => 'Registration failed. Please try again.';
+
+  @override
+  String get unexpectedResponse => 'Unexpected response.';
+
+  @override
+  String get somethingWentWrong => 'Something went wrong. Please try again.';
+
+  @override
+  String failedTracks(String names) {
+    return 'Tracks: $names';
+  }
+
+  @override
+  String failedGenres(String names) {
+    return 'Genres: $names';
+  }
+
+  @override
+  String someItemsFailed(String items) {
+    return 'Some items failed: $items. You can update them later.';
+  }
+
+  @override
+  String get validatorRequired => 'Required';
+
+  @override
+  String get validatorAtLeast2Chars => 'At least 2 characters';
+
+  @override
+  String get validatorMax30Chars => 'Max 30 characters';
+
+  @override
+  String get validatorMax50Chars => 'Max 50 characters';
+
+  @override
+  String get validatorLettersNumbersUnderscoresOnly =>
+      'Letters, numbers, and underscores only';
+
+  @override
+  String get validatorEnterValidYear => 'Enter a valid year';
+
+  @override
+  String validatorYearRange(int maxYear) {
+    return 'Must be between 1900 and $maxYear';
+  }
+
+  @override
+  String get failedUpdateProfile =>
+      'Failed to update profile. Please try again.';
+
+  @override
+  String get titleIsRequired => 'Title is required';
+
+  @override
+  String get failedAddMilestone => 'Failed to add milestone';
+
+  @override
+  String get failedAddLink => 'Failed to add link. Please try again.';
+
+  @override
+  String get platformNameRequired => 'Platform name is required';
+
+  @override
+  String get failedCreateTrackRetry =>
+      'Failed to create track. Please try again.';
+
+  @override
+  String get trackNameRequired => 'Track name is required';
+
+  @override
+  String get trackNameAlreadyExists => 'Track name already exists';
+
+  @override
+  String activeSince(int year) {
+    return 'Active since $year';
+  }
+
+  @override
+  String get enterDisplayName => 'Enter display name';
+
+  @override
+  String get failedUpdateArtist => 'Failed to update. Please try again.';
+
+  @override
+  String enterValidYear(int maxYear) {
+    return 'Enter a valid year (1900-$maxYear)';
+  }
+
+  @override
+  String get connectionTypeReference => 'Reference';
+
+  @override
+  String get connectionTypeEvolution => 'Evolution';
+
+  @override
+  String get connectionTypeRemix => 'Remix';
+
+  @override
+  String get connectionTypeReply => 'Reply';
+
+  @override
+  String get connectionTypeReferenceDesc => 'Inspired by or related to';
+
+  @override
+  String get connectionTypeEvolutionDesc => 'Next version of this piece';
+
+  @override
+  String get connectionTypeRemixDesc => 'A remix or reinterpretation';
+
+  @override
+  String get connectionTypeReplyDesc => 'A response to this post';
+
+  @override
+  String get connectionType => 'Connection Type';
+
+  @override
+  String get aboutExternal => 'About / External Services';
+
+  @override
+  String get selectRelatedPost => 'Select related post';
+
+  @override
+  String get searchPosts => 'Search posts...';
+
+  @override
+  String get unknown => 'Unknown';
+
+  @override
+  String get noPostsFound => 'No posts found';
+
+  @override
+  String get you => 'You';
+
+  @override
+  String get milestone => 'Milestone';
+
+  @override
+  String get monthJanuary => 'January';
+
+  @override
+  String get monthFebruary => 'February';
+
+  @override
+  String get monthMarch => 'March';
+
+  @override
+  String get monthApril => 'April';
+
+  @override
+  String get monthMay => 'May';
+
+  @override
+  String get monthJune => 'June';
+
+  @override
+  String get monthJuly => 'July';
+
+  @override
+  String get monthAugust => 'August';
+
+  @override
+  String get monthSeptember => 'September';
+
+  @override
+  String get monthOctober => 'October';
+
+  @override
+  String get monthNovember => 'November';
+
+  @override
+  String get monthDecember => 'December';
 }

--- a/frontend/lib/l10n/app_localizations_ja.dart
+++ b/frontend/lib/l10n/app_localizations_ja.dart
@@ -1037,4 +1037,181 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get imageProcessingFailed => '画像を処理できませんでした。別のファイルをお試しください。';
+
+  @override
+  String get mediaTypeMedia => 'メディア';
+
+  @override
+  String get artistRegisterAddAtLeastOneTrack => 'トラックを1つ以上追加してください。';
+
+  @override
+  String get registrationFailed => '登録に失敗しました。再試行してください。';
+
+  @override
+  String get unexpectedResponse => '予期しないレスポンスが返されました。';
+
+  @override
+  String get somethingWentWrong => 'エラーが発生しました。再試行してください。';
+
+  @override
+  String failedTracks(String names) {
+    return 'トラック: $names';
+  }
+
+  @override
+  String failedGenres(String names) {
+    return 'ジャンル: $names';
+  }
+
+  @override
+  String someItemsFailed(String items) {
+    return '一部の項目に失敗しました: $items。後から更新できます。';
+  }
+
+  @override
+  String get validatorRequired => '必須項目です';
+
+  @override
+  String get validatorAtLeast2Chars => '2文字以上で入力してください';
+
+  @override
+  String get validatorMax30Chars => '30文字以内で入力してください';
+
+  @override
+  String get validatorMax50Chars => '50文字以内で入力してください';
+
+  @override
+  String get validatorLettersNumbersUnderscoresOnly => '英数字とアンダースコアのみ使用できます';
+
+  @override
+  String get validatorEnterValidYear => '有効な年を入力してください';
+
+  @override
+  String validatorYearRange(int maxYear) {
+    return '1900〜$maxYearの間で入力してください';
+  }
+
+  @override
+  String get failedUpdateProfile => 'プロフィールの更新に失敗しました。再試行してください。';
+
+  @override
+  String get titleIsRequired => 'タイトルは必須です';
+
+  @override
+  String get failedAddMilestone => 'マイルストーンの追加に失敗しました';
+
+  @override
+  String get failedAddLink => 'リンクの追加に失敗しました。再試行してください。';
+
+  @override
+  String get platformNameRequired => 'プラットフォーム名は必須です';
+
+  @override
+  String get failedCreateTrackRetry => 'トラックの作成に失敗しました。再試行してください。';
+
+  @override
+  String get trackNameRequired => 'トラック名は必須です';
+
+  @override
+  String get trackNameAlreadyExists => 'このトラック名は既に存在します';
+
+  @override
+  String activeSince(int year) {
+    return '$year年から活動';
+  }
+
+  @override
+  String get enterDisplayName => '表示名を入力';
+
+  @override
+  String get failedUpdateArtist => '更新に失敗しました。再試行してください。';
+
+  @override
+  String enterValidYear(int maxYear) {
+    return '有効な年を入力してください（1900〜$maxYear）';
+  }
+
+  @override
+  String get connectionTypeReference => 'リファレンス';
+
+  @override
+  String get connectionTypeEvolution => '進化';
+
+  @override
+  String get connectionTypeRemix => 'リミックス';
+
+  @override
+  String get connectionTypeReply => '返答';
+
+  @override
+  String get connectionTypeReferenceDesc => 'インスピレーション元・関連作品';
+
+  @override
+  String get connectionTypeEvolutionDesc => 'この作品の次バージョン';
+
+  @override
+  String get connectionTypeRemixDesc => 'リミックスまたは再解釈';
+
+  @override
+  String get connectionTypeReplyDesc => 'この投稿への返答';
+
+  @override
+  String get connectionType => '接続タイプ';
+
+  @override
+  String get aboutExternal => '概要 / 外部サービス';
+
+  @override
+  String get selectRelatedPost => '関連投稿を選択';
+
+  @override
+  String get searchPosts => '投稿を検索...';
+
+  @override
+  String get unknown => '不明';
+
+  @override
+  String get noPostsFound => '投稿が見つかりません';
+
+  @override
+  String get you => '自分';
+
+  @override
+  String get milestone => 'マイルストーン';
+
+  @override
+  String get monthJanuary => '1月';
+
+  @override
+  String get monthFebruary => '2月';
+
+  @override
+  String get monthMarch => '3月';
+
+  @override
+  String get monthApril => '4月';
+
+  @override
+  String get monthMay => '5月';
+
+  @override
+  String get monthJune => '6月';
+
+  @override
+  String get monthJuly => '7月';
+
+  @override
+  String get monthAugust => '8月';
+
+  @override
+  String get monthSeptember => '9月';
+
+  @override
+  String get monthOctober => '10月';
+
+  @override
+  String get monthNovember => '11月';
+
+  @override
+  String get monthDecember => '12月';
 }

--- a/frontend/lib/screens/artist/artist_page_screen.dart
+++ b/frontend/lib/screens/artist/artist_page_screen.dart
@@ -464,7 +464,9 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
                                                 ),
                                               if (artist.activeSince != null)
                                                 Text(
-                                                  'Active since ${artist.activeSince}',
+                                                  context.l10n.activeSince(
+                                                    artist.activeSince!,
+                                                  ),
                                                   style: const TextStyle(
                                                     color: colorTextMuted,
                                                     fontSize: fontSizeSm,
@@ -966,7 +968,7 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
               autofocus: true,
               style: const TextStyle(color: colorTextPrimary),
               decoration: InputDecoration(
-                hintText: 'Enter display name',
+                hintText: context.l10n.enterDisplayName,
                 hintStyle: const TextStyle(color: colorTextMuted),
                 enabledBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(radiusMd),

--- a/frontend/lib/screens/artist/edit_artist_about_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_about_sheet.dart
@@ -86,7 +86,7 @@ class _EditArtistAboutSheetState extends ConsumerState<EditArtistAboutSheet> {
     } else {
       setState(() {
         _isSubmitting = false;
-        _error = 'Failed to update. Please try again.';
+        _error = context.l10n.failedUpdateArtist;
       });
     }
   }
@@ -186,7 +186,7 @@ class _EditArtistAboutSheetState extends ConsumerState<EditArtistAboutSheet> {
                       if (year == null ||
                           year < 1900 ||
                           year > DateTime.now().year) {
-                        return 'Enter a valid year (1900-${DateTime.now().year})';
+                        return context.l10n.enterValidYear(DateTime.now().year);
                       }
                     }
                     return null;

--- a/frontend/lib/screens/artist/edit_artist_links_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_links_sheet.dart
@@ -84,7 +84,7 @@ class _EditArtistLinksSheetState extends ConsumerState<EditArtistLinksSheet> {
     } else {
       setState(() {
         _isSubmitting = false;
-        _error = 'Failed to add link. Please try again.';
+        _error = context.l10n.failedAddLink;
       });
     }
   }
@@ -401,7 +401,7 @@ class _AddLinkForm extends StatelessWidget {
             decoration: _inputDecoration(context.l10n.platform),
             validator: (value) {
               if (value == null || value.trim().isEmpty) {
-                return 'Platform name is required';
+                return context.l10n.platformNameRequired;
               }
               return null;
             },

--- a/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
@@ -75,7 +75,7 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
     } else {
       setState(() {
         _isSubmitting = false;
-        _error = 'Failed to create track. Please try again.';
+        _error = context.l10n.failedCreateTrackRetry;
       });
     }
   }
@@ -271,14 +271,14 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
                         ),
                         validator: (value) {
                           if (value == null || value.trim().isEmpty) {
-                            return 'Track name is required';
+                            return context.l10n.trackNameRequired;
                           }
                           if (_tracks.any(
                             (t) =>
                                 t.name.toLowerCase() ==
                                 value.trim().toLowerCase(),
                           )) {
-                            return 'Track name already exists';
+                            return context.l10n.trackNameAlreadyExists;
                           }
                           return null;
                         },

--- a/frontend/lib/screens/artist/edit_milestones_sheet.dart
+++ b/frontend/lib/screens/artist/edit_milestones_sheet.dart
@@ -51,7 +51,7 @@ class _EditMilestonesSheetState extends ConsumerState<EditMilestonesSheet> {
   Future<void> _addMilestone() async {
     final title = _titleController.text.trim();
     if (title.isEmpty) {
-      setState(() => _error = 'Title is required');
+      setState(() => _error = context.l10n.titleIsRequired);
       return;
     }
 
@@ -89,7 +89,7 @@ class _EditMilestonesSheetState extends ConsumerState<EditMilestonesSheet> {
       ref.read(artistPageProvider.notifier).loadArtist(widget.artistUsername);
     } else {
       setState(() {
-        _error = 'Failed to add milestone';
+        _error = context.l10n.failedAddMilestone;
         _isSubmitting = false;
       });
     }

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -929,10 +929,18 @@ class _FormStep extends ConsumerWidget {
     WidgetRef ref,
   ) {
     final (icon, _) = switch (mediaType) {
-      MediaType.image => (Icons.add_photo_alternate_outlined, 'Image'),
-      MediaType.video => (Icons.videocam_outlined, 'Video'),
-      MediaType.audio => (Icons.audiotrack_outlined, 'Audio'),
-      _ => (Icons.attach_file, 'Media'),
+      MediaType.image => (
+        Icons.add_photo_alternate_outlined,
+        context.l10n.mediaTypeImage,
+      ),
+      MediaType.video => (Icons.videocam_outlined, context.l10n.mediaTypeVideo),
+      MediaType.audio => (
+        Icons.audiotrack_outlined,
+        context.l10n.mediaTypeAudio,
+      ),
+      MediaType.thought ||
+      MediaType.article ||
+      MediaType.link => (Icons.attach_file, context.l10n.mediaTypeMedia),
     };
 
     final uploadState = ref.watch(mediaUploadProvider);
@@ -1569,7 +1577,7 @@ class _ConnectionsSection extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
               subtitle: Text(
-                '${c.connectionType.label} · ${post.trackName ?? ''}',
+                '${c.connectionType.label(context)} · ${post.trackName ?? ''}',
                 style: theme.textTheme.labelSmall,
               ),
               trailing: IconButton(

--- a/frontend/lib/screens/profile/create_child_sheet.dart
+++ b/frontend/lib/screens/profile/create_child_sheet.dart
@@ -328,7 +328,7 @@ class _CreateChildSheetState extends ConsumerState<CreateChildSheet> {
       final error = ref.read(guardianProvider).error;
       setState(() {
         _submitting = false;
-        _error = error ?? 'Something went wrong. Please try again.';
+        _error = error ?? context.l10n.somethingWentWrong;
       });
     }
   }

--- a/frontend/lib/screens/profile/edit_profile_sheet.dart
+++ b/frontend/lib/screens/profile/edit_profile_sheet.dart
@@ -97,7 +97,7 @@ class _EditProfileSheetState extends ConsumerState<EditProfileSheet> {
     } else {
       setState(() {
         _isSubmitting = false;
-        _error = 'Failed to update profile. Please try again.';
+        _error = context.l10n.failedUpdateProfile;
       });
     }
   }

--- a/frontend/lib/screens/profile/profile_screen.dart
+++ b/frontend/lib/screens/profile/profile_screen.dart
@@ -15,6 +15,7 @@ import '../../providers/tutorial_provider.dart';
 import '../../providers/unassigned_posts_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../utils/account_switch_helper.dart';
+import '../../utils/month_names.dart';
 import '../../theme/gleisner_tokens.dart';
 import 'create_child_sheet.dart';
 import 'edit_profile_sheet.dart';
@@ -121,7 +122,9 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                 spacing: spaceLg,
                 children: [
                   Text(
-                    context.l10n.joinedDate(_formatJoinDate(user.createdAt)),
+                    context.l10n.joinedDate(
+                      _formatJoinDate(context, user.createdAt),
+                    ),
                     style: textCaption.copyWith(color: colorTextMuted),
                   ),
                   if (tuneInState.tunedInArtists.isNotEmpty)
@@ -564,22 +567,8 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
     await ref.read(guardianProvider.notifier).loadChildren(forceReload: true);
   }
 
-  static String _formatJoinDate(DateTime date) {
-    const months = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    return '${months[date.month - 1]} ${date.year}';
+  static String _formatJoinDate(BuildContext context, DateTime date) {
+    return '${monthShort(context, date.month)} ${date.year}';
   }
 
   void _showEditSheet(BuildContext context, User user) {

--- a/frontend/lib/screens/profile/register_artist_sheet.dart
+++ b/frontend/lib/screens/profile/register_artist_sheet.dart
@@ -57,7 +57,7 @@ class _RegisterArtistSheetState extends ConsumerState<RegisterArtistSheet> {
         debugPrint('[RegisterArtist] GraphQL error: ${result.exception}');
         setState(() {
           _isSubmitting = false;
-          _error = 'Registration failed. Please try again.';
+          _error = context.l10n.registrationFailed;
         });
         return;
       }
@@ -66,7 +66,7 @@ class _RegisterArtistSheetState extends ConsumerState<RegisterArtistSheet> {
       if (data == null) {
         setState(() {
           _isSubmitting = false;
-          _error = 'Unexpected response';
+          _error = context.l10n.unexpectedResponse;
         });
         return;
       }
@@ -79,7 +79,7 @@ class _RegisterArtistSheetState extends ConsumerState<RegisterArtistSheet> {
       debugPrint('[RegisterArtist] Unexpected error: $e');
       setState(() {
         _isSubmitting = false;
-        _error = 'Something went wrong. Please try again.';
+        _error = context.l10n.somethingWentWrong;
       });
     }
   }
@@ -128,12 +128,15 @@ class _RegisterArtistSheetState extends ConsumerState<RegisterArtistSheet> {
                 border: const OutlineInputBorder(),
               ),
               validator: (v) {
-                if (v == null || v.trim().isEmpty) return 'Required';
+                if (v == null || v.trim().isEmpty)
+                  return context.l10n.validatorRequired;
                 final trimmed = v.trim();
-                if (trimmed.length < 2) return 'At least 2 characters';
-                if (trimmed.length > 30) return 'Max 30 characters';
+                if (trimmed.length < 2)
+                  return context.l10n.validatorAtLeast2Chars;
+                if (trimmed.length > 30)
+                  return context.l10n.validatorMax30Chars;
                 if (!RegExp(r'^[a-zA-Z0-9_]+$').hasMatch(trimmed)) {
-                  return 'Letters, numbers, and underscores only';
+                  return context.l10n.validatorLettersNumbersUnderscoresOnly;
                 }
                 return null;
               },
@@ -147,8 +150,10 @@ class _RegisterArtistSheetState extends ConsumerState<RegisterArtistSheet> {
                 border: const OutlineInputBorder(),
               ),
               validator: (v) {
-                if (v == null || v.trim().isEmpty) return 'Required';
-                if (v.trim().length > 50) return 'Max 50 characters';
+                if (v == null || v.trim().isEmpty)
+                  return context.l10n.validatorRequired;
+                if (v.trim().length > 50)
+                  return context.l10n.validatorMax50Chars;
                 return null;
               },
             ),

--- a/frontend/lib/screens/profile/register_artist_wizard.dart
+++ b/frontend/lib/screens/profile/register_artist_wizard.dart
@@ -216,7 +216,7 @@ class _RegisterArtistWizardState extends ConsumerState<RegisterArtistWizard> {
 
   Future<void> _handleRegister() async {
     if (_tracks.isEmpty) {
-      setState(() => _error = 'Add at least one track.');
+      setState(() => _error = context.l10n.artistRegisterAddAtLeastOneTrack);
       return;
     }
 
@@ -253,7 +253,7 @@ class _RegisterArtistWizardState extends ConsumerState<RegisterArtistWizard> {
         debugPrint('[RegisterArtist] error: ${result.exception}');
         setState(() {
           _isSubmitting = false;
-          _error = 'Registration failed. Please try again.';
+          _error = context.l10n.registrationFailed;
           _step = 1; // Go back to profile step
         });
         return;
@@ -263,7 +263,7 @@ class _RegisterArtistWizardState extends ConsumerState<RegisterArtistWizard> {
       if (data == null) {
         setState(() {
           _isSubmitting = false;
-          _error = 'Unexpected response.';
+          _error = context.l10n.unexpectedResponse;
         });
         return;
       }
@@ -317,17 +317,15 @@ class _RegisterArtistWizardState extends ConsumerState<RegisterArtistWizard> {
 
       final errors = <String>[];
       if (failedTracks.isNotEmpty) {
-        errors.add('Tracks: ${failedTracks.join(", ")}');
+        errors.add(context.l10n.failedTracks(failedTracks.join(', ')));
       }
       if (failedGenres.isNotEmpty) {
-        errors.add('Genres: ${failedGenres.join(", ")}');
+        errors.add(context.l10n.failedGenres(failedGenres.join(', ')));
       }
       if (errors.isNotEmpty) {
         setState(() {
           _isSubmitting = false;
-          _error =
-              'Some items failed: ${errors.join("; ")}. '
-              'You can update them later.';
+          _error = context.l10n.someItemsFailed(errors.join('; '));
           _step = 3; // Still proceed to Complete — artist is registered
         });
         return;
@@ -342,7 +340,7 @@ class _RegisterArtistWizardState extends ConsumerState<RegisterArtistWizard> {
       debugPrint('[RegisterArtist] error: $e');
       setState(() {
         _isSubmitting = false;
-        _error = 'Something went wrong. Please try again.';
+        _error = context.l10n.somethingWentWrong;
       });
     }
   }
@@ -531,12 +529,15 @@ class _StepProfile extends StatelessWidget {
                 helperText: context.l10n.usernameFormat,
               ),
               validator: (v) {
-                if (v == null || v.trim().isEmpty) return 'Required';
+                if (v == null || v.trim().isEmpty)
+                  return context.l10n.validatorRequired;
                 final trimmed = v.trim();
-                if (trimmed.length < 2) return 'At least 2 characters';
-                if (trimmed.length > 30) return 'Max 30 characters';
+                if (trimmed.length < 2)
+                  return context.l10n.validatorAtLeast2Chars;
+                if (trimmed.length > 30)
+                  return context.l10n.validatorMax30Chars;
                 if (!RegExp(r'^[a-zA-Z0-9_]+$').hasMatch(trimmed)) {
-                  return 'Letters, numbers, and underscores only';
+                  return context.l10n.validatorLettersNumbersUnderscoresOnly;
                 }
                 return null;
               },
@@ -551,8 +552,10 @@ class _StepProfile extends StatelessWidget {
                 border: const OutlineInputBorder(),
               ),
               validator: (v) {
-                if (v == null || v.trim().isEmpty) return 'Required';
-                if (v.trim().length > 50) return 'Max 50 characters';
+                if (v == null || v.trim().isEmpty)
+                  return context.l10n.validatorRequired;
+                if (v.trim().length > 50)
+                  return context.l10n.validatorMax50Chars;
                 return null;
               },
             ),
@@ -591,9 +594,9 @@ class _StepProfile extends StatelessWidget {
               validator: (v) {
                 if (v == null || v.trim().isEmpty) return null; // Optional
                 final year = int.tryParse(v.trim());
-                if (year == null) return 'Enter a valid year';
+                if (year == null) return context.l10n.validatorEnterValidYear;
                 if (year < 1900 || year > DateTime.now().year) {
-                  return 'Must be between 1900 and ${DateTime.now().year}';
+                  return context.l10n.validatorYearRange(DateTime.now().year);
                 }
                 return null;
               },

--- a/frontend/lib/screens/timeline/public_timeline_screen.dart
+++ b/frontend/lib/screens/timeline/public_timeline_screen.dart
@@ -20,6 +20,7 @@ import '../../theme/gleisner_assets.dart';
 import '../../theme/gleisner_tokens.dart';
 import '../../widgets/common/artist_not_found_view.dart';
 import '../../l10n/l10n.dart';
+import '../../utils/month_names.dart';
 
 class PublicTimelineScreen extends ConsumerStatefulWidget {
   final String username;
@@ -605,7 +606,7 @@ class _DateLabel extends StatelessWidget {
                 ),
               ),
             Text(
-              '${_shortMonth(day.date.month)} ${day.date.day}',
+              '${monthShort(context, day.date.month)} ${day.date.day}',
               style: TextStyle(
                 color: dayColor,
                 fontSize: fontSizeSm,
@@ -652,7 +653,7 @@ class _DateLabel extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
           Text(
-            _shortMonth(day.date.month),
+            monthShort(context, day.date.month),
             style: TextStyle(
               color: monthColor,
               fontSize: 9,
@@ -682,23 +683,6 @@ class _DateLabel extends StatelessWidget {
     );
   }
 }
-
-const _months = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-];
-
-String _shortMonth(int month) => _months[month - 1];
 
 class _TuneInButton extends StatelessWidget {
   final bool isTunedIn;

--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -13,6 +13,7 @@ import '../../providers/tune_in_provider.dart';
 import '../../utils/constellation_layout.dart';
 import '../../widgets/timeline/avatar_rail.dart';
 import '../../l10n/l10n.dart';
+import '../../utils/month_names.dart';
 import '../../widgets/timeline/constellation_painter.dart';
 import '../../widgets/timeline/milestone_detail_sheet.dart';
 import '../../widgets/timeline/milestone_node_card.dart';
@@ -629,8 +630,18 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                                 Expanded(
                                   child: Text(
                                     constellationName != null
-                                        ? context.l10n.constellationNamedPostCount(constellationName, timeline.constellationPostIds!.length)
-                                        : context.l10n.constellationPostCount(timeline.constellationPostIds!.length),
+                                        ? context.l10n
+                                              .constellationNamedPostCount(
+                                                constellationName,
+                                                timeline
+                                                    .constellationPostIds!
+                                                    .length,
+                                              )
+                                        : context.l10n.constellationPostCount(
+                                            timeline
+                                                .constellationPostIds!
+                                                .length,
+                                          ),
                                     style: const TextStyle(
                                       color: colorTextSecondary,
                                       fontSize: fontSizeSm,
@@ -1130,7 +1141,7 @@ class _DateLabel extends StatelessWidget {
                 ),
               ),
             Text(
-              '${_shortMonth(day.date.month)} ${day.date.day}',
+              '${monthShort(context, day.date.month)} ${day.date.day}',
               style: TextStyle(
                 color: dayColor,
                 fontSize: fontSizeSm,
@@ -1177,7 +1188,7 @@ class _DateLabel extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
           Text(
-            _shortMonth(day.date.month),
+            monthShort(context, day.date.month),
             style: TextStyle(
               color: monthColor,
               fontSize: 9,
@@ -1207,23 +1218,6 @@ class _DateLabel extends StatelessWidget {
     );
   }
 }
-
-const _months = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-];
-
-String _shortMonth(int month) => _months[month - 1];
 
 class _TrackSelector extends StatelessWidget {
   final List<Track> tracks;

--- a/frontend/lib/screens/unassigned_posts/unassigned_posts_screen.dart
+++ b/frontend/lib/screens/unassigned_posts/unassigned_posts_screen.dart
@@ -8,6 +8,7 @@ import '../../theme/gleisner_tokens.dart';
 import '../../widgets/timeline/post_detail_sheet.dart';
 import '../edit_post/edit_post_screen.dart';
 import '../../l10n/l10n.dart';
+import '../../utils/month_names.dart';
 
 class UnassignedPostsScreen extends ConsumerWidget {
   final List<Track> tracks;
@@ -148,7 +149,7 @@ class _PostTile extends StatelessWidget {
                   ),
                   const SizedBox(height: spaceXxs),
                   Text(
-                    _formatDate(post.createdAt),
+                    _formatDate(context, post.createdAt),
                     style: const TextStyle(
                       color: colorTextMuted,
                       fontSize: fontSizeXs,
@@ -248,21 +249,7 @@ class _PostTile extends StatelessWidget {
     };
   }
 
-  static String _formatDate(DateTime date) {
-    const months = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    return '${months[date.month - 1]} ${date.day}, ${date.year}';
+  static String _formatDate(BuildContext context, DateTime date) {
+    return '${monthShort(context, date.month)} ${date.day}, ${date.year}';
   }
 }

--- a/frontend/lib/utils/month_names.dart
+++ b/frontend/lib/utils/month_names.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+
+import '../l10n/app_localizations.dart';
+
+/// Returns the abbreviated month name (e.g. "Jan" / "1月") for [month] (1–12).
+///
+/// Uses [intl.DateFormat('MMM')] with the current locale so that Japanese
+/// returns "1月"–"12月" and English returns "Jan"–"Dec".
+String monthShort(BuildContext context, int month) {
+  final locale = Localizations.localeOf(context).languageCode;
+  final date = DateTime(2000, month);
+  return DateFormat('MMM', locale).format(date);
+}
+
+/// Returns the full month name (e.g. "January" / "1月") for [month] (1–12)
+/// from the ARB translations.
+String monthFull(BuildContext context, int month) {
+  final l10n = AppLocalizations.of(context)!;
+  switch (month) {
+    case 1:
+      return l10n.monthJanuary;
+    case 2:
+      return l10n.monthFebruary;
+    case 3:
+      return l10n.monthMarch;
+    case 4:
+      return l10n.monthApril;
+    case 5:
+      return l10n.monthMay;
+    case 6:
+      return l10n.monthJune;
+    case 7:
+      return l10n.monthJuly;
+    case 8:
+      return l10n.monthAugust;
+    case 9:
+      return l10n.monthSeptember;
+    case 10:
+      return l10n.monthOctober;
+    case 11:
+      return l10n.monthNovember;
+    case 12:
+      return l10n.monthDecember;
+    default:
+      return '';
+  }
+}

--- a/frontend/lib/widgets/common/app_footer.dart
+++ b/frontend/lib/widgets/common/app_footer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../l10n/l10n.dart';
 import '../../theme/gleisner_tokens.dart';
 
 /// Minimal footer for public-facing pages (login, signup, public timeline).
@@ -23,9 +24,9 @@ class AppFooter extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Text(
-            'Gleisner',
-            style: TextStyle(
+          Text(
+            context.l10n.appTitle,
+            style: const TextStyle(
               color: colorTextMuted,
               fontSize: fontSizeXs,
               fontWeight: weightMedium,
@@ -34,8 +35,8 @@ class AppFooter extends StatelessWidget {
           const SizedBox(height: spaceXxs),
           GestureDetector(
             onTap: onAboutTap,
-            child: const Text(
-              'About / External Services',
+            child: Text(
+              context.l10n.aboutExternal,
               style: TextStyle(
                 color: colorInteractive,
                 fontSize: fontSizeXs,

--- a/frontend/lib/widgets/common/connection_type_picker.dart
+++ b/frontend/lib/widgets/common/connection_type_picker.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
 
+import '../../l10n/l10n.dart';
 import '../../models/post.dart';
 import '../../theme/gleisner_tokens.dart';
 
 /// Metadata for each [ConnectionType].
 extension ConnectionTypeMeta on ConnectionType {
-  String get label => switch (this) {
-    ConnectionType.reference => 'Reference',
-    ConnectionType.evolution => 'Evolution',
-    ConnectionType.remix => 'Remix',
-    ConnectionType.reply => 'Reply',
+  String label(BuildContext context) => switch (this) {
+    ConnectionType.reference => context.l10n.connectionTypeReference,
+    ConnectionType.evolution => context.l10n.connectionTypeEvolution,
+    ConnectionType.remix => context.l10n.connectionTypeRemix,
+    ConnectionType.reply => context.l10n.connectionTypeReply,
   };
 
   IconData get icon => switch (this) {
@@ -19,11 +20,11 @@ extension ConnectionTypeMeta on ConnectionType {
     ConnectionType.reply => Icons.reply,
   };
 
-  String get description => switch (this) {
-    ConnectionType.reference => 'Inspired by or related to',
-    ConnectionType.evolution => 'Next version of this piece',
-    ConnectionType.remix => 'A remix or reinterpretation',
-    ConnectionType.reply => 'A response to this post',
+  String description(BuildContext context) => switch (this) {
+    ConnectionType.reference => context.l10n.connectionTypeReferenceDesc,
+    ConnectionType.evolution => context.l10n.connectionTypeEvolutionDesc,
+    ConnectionType.remix => context.l10n.connectionTypeRemixDesc,
+    ConnectionType.reply => context.l10n.connectionTypeReplyDesc,
   };
 }
 
@@ -63,9 +64,9 @@ class _ConnectionTypePicker extends StatelessWidget {
             ),
           ),
           const SizedBox(height: spaceLg),
-          const Text(
-            'Connection Type',
-            style: TextStyle(
+          Text(
+            context.l10n.connectionType,
+            style: const TextStyle(
               color: colorTextPrimary,
               fontSize: fontSizeLg,
               fontWeight: weightBold,
@@ -94,7 +95,7 @@ class _ConnectionTypePicker extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              type.label,
+                              type.label(context),
                               style: const TextStyle(
                                 color: colorTextPrimary,
                                 fontSize: fontSizeMd,
@@ -102,7 +103,7 @@ class _ConnectionTypePicker extends StatelessWidget {
                               ),
                             ),
                             Text(
-                              type.description,
+                              type.description(context),
                               style: const TextStyle(
                                 color: colorTextMuted,
                                 fontSize: fontSizeXs,

--- a/frontend/lib/widgets/common/related_post_picker.dart
+++ b/frontend/lib/widgets/common/related_post_picker.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../l10n/l10n.dart';
 import '../../models/post.dart';
 import '../../models/track.dart' show parseHexColor;
 
@@ -82,7 +83,7 @@ class _RelatedPostPickerState extends State<RelatedPostPicker> {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: Text(
-                'Select related post',
+                context.l10n.selectRelatedPost,
                 style: theme.textTheme.titleMedium,
               ),
             ),
@@ -93,7 +94,7 @@ class _RelatedPostPickerState extends State<RelatedPostPicker> {
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: TextField(
                 decoration: InputDecoration(
-                  hintText: 'Search posts...',
+                  hintText: context.l10n.searchPosts,
                   prefixIcon: const Icon(Icons.search, size: 20),
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
@@ -118,7 +119,7 @@ class _RelatedPostPickerState extends State<RelatedPostPicker> {
                   padding: const EdgeInsets.symmetric(horizontal: 16),
                   children: [
                     _TrackFilterChip(
-                      label: 'All',
+                      label: context.l10n.all,
                       color: null,
                       isSelected: _filterTrackId == null,
                       onTap: () => setState(() => _filterTrackId = null),
@@ -128,7 +129,7 @@ class _RelatedPostPickerState extends State<RelatedPostPicker> {
                         (p) => p.trackId == tid,
                       );
                       return _TrackFilterChip(
-                        label: post.trackName ?? 'Unknown',
+                        label: post.trackName ?? context.l10n.unknown,
                         color: post.trackColor,
                         isSelected: _filterTrackId == tid,
                         onTap: () => setState(() => _filterTrackId = tid),
@@ -144,7 +145,7 @@ class _RelatedPostPickerState extends State<RelatedPostPicker> {
               child: filtered.isEmpty
                   ? Center(
                       child: Text(
-                        'No posts found',
+                        context.l10n.noPostsFound,
                         style: theme.textTheme.bodyMedium?.copyWith(
                           color: theme.colorScheme.onSurface.withAlpha(128),
                         ),

--- a/frontend/lib/widgets/timeline/avatar_rail.dart
+++ b/frontend/lib/widgets/timeline/avatar_rail.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../l10n/l10n.dart';
 import '../../providers/tune_in_provider.dart';
 import '../../theme/gleisner_tokens.dart';
 import '../../utils/deterministic_rng.dart';
@@ -54,7 +55,7 @@ class AvatarRail extends StatelessWidget {
             return _AvatarItem(
               username: selfArtistUsername!,
               avatarUrl: selfAvatarUrl,
-              displayName: 'You',
+              displayName: context.l10n.you,
               isSelected: isSelected,
               isSelf: true,
               isPrivate: selfIsPrivate,
@@ -187,7 +188,7 @@ class _AvatarItem extends StatelessWidget {
               ),
               const SizedBox(height: spaceXxs),
               Text(
-                isSelf ? 'You' : _truncate(displayName, 6),
+                isSelf ? context.l10n.you : _truncate(displayName, 6),
                 textAlign: TextAlign.center,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,

--- a/frontend/lib/widgets/timeline/milestone_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/milestone_detail_sheet.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../l10n/l10n.dart';
 import '../../models/artist.dart';
 import '../../models/post.dart' show ReactionCount;
 import '../../providers/timeline_provider.dart';
 import '../../theme/gleisner_tokens.dart';
 import '../../utils/milestone_category.dart';
+import '../../utils/month_names.dart';
 
 const _reactionPresets = ['🔥', '❤️', '👏', '✨', '😍', '🎵', '💪', '🎸'];
 
@@ -128,9 +130,9 @@ class _MilestoneDetailSheet extends ConsumerWidget {
                         ),
                       ),
                       const Spacer(),
-                      const Text(
-                        'Milestone',
-                        style: TextStyle(
+                      Text(
+                        context.l10n.milestone,
+                        style: const TextStyle(
                           color: colorTextMuted,
                           fontSize: fontSizeSm,
                         ),
@@ -150,7 +152,7 @@ class _MilestoneDetailSheet extends ConsumerWidget {
                   const SizedBox(height: spaceSm),
                   // Date
                   Text(
-                    _formatDate(milestone.date),
+                    _formatDate(context, milestone.date),
                     style: const TextStyle(
                       color: colorTextMuted,
                       fontSize: fontSizeMd,
@@ -240,24 +242,10 @@ class _MilestoneDetailSheet extends ConsumerWidget {
     );
   }
 
-  static String _formatDate(String dateStr) {
+  static String _formatDate(BuildContext context, String dateStr) {
     try {
       final date = DateTime.parse(dateStr);
-      const months = [
-        'January',
-        'February',
-        'March',
-        'April',
-        'May',
-        'June',
-        'July',
-        'August',
-        'September',
-        'October',
-        'November',
-        'December',
-      ];
-      return '${months[date.month - 1]} ${date.day}, ${date.year}';
+      return '${monthFull(context, date.month)} ${date.day}, ${date.year}';
     } catch (_) {
       return dateStr;
     }

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -2,6 +2,7 @@
 flutter = "latest"
 
 [tasks]
+gen_l10n = { run = "flutter gen-l10n", depends = "pub_get" }
 lint = { run = ["dart format lib test", "flutter analyze", ], depends = "pub_get" } # dart fmt にpub_getが必要
 lint_check = { run = ["flutter analyze", "dart format --set-exit-if-changed lib test"], depends = "pub_get" } # 書き換えなしチェック（Stop Hook 用）
 run_web = { run = "flutter run" }

--- a/frontend/test/models/post_copyWith_test.dart
+++ b/frontend/test/models/post_copyWith_test.dart
@@ -5,7 +5,7 @@ Post _makeTestPost() {
   final now = DateTime(2026, 1, 1);
   return Post(
     id: 'p1',
-    mediaType: MediaType.text,
+    mediaType: MediaType.thought,
     title: 'Original Title',
     body: 'Original Body',
     mediaUrl: 'https://example.com',

--- a/frontend/test/models/post_test.dart
+++ b/frontend/test/models/post_test.dart
@@ -5,7 +5,7 @@ import 'package:gleisner_web/models/post.dart';
 void main() {
   final validJson = {
     'id': 'post-1',
-    'mediaType': 'text',
+    'mediaType': 'article',
     'title': 'Hello',
     'body': 'World',
     'mediaUrl': null,
@@ -28,7 +28,7 @@ void main() {
       final post = Post.fromJson(validJson);
 
       expect(post.id, 'post-1');
-      expect(post.mediaType, MediaType.text);
+      expect(post.mediaType, MediaType.article);
       expect(post.title, 'Hello');
       expect(post.body, 'World');
       expect(post.importance, 0.5);
@@ -67,10 +67,10 @@ void main() {
       }
     });
 
-    test('falls back to text on unknown mediaType', () {
+    test('falls back to article on unknown mediaType', () {
       final json = {...validJson, 'mediaType': 'unknown'};
       final post = Post.fromJson(json);
-      expect(post.mediaType, MediaType.text);
+      expect(post.mediaType, MediaType.article);
     });
 
     test('parses duration', () {

--- a/frontend/test/providers/auth_provider_test.dart
+++ b/frontend/test/providers/auth_provider_test.dart
@@ -275,6 +275,7 @@ void main() {
             email: 'test@test.com',
             password: 'password123',
             username: 'testuser',
+            birthYearMonth: '2000-01',
             inviteCode: 'abc123',
           );
 
@@ -288,6 +289,7 @@ void main() {
             email: 'test@test.com',
             password: 'password123',
             username: 'testuser',
+            birthYearMonth: '2000-01',
           );
 
       expect(link.lastVariables?.containsKey('inviteCode'), isFalse);

--- a/frontend/test/providers/create_post_provider_test.dart
+++ b/frontend/test/providers/create_post_provider_test.dart
@@ -119,11 +119,11 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
 
       final state = container.read(createPostProvider);
       expect(state.step, 2);
-      expect(state.selectedMediaType, MediaType.text);
+      expect(state.selectedMediaType, MediaType.thought);
     });
 
     test('goBack decrements step', () {
@@ -132,7 +132,7 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
       expect(container.read(createPostProvider).step, 2);
 
       notifier.goBack();
@@ -151,7 +151,7 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
       notifier.setImportance(0.8);
       notifier.reset();
 
@@ -169,7 +169,7 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
 
       // Capture isSubmitting during the mutation
       final states = <bool>[];
@@ -206,7 +206,7 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
 
       final result = await notifier.submit(
         title: 'Hello',
@@ -228,7 +228,7 @@ void main() {
 
       final notifier = container.read(createPostProvider.notifier);
       notifier.selectTrack(_testTrack);
-      notifier.selectMediaType(MediaType.text);
+      notifier.selectMediaType(MediaType.thought);
 
       final result = await notifier.submit(
         title: 'Hello',
@@ -258,7 +258,7 @@ void main() {
     group('addConnection / removeConnection', () {
       Post _fakePost(String id) => Post(
         id: id,
-        mediaType: MediaType.text,
+        mediaType: MediaType.article,
         title: 'Post $id',
         importance: 0.5,
         createdAt: DateTime(2026),

--- a/frontend/test/utils/constellation_graph_test.dart
+++ b/frontend/test/utils/constellation_graph_test.dart
@@ -9,7 +9,7 @@ Post _makePost({
 }) {
   return Post(
     id: id,
-    mediaType: MediaType.text,
+    mediaType: MediaType.thought,
     title: 'Post $id',
     importance: 0.5,
     createdAt: DateTime(2026, 1, 1),

--- a/frontend/test/utils/constellation_layout_test.dart
+++ b/frontend/test/utils/constellation_layout_test.dart
@@ -8,7 +8,7 @@ Post _makePost({
   required String id,
   required DateTime createdAt,
   double importance = 0.5,
-  MediaType mediaType = MediaType.text,
+  MediaType mediaType = MediaType.thought,
   String? trackId,
   String? trackName,
   String? trackColor,
@@ -465,7 +465,7 @@ void main() {
           id: 'text',
           createdAt: now.subtract(const Duration(hours: 1)),
           importance: 0.5,
-          mediaType: MediaType.text,
+          mediaType: MediaType.thought,
         ),
       ];
       final result = ConstellationLayout.compute(

--- a/frontend/test/widgets/app_footer_test.dart
+++ b/frontend/test/widgets/app_footer_test.dart
@@ -1,13 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:gleisner_web/l10n/app_localizations.dart';
 import 'package:gleisner_web/widgets/common/app_footer.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+  locale: const Locale('en'),
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(body: child),
+);
 
 void main() {
   group('AppFooter', () {
     testWidgets('renders Gleisner text and About link', (tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(home: Scaffold(body: AppFooter())),
-      );
+      await tester.pumpWidget(_wrap(const AppFooter()));
+      await tester.pumpAndSettle();
 
       expect(find.text('Gleisner'), findsOneWidget);
       expect(find.text('About / External Services'), findsOneWidget);
@@ -16,19 +23,17 @@ void main() {
     testWidgets('fires onAboutTap when link is tapped', (tester) async {
       var tapped = false;
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(body: AppFooter(onAboutTap: () => tapped = true)),
-        ),
+        _wrap(AppFooter(onAboutTap: () => tapped = true)),
       );
+      await tester.pumpAndSettle();
 
       await tester.tap(find.text('About / External Services'));
       expect(tapped, isTrue);
     });
 
     testWidgets('renders safely when onAboutTap is null', (tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(home: Scaffold(body: AppFooter())),
-      );
+      await tester.pumpWidget(_wrap(const AppFooter()));
+      await tester.pumpAndSettle();
 
       // Tapping should not crash
       await tester.tap(find.text('About / External Services'));


### PR DESCRIPTION
## Summary

The umbrella's session-end hook flagged ~130 hardcoded English literal candidates across `lib/screens/` and `lib/widgets/`. This PR replaces them with ARB-backed `context.l10n.*` calls or routes them through a shared utility, dropping the count to **11** — all of which are template-track preset names that need a product decision before localization (see "Out of scope").

> **Stacked on #259.** That PR refreshes the `MediaType.text` and `birthYearMonth` references in `test/`. Without it the whole `test/` tree fails to compile, and `flutter test --platform chrome` can't run any of the suites we want to verify here. Merge #259 first; this PR will rebase clean.

## Changes

| Area | What changed |
|---|---|
| ARB | 56 new keys in `app_en.arb` + `app_ja.arb`, each with `@key` description (per the project's ARB trap rules). Plurals use ICU syntax; placeholders use `"type": "int"` / `"String"` only. |
| Generated | Re-ran `flutter gen-l10n`; `app_localizations*.dart` is committed. |
| `lib/utils/month_names.dart` (new) | `monthShort(context, n)` / `monthFull(context, n)` consolidate four inline `['Jan'…'Dec']` / `['January'…'December']` arrays previously duplicated in unassigned_posts_screen, profile_screen, public_timeline_screen, timeline_screen, avatar_rail, and milestone_detail_sheet. |
| `create_post_screen` | MediaType label switch is now exhaustive (thought / article / image / video / audio / link); pulls labels from `context.l10n.mediaTypeXxx`. The wildcard fallback the project rules forbid is removed. |
| Profile / artist editing | `register_artist_wizard`, `register_artist_sheet`, `edit_profile_sheet`, `create_child_sheet`, `edit_milestones_sheet`, `edit_artist_*_sheet`, `related_post_picker` route error messages and validators through ARB. Generic fallbacks land on `somethingWentWrong`; specific cases get their own keys (`registrationFailed`, `unexpectedResponse`, `failedTracks`, …). |
| `connection_type_picker` | `label` / `description` fields are now `context`-aware methods so static lookup tables can resolve through `AppLocalizations`. |
| `mise.toml` | Added a `gen_l10n` task so future runs don't have to invoke `flutter gen-l10n` directly. |
| `test/widgets/app_footer_test.dart` | Wraps `AppFooter` in a `MaterialApp` with `AppLocalizations.localizationsDelegates` and explicit `Locale('en')` so existing English assertions (`'About / External Services'`) match regardless of host locale. The `'Gleisner'` literal in `app_footer.dart` was reverted to a non-localized string — it's a brand name. |

## Out of scope

- **Template track presets** (`_TemplateTrack('Play', …)`, `'Compose'`, `'Life'`, `'Works'`, `'Process'`, `'Thoughts'`, `'Writing'`, `'Notes'`, `'Films'`, `'Stills'`) in `register_artist_wizard.dart`. These 11 remaining hits are starter-track names users see during onboarding. Whether and how to localize them (e.g. `Play` → `演奏` vs. keeping English-only) is a product decision; flagging for a follow-up issue.
- `pubspec.lock` changes from `flutter pub get` were excluded.

## Test plan

- [x] Stop Hook grep: 130 → **11** hits remaining (all template presets, listed above)
- [x] `mise run -C frontend lint_check`: 0 new errors introduced (8 existing setUpAll/tearDownAll failures on `--platform chrome` are unrelated `dart:io` issues)
- [x] `flutter test --platform chrome`: 253 passed, 8 errored (the same 8 pre-existing `setUpAll`/`tearDownAll` failures present on main; nothing new broken)
- [x] `flutter test --platform chrome test/widgets/app_footer_test.dart`: all 3 tests pass with the test refactor
- [ ] Reviewer eyeballs the JA translations for tone (UI labels are direct, error messages match existing fallback patterns, marketing/explanatory copy was kept literal where it occurs)
- [ ] Reviewer decides whether the template track preset names should be localized in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)