### PR TITLE
fix(frontend/test): unbreak provider tests on --platform chrome

### DIFF
--- a/frontend/test/providers/auth_provider_test.dart
+++ b/frontend/test/providers/auth_provider_test.dart
@@ -1,10 +1,7 @@
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:hive_ce/hive.dart';
 
 import 'package:gleisner_web/graphql/client.dart';
 import 'package:gleisner_web/providers/auth_provider.dart';
@@ -106,16 +103,6 @@ ProviderContainer _createContainer({
 
 void main() {
   late MockSecureStorage mockStorage;
-  late Directory tempDir;
-
-  setUpAll(() {
-    tempDir = Directory.systemTemp.createTempSync('gleisner_test_');
-    Hive.init(tempDir.path);
-  });
-
-  tearDownAll(() {
-    tempDir.deleteSync(recursive: true);
-  });
 
   setUp(() {
     mockStorage = MockSecureStorage();
@@ -205,7 +192,10 @@ void main() {
 
       final container = _createContainer(
         client: _clientWith(
-          exception: const SocketException('Connection refused'),
+          // Use a plain Exception (not dart:io's SocketException) so this test
+          // compiles on `--platform chrome`. AuthNotifier treats any
+          // non-GraphQL exception as a network error.
+          exception: Exception('Connection refused'),
         ),
         storage: mockStorage,
       );

--- a/frontend/test/providers/create_post_provider_test.dart
+++ b/frontend/test/providers/create_post_provider_test.dart
@@ -1,9 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:hive_ce/hive.dart';
 
 import 'package:gleisner_web/graphql/client.dart';
 import 'package:gleisner_web/models/post.dart';
@@ -77,17 +74,6 @@ const _postResponse = {
 };
 
 void main() {
-  late Directory tempDir;
-
-  setUpAll(() {
-    tempDir = Directory.systemTemp.createTempSync('gleisner_create_post_test_');
-    Hive.init(tempDir.path);
-  });
-
-  tearDownAll(() {
-    tempDir.deleteSync(recursive: true);
-  });
-
   group('CreatePostNotifier', () {
     test('initial state', () {
       final container = _createContainer(client: _clientWith());

--- a/frontend/test/providers/timeline_provider_test.dart
+++ b/frontend/test/providers/timeline_provider_test.dart
@@ -1,9 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:hive_ce/hive.dart';
 
 import 'package:gleisner_web/graphql/client.dart';
 import 'package:gleisner_web/models/artist.dart';
@@ -42,17 +39,6 @@ ProviderContainer _createContainer({required GraphQLClient client}) {
 }
 
 void main() {
-  late Directory tempDir;
-
-  setUpAll(() {
-    tempDir = Directory.systemTemp.createTempSync('gleisner_timeline_test_');
-    Hive.init(tempDir.path);
-  });
-
-  tearDownAll(() {
-    tempDir.deleteSync(recursive: true);
-  });
-
   group('TimelineNotifier', () {
     test('initial state', () {
       final container = _createContainer(client: _clientWith());
@@ -99,7 +85,10 @@ void main() {
     test('loadArtist sets error on network exception', () async {
       final container = _createContainer(
         client: _clientWith(
-          exception: const SocketException('Connection refused'),
+          // Use a plain Exception (not dart:io's SocketException) so this test
+          // compiles on `--platform chrome`. The error path is exception-type
+          // agnostic.
+          exception: Exception('Connection refused'),
         ),
       );
       addTearDown(container.dispose);

--- a/frontend/test/providers/tune_in_provider_test.dart
+++ b/frontend/test/providers/tune_in_provider_test.dart
@@ -1,9 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:hive_ce/hive.dart';
 
 import 'package:gleisner_web/graphql/client.dart';
 import 'package:gleisner_web/providers/tune_in_provider.dart';
@@ -84,21 +81,13 @@ Map<String, dynamic> _artistData(String id, String username, String name) {
     'displayName': name,
     'avatarUrl': null,
     'tunedInCount': 1,
+    // myTuneInsQuery selects profileVisibility — must be present in mock data
+    // or graphql_flutter cache normalization throws PartialDataException.
+    'profileVisibility': 'public',
   };
 }
 
 void main() {
-  late Directory tempDir;
-
-  setUpAll(() {
-    tempDir = Directory.systemTemp.createTempSync('gleisner_tunein_test_');
-    Hive.init(tempDir.path);
-  });
-
-  tearDownAll(() {
-    tempDir.deleteSync(recursive: true);
-  });
-
   group('TuneInNotifier', () {
     group('toggleTuneIn', () {
       test('adds artist to list on Tune In', () async {


### PR DESCRIPTION
## Summary

Fixes 4 provider test files that were silently broken on `flutter test --platform chrome` (the project's mandatory PR-prep target). The full test suite now runs **282 tests, all passing** — previously several were masked behind a `LateInitializationError` cascade.

## Root cause

Each test imported `dart:io` and initialized Hive against `Directory.systemTemp.createTempSync(...)` in `setUpAll`:

```dart
late Directory tempDir;
setUpAll(() {
  tempDir = Directory.systemTemp.createTempSync('gleisner_test_');
  Hive.init(tempDir.path);
});
```

On Web, `Directory.systemTemp.createTempSync` throws at runtime, leaving `late tempDir` uninitialized. The `tearDownAll` then tried `tempDir.deleteSync(...)` and surfaced `LateInitializationError`, masking the whole file's results.

The Hive setup was dead weight to begin with — every test's mock client uses `GraphQLCache(store: InMemoryStore())` with `FetchPolicy.noCache`, so no test reached Hive.

## Changes

### Removed dead Hive setup (4 files)

- `dart:io` import dropped
- `package:hive_ce/hive.dart` import dropped
- `setUpAll` / `tearDownAll` blocks dropped
- `late Directory tempDir;` dropped

### Replaced `SocketException` with `Exception` (2 places)

`auth_provider_test.dart` and `timeline_provider_test.dart` used `SocketException('Connection refused')` to simulate a network failure. `SocketException` is in `dart:io` and isn't constructible on Web. Replaced with `Exception('Connection refused')`.

`AuthNotifier` / `TimelineNotifier` error paths are exception-type-agnostic — both categorize any non-GraphQL exception as "Network unavailable" — so the test's contract is preserved.

### Added missing field to mock fixture (1 place)

`tune_in_provider_test.dart`'s `_artistData` mock helper was missing `profileVisibility`, but `myTuneInsQuery` selects it. graphql_flutter's cache normalizer threw `PartialDataException` for the mismatched response, silently aborting `loadMyTuneIns` (the failure was hidden behind the `dart:io` issue until now). Added `'profileVisibility': 'public'` to the fixture.

## Production code

Untouched. Test-only fix.

## Out of scope (observed during review)

`toggleTuneInMutation` does not select `profileVisibility`, and `TunedInArtist.fromJson` defaults missing values to `'public'`. Tuning into a private artist could therefore briefly show them as public in local state until the next `loadMyTuneIns` reconciles. Pre-existing behavior, not introduced or affected by this PR — flag for separate consideration.

## Verification

- `flutter test --platform chrome test/providers/` → 74 tests passing
- `flutter test --platform chrome` (full suite) → 282 tests passing
- `flutter analyze` on edited files → no new warnings (the 2 pre-existing warnings on `create_post_provider_test.dart` shifted line numbers but predate this PR)
- `dart format --set-exit-if-changed` on edited files → clean

## Test plan

- [ ] `cd frontend && flutter test --platform chrome` — 282 tests pass
- [ ] `cd frontend && flutter test --platform chrome test/providers/auth_provider_test.dart` — passes
- [ ] `cd frontend && flutter test --platform chrome test/providers/create_post_provider_test.dart` — passes
- [ ] `cd frontend && flutter test --platform chrome test/providers/timeline_provider_test.dart` — passes
- [ ] `cd frontend && flutter test --platform chrome test/providers/tune_in_provider_test.dart` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)