### PR TITLE
chore(frontend): bootstrap integration_test smoke test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,14 @@ mise tasks             # 利用可能なタスク一覧を表示
 | `run_web` | `flutter run` | — |
 | `build` | `flutter build web` | `clean` |
 | `test` | `flutter test` | — |
+| `test_integration` | `flutter test test/integration --platform chrome`（E2E smoke test） | `pub_get` |
 | `clean` | `flutter clean` | — |
+
+**テスト層の使い分け**:
+- `frontend/test/` 直下 — unit / widget test（ロジック・個別ウィジェット）。`mise run test`
+- `frontend/test/integration/` — アプリ全体の起動と主要フロー（splash → home 等）の E2E smoke test。`mise run test_integration`（Chrome 必須）
+  - `IntegrationTestWidgetsFlutterBinding` を使う実装にしてあるので、将来 iOS/Android ターゲット追加時に `frontend/integration_test/` へ物理移動するだけで Flutter 公式の integration test runner に乗せ替えできる
+  - Web のみのうちは `flutter test` の integration test ランナーが web デバイスを未サポート（flutter/flutter#66264）のため、widget test 扱いで `--platform chrome` 経由で実行する
 
 ### ⚠ `db:push` の注意事項
 

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -9,4 +9,5 @@ run_web = { run = "flutter run" }
 build = { run = "flutter build web", depends = "clean" }
 pub_get = { run = "flutter pub get" }
 test = { run = "flutter test" }
+test_integration = { run = "flutter test test/integration --platform chrome", depends = "pub_get" } # E2E smoke test（Web only のため widget test 扱い、Chrome 必須）
 clean = { run = "flutter clean" }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -254,6 +254,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_hooks:
     dependency: transitive
     description:
@@ -421,6 +426,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -629,6 +639,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -653,6 +668,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -713,18 +736,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -885,6 +908,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -1066,6 +1097,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1078,26 +1117,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:
@@ -1290,6 +1329,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -50,6 +50,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   hive_ce: ^2.19.3
 
   # The "flutter_lints" package below contains a set of recommended lints to

--- a/frontend/test/integration/app_smoke_test.dart
+++ b/frontend/test/integration/app_smoke_test.dart
@@ -1,0 +1,32 @@
+// Phase 0 smoke test: verifies the full app boot path (Hive cache → ProviderScope
+// → GraphQLProvider → MaterialApp.router → splash screen) succeeds. This goes
+// beyond `test/widget_test.dart` (which only asserts the splash text) by
+// confirming router and theme bootstrap also complete without throwing.
+//
+// Web-only for now: lives in `test/integration/` because Flutter's integration
+// test runner does not support web devices (flutter/flutter#66264). When iOS /
+// Android targets are added (ADR 015), move this file to `integration_test/`
+// to lift it onto the official integration test harness with no code change.
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:gleisner_web/app.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('App boots through MaterialApp.router into splash screen', (
+    tester,
+  ) async {
+    await initHiveForFlutter();
+
+    await tester.pumpWidget(const ProviderScope(child: GleisnerApp()));
+    await tester.pump();
+
+    expect(find.byType(MaterialApp), findsOneWidget);
+    expect(find.text('Gleisner'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

- Adds the first end-to-end smoke test (`test/integration/app_smoke_test.dart`) covering the full boot path: Hive cache → `ProviderScope` → `GraphQLProvider` → `MaterialApp.router` → splash screen. Catches regressions that pure unit/widget tests miss.
- Sets up the harness so future flows (login, timeline render, etc.) can plug in without re-paving infrastructure.
- Adds `mise run test_integration` (`flutter test test/integration --platform chrome`) so the suite is one command away locally.

## Web-only caveat

Flutter's integration test runner does not yet support web devices ([flutter/flutter#66264](https://github.com/flutter/flutter/issues/66264)). The test therefore lives under `test/integration/` (not the official `integration_test/`) and runs as a widget test via `--platform chrome`. It uses `IntegrationTestWidgetsFlutterBinding`, so when iOS/Android targets land (ADR 015), moving the file to `integration_test/` lifts it onto the official harness with no code change.

## pubspec.lock churn

Pulling in `integration_test: sdk: flutter` forces the SDK-bundled package's pinned versions:

- Downgrades: `test`, `test_api`, `test_core`, `matcher`, `material_color_utilities`, `characters`
- New transitive: `flutter_driver`, `fuchsia_remote_debug_protocol`, `sync_http`, `webdriver`, `process`, `js`

All confined to `dev_dependencies`; production `flutter build web` unaffected.

## Out of scope (pre-existing, surfaced during verification)

`test/providers/tune_in_provider_test.dart` fails 8 cases under `flutter test --platform chrome` because it `import 'dart:io'` (and `Hive.init` on `Directory.systemTemp`). Confirmed identical on `main` (`git show main:frontend/test/providers/tune_in_provider_test.dart | head -1`). Not addressed here — track separately (e.g., switch to `package:universal_io` or VM-only tag).

## Verification

- `mise run test_integration` → All tests passed
- `flutter analyze test/integration/` → No issues found
- `dart format --set-exit-if-changed test/integration/` → no changes
- pre-existing analyzer warnings on `lib/` and other `test/` files are unchanged

## Test plan

- [ ] `cd frontend && mise run pub_get`
- [ ] `cd frontend && mise run test_integration` — smoke test passes
- [ ] `cd frontend && flutter test --platform chrome test/widget_test.dart` — existing widget smoke still passes
- [ ] PR-prep `cd frontend && flutter test --platform chrome` — passes modulo the pre-existing `tune_in_provider_test.dart` failures noted above
- [ ] `cd frontend && dart analyze lib/ && dart format --set-exit-if-changed lib test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)