### PR TITLE
fix(frontend/tune-in): include profileVisibility in toggleTuneIn mutation

### DIFF
--- a/frontend/lib/graphql/mutations/tune_in.dart
+++ b/frontend/lib/graphql/mutations/tune_in.dart
@@ -8,6 +8,7 @@ const toggleTuneInMutation = r'''
         displayName
         avatarUrl
         tunedInCount
+        profileVisibility
       }
     }
   }

--- a/frontend/test/providers/tune_in_provider_test.dart
+++ b/frontend/test/providers/tune_in_provider_test.dart
@@ -39,7 +39,12 @@ ProviderContainer _createContainer({required GraphQLClient client}) {
   );
 }
 
-Map<String, dynamic> _tuneInResponse(String id, String username, String name) {
+Map<String, dynamic> _tuneInResponse(
+  String id,
+  String username,
+  String name, {
+  String profileVisibility = 'public',
+}) {
   return {
     'toggleTuneIn': {
       'createdAt': '2026-01-01T00:00:00Z',
@@ -49,6 +54,7 @@ Map<String, dynamic> _tuneInResponse(String id, String username, String name) {
         'displayName': name,
         'avatarUrl': null,
         'tunedInCount': 1,
+        'profileVisibility': profileVisibility,
       },
     },
   };
@@ -106,6 +112,30 @@ void main() {
           container.read(tuneInProvider).tunedInArtists.first.artistUsername,
           'artist1',
         );
+      });
+
+      test('preserves profileVisibility on Tune In (private artist)', () async {
+        // Regression: toggleTuneInMutation must select profileVisibility so
+        // the local state reflects whether the tuned-in artist is private.
+        // Without this, TunedInArtist.fromJson silently defaults to 'public'
+        // and the avatar rail / `isPrivate` checks misclassify the artist
+        // until the next loadMyTuneIns reconciles.
+        final client = _clientWithResponses([
+          _tuneInResponse(
+            'a1',
+            'artist1',
+            'Artist One',
+            profileVisibility: 'private',
+          ),
+        ]);
+        final container = _createContainer(client: client);
+        addTearDown(container.dispose);
+
+        await container.read(tuneInProvider.notifier).toggleTuneIn('a1');
+
+        final artist = container.read(tuneInProvider).tunedInArtists.first;
+        expect(artist.profileVisibility, 'private');
+        expect(artist.isPrivate, isTrue);
       });
 
       test('removes artist from list on Tune Out', () async {


### PR DESCRIPTION
## Summary

Fixes a minor data-staleness bug discovered while reviewing PR #263: tuning into a **private** artist briefly mislabeled them as public in local state until the next `loadMyTuneIns`.

## Root cause

`toggleTuneInMutation` selected `id, artistUsername, displayName, avatarUrl, tunedInCount` — but **not** `profileVisibility`. After Tune In, the response was parsed by `TunedInArtist.fromJson`, whose fallback

```dart
profileVisibility: artist['profileVisibility'] as String? ?? 'public',
```

silently treated the new artist as public regardless of their real visibility.

## Effect

After Tune In on a private artist:
- avatar rail and any `isPrivate`-driven UI rendered them as public
- corrected on next `loadMyTuneIns`

Not security-critical (backend authorization isn't affected; this is local state display only), but a real UX inconsistency — and exactly the kind of silent wrong-default that's easy to miss in review.

## Fix

1. Add `profileVisibility` to the mutation selection. Backend `Artist` type already exposes the field (same field selected by `myTuneInsQuery`).
2. Parameterize the test fixture `_tuneInResponse` with `profileVisibility` (defaults to `'public'`) so the mock matches the new mutation contract.
3. Add a regression test: tuning into a private artist results in `profileVisibility == 'private'` and `isPrivate == true` in local state.

## Verification

- `flutter test --platform chrome test/providers/tune_in_provider_test.dart` → 11 tests pass (10 pre-existing + 1 new regression)
- `flutter test --platform chrome` (full suite) → 283 tests pass
- `flutter analyze` on edited files → no issues
- `dart format --set-exit-if-changed` → clean

## Test plan

- [ ] `cd frontend && flutter test --platform chrome test/providers/tune_in_provider_test.dart` — passes
- [ ] Manual: tune into a private artist account, verify avatar rail / UI shows private indicator immediately (no public flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)