### PR TITLE
test(frontend/integration): cover auth routing + bottom-nav with stub graphql

### DIFF
--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -456,7 +456,7 @@ packages:
     source: hosted
     version: "8.0.2"
   gql:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: gql
       sha256: "67c32325eb55c15f526f0f5e7d8b38a463dbff2ec3c2e046be4a1a95f0dc93d1"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -53,6 +53,10 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   hive_ce: ^2.19.3
+  # `gql` is already a transitive dep via graphql_flutter; declared explicitly
+  # so test/integration/_helpers.dart can import the AST types
+  # (OperationDefinitionNode) without depend_on_referenced_packages lint.
+  gql: ^1.0.0
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/frontend/test/integration/_helpers.dart
+++ b/frontend/test/integration/_helpers.dart
@@ -1,0 +1,260 @@
+// Shared infrastructure for integration tests in `test/integration/`.
+//
+// Why this file exists: most flows beyond the cold-boot smoke test need a
+// stub GraphQL link (so `featuredArtistProvider.load()` and `me` queries
+// don't hang on the default HttpLink) and a mock secure storage (so
+// `AuthNotifier.initialize()` can be driven into authenticated state without
+// real keychain access). Test cases override `graphqlClientProvider` and
+// `secureStorageProvider` via `ProviderScope.overrides`.
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+import 'package:gql/ast.dart';
+
+import 'package:gleisner_web/app.dart';
+import 'package:gleisner_web/graphql/client.dart';
+import 'package:gleisner_web/providers/auth_provider.dart';
+
+/// Mock GraphQL link that responds based on the operation name extracted
+/// from the parsed GraphQL AST.
+///
+/// Tests register handlers via the [responses] map keyed by operation name
+/// (e.g. `'Me'`, `'FeaturedArtist'`). The operation name is read from the
+/// first `OperationDefinitionNode` in the document AST because
+/// graphql_flutter's `Request.operation.operationName` arrives empty on the
+/// link side for parsed-document queries. The codebase only uses named
+/// single-operation documents (`gql('query Foo { ... }')`) so this is safe;
+/// anonymous queries land in the unmatched bucket and surface a warning.
+///
+/// Unmatched operations log a debug warning and return empty data. The
+/// warning is the failure mode for typos / forgotten registrations — silent
+/// pass is the worst outcome for an integration test, so tests that want to
+/// assert "no operation X" should use [errors] explicitly.
+class StubGraphQLLink extends Link {
+  final Map<String, Map<String, dynamic>> responses;
+  final Map<String, List<GraphQLError>> errors;
+
+  StubGraphQLLink({
+    Map<String, Map<String, dynamic>>? responses,
+    Map<String, List<GraphQLError>>? errors,
+  }) : responses = responses ?? {},
+       errors = errors ?? {};
+
+  String _operationName(Request request) {
+    final declared = request.operation.operationName;
+    if (declared != null && declared.isNotEmpty) return declared;
+    for (final def in request.operation.document.definitions) {
+      if (def is OperationDefinitionNode) {
+        final name = def.name?.value;
+        if (name != null && name.isNotEmpty) return name;
+      }
+    }
+    return '';
+  }
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    final operationName = _operationName(request);
+    final hasResponse = responses.containsKey(operationName);
+    final hasError = errors.containsKey(operationName);
+    if (!hasResponse && !hasError) {
+      // Surface unmatched operations so test typos (e.g. registering
+      // `'Mee'` instead of `'Me'`) don't fail silently. Tests that want a
+      // "no data" response must register `responses['Foo'] = {}`
+      // explicitly.
+      debugPrint(
+        '[StubGraphQLLink] Unmatched operation "$operationName" — '
+        'returning empty data. Register responses["$operationName"] in '
+        'the test if this is intentional.',
+      );
+    }
+    return Stream.value(
+      Response(
+        data: responses[operationName],
+        errors: errors[operationName],
+        response: const {},
+      ),
+    );
+  }
+}
+
+/// Builds a GraphQL client backed by [StubGraphQLLink].
+///
+/// Note on [FetchPolicy.noCache]: this differs from production
+/// (`lib/graphql/client.dart` uses defaults — `cacheFirst` for queries,
+/// `networkOnly` for mutations) but is a deliberate choice for integration
+/// tests. Cache normalization in graphql_flutter requires every selected
+/// field (including `__typename`) to be present in the response or it
+/// throws `PartialDataException`. We don't want integration tests to police
+/// fixture completeness — that's what provider unit tests
+/// (`test/providers/`) cover. `noCache` lets the link's response flow
+/// straight to the caller without normalization, keeping the assertion
+/// surface focused on routing/UI behaviour.
+GraphQLClient stubClient({
+  Map<String, Map<String, dynamic>>? responses,
+  Map<String, List<GraphQLError>>? errors,
+}) {
+  return GraphQLClient(
+    link: StubGraphQLLink(responses: responses, errors: errors),
+    cache: GraphQLCache(store: InMemoryStore()),
+    defaultPolicies: DefaultPolicies(
+      query: Policies(fetch: FetchPolicy.noCache),
+      mutate: Policies(fetch: FetchPolicy.noCache),
+    ),
+  );
+}
+
+/// In-memory secure storage for tests. Mirrors the surface used by
+/// [AuthNotifier] / [TutorialNotifier] / [GuardianNotifier]; methods we don't
+/// exercise fall back to [Map.remove] / no-op so tests stay deterministic.
+class FakeSecureStorage implements FlutterSecureStorage {
+  final Map<String, String> _store = {};
+
+  FakeSecureStorage({Map<String, String>? initial}) {
+    if (initial != null) _store.addAll(initial);
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    return _store[key];
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      _store.remove(key);
+    } else {
+      _store[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _store.remove(key);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Boots the full app with stubbed GraphQL + secure storage. Pumps until the
+/// router has settled (auth init → redirect → first frame of destination
+/// screen) so tests can assert against the resulting route.
+///
+/// Locale is forced to English so assertions can match l10n strings without
+/// depending on the developer's machine locale (CI / Chrome on a Japanese
+/// Mac would otherwise resolve to ja_JP).
+Future<void> pumpApp(
+  WidgetTester tester, {
+  GraphQLClient? client,
+  FakeSecureStorage? storage,
+  Size? surfaceSize,
+}) async {
+  await initHiveForFlutter();
+  tester.platformDispatcher.localesTestValue = const <Locale>[Locale('en')];
+  addTearDown(tester.platformDispatcher.clearLocalesTestValue);
+
+  // Default to a mobile-sized surface so AuthLayout / BottomNavShell pick the
+  // narrow (non-rail, hero-compact) variant. The default test surface
+  // (800x600) lands in the tablet breakpoint where `GleisnerHero`'s wide
+  // layout overflows and BottomNavShell uses NavigationRail — both of which
+  // make assertions noisier than necessary for routing tests.
+  await tester.binding.setSurfaceSize(surfaceSize ?? const Size(414, 896));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final effectiveClient = client ?? stubClient();
+  final effectiveStorage = storage ?? FakeSecureStorage();
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        graphqlClientProvider.overrideWithValue(effectiveClient),
+        secureStorageProvider.overrideWithValue(effectiveStorage),
+      ],
+      child: const GleisnerApp(),
+    ),
+  );
+
+  // Drive the boot path:
+  //   1. SplashScreen schedules `auth.initialize()` via Future.microtask
+  //   2. initialize() awaits storage / GraphQL → state becomes (un)authed
+  //   3. routerProvider's refreshListenable fires → redirect → navigation
+  //   4. Destination screen mounts and runs its initState
+  //
+  // Strategy: `pumpAndSettle` would settle the splash screen's
+  // CircularProgressIndicator and the GoRouter transition, but the post-
+  // login TimelineScreen owns a 35-second repeating AnimationController
+  // (synapse dots) that never settles — settle would hang for 10 minutes.
+  // Wrap it in a short timeout so we get the benefit on the unauth side
+  // (where everything settles fast) and fall back to explicit pumps on
+  // the authenticated side.
+  try {
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 100),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 3),
+    );
+  } on FlutterError {
+    // Timeout reached — destination has perpetual animations (Timeline).
+    // Fall through; the last few pumps below still flush pending
+    // microtasks and the GoRouter transition.
+  }
+  for (var i = 0; i < 4; i++) {
+    await tester.pump(const Duration(milliseconds: 200));
+  }
+}
+
+/// Shorthand: a `me` query payload representing an authenticated, non-child
+/// user with no artist registration. Sufficient to drive the router into
+/// `/timeline` and render the bottom-nav shell.
+Map<String, dynamic> meUserPayload({
+  String id = 'u1',
+  String username = 'tester',
+  String? displayName,
+}) {
+  return {
+    'me': {
+      'id': id,
+      'did': 'did:web:gleisner.app:u:$id',
+      'email': '$username@test.local',
+      'username': username,
+      'displayName': displayName,
+      'bio': null,
+      'avatarUrl': null,
+      'profileVisibility': 'public',
+      'publicKey': 'pk',
+      'birthYearMonth': '1990-01',
+      'isChildAccount': false,
+      'createdAt': '2026-01-01T00:00:00Z',
+      'updatedAt': '2026-01-01T00:00:00Z',
+    },
+  };
+}

--- a/frontend/test/integration/auth_routing_test.dart
+++ b/frontend/test/integration/auth_routing_test.dart
@@ -1,0 +1,65 @@
+// Routing-level integration tests for unauthenticated users. Exercises the
+// real `routerProvider` redirect rules end-to-end (no JWT in storage →
+// /splash → /login → other public routes), which is hard to verify with
+// pure unit tests because GoRouter needs a widget context.
+//
+// Why this is integration-flavored, not a widget test: it boots `GleisnerApp`
+// (router + theme + i18n + GraphQLProvider) so the same redirect chain a
+// user hits in production runs here. Provider-layer tests cannot catch
+// regressions like a routing rule that only triggers after auth init
+// settles.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Unauthenticated routing', () {
+    testWidgets('no JWT → splash redirects to login', (tester) async {
+      await pumpApp(tester);
+
+      // Login screen renders email/password form + signup link.
+      expect(find.text('Sign In'), findsOneWidget);
+      expect(find.text("Don't have an account? Sign up"), findsOneWidget);
+      expect(find.byType(TextFormField), findsNWidgets(2));
+    });
+
+    testWidgets('login → tap "no account" link → signup screen', (
+      tester,
+    ) async {
+      await pumpApp(tester);
+
+      await tester.tap(find.text("Don't have an account? Sign up"));
+      await tester.pumpAndSettle();
+
+      // Signup screen has 6 TextFormFields: displayName, username, email,
+      // password, confirmPassword, inviteCode (all optional except the
+      // required ones — but they all render).
+      expect(find.text('Create Account'), findsOneWidget);
+      expect(find.text('Already have an account? Sign in'), findsOneWidget);
+    });
+
+    testWidgets('signup → "already have account" link → login screen', (
+      tester,
+    ) async {
+      await pumpApp(tester);
+
+      await tester.tap(find.text("Don't have an account? Sign up"));
+      await tester.pumpAndSettle();
+
+      // The link sits below 6 form fields in the narrow layout, so it
+      // can fall outside the viewport. Scroll it into view before tapping.
+      final backLink = find.text('Already have an account? Sign in');
+      await tester.ensureVisible(backLink);
+      await tester.pumpAndSettle();
+      await tester.tap(backLink);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Sign In'), findsOneWidget);
+      expect(find.text("Don't have an account? Sign up"), findsOneWidget);
+    });
+  });
+}

--- a/frontend/test/integration/authenticated_navigation_test.dart
+++ b/frontend/test/integration/authenticated_navigation_test.dart
@@ -1,0 +1,82 @@
+// Authenticated-state navigation: a JWT is present in fake storage and the
+// `Me` query returns a fan-only user (no artist registration). The router
+// should land the user on `/timeline`, and tapping bottom-nav destinations
+// should swap branches without throwing.
+//
+// Why fan-only / no artist: keeps the GraphQL surface narrow. With no own
+// artist and no tune-ins, Timeline / Discover / Profile render their empty
+// state (or just the screen scaffold + AppBar) without firing follow-up
+// queries that would require additional mocks.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:gleisner_web/screens/discover/discover_screen.dart';
+import 'package:gleisner_web/screens/timeline/timeline_screen.dart';
+
+import '_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Authenticated navigation', () {
+    testWidgets('valid JWT → router lands on /timeline with bottom nav', (
+      tester,
+    ) async {
+      await pumpApp(
+        tester,
+        client: stubClient(
+          responses: {
+            'Me': meUserPayload(),
+            'MyArtist': const {'myArtist': null},
+            'MyTuneIns': const {'myTuneIns': []},
+          },
+        ),
+        storage: FakeSecureStorage(initial: {'jwt': 'valid-token'}),
+      );
+
+      // The Timeline branch is the initial destination after auth.
+      expect(find.byType(TimelineScreen), findsOneWidget);
+      // All three destination labels render in the bottom NavigationBar.
+      expect(find.text('Timeline'), findsOneWidget);
+      expect(find.text('Discover'), findsOneWidget);
+      expect(find.text('Profile'), findsOneWidget);
+    });
+
+    testWidgets('Timeline → tap Discover destination switches branch', (
+      tester,
+    ) async {
+      await pumpApp(
+        tester,
+        client: stubClient(
+          responses: {
+            'Me': meUserPayload(),
+            'MyArtist': const {'myArtist': null},
+            'MyTuneIns': const {'myTuneIns': []},
+            'DiscoverArtists': const {'discoverArtists': []},
+            'Genres': const {'genres': []},
+          },
+        ),
+        storage: FakeSecureStorage(initial: {'jwt': 'valid-token'}),
+      );
+
+      // Before navigation: Timeline branch is mounted; the only "Discover"
+      // text in the tree is the bottom-nav destination label.
+      expect(find.byType(TimelineScreen), findsOneWidget);
+      expect(find.byType(DiscoverScreen), findsNothing);
+      expect(find.text('Discover'), findsOneWidget);
+
+      // Tap the destination by its visible label.
+      await tester.tap(find.text('Discover'));
+      // Use pump (not pumpAndSettle) — Discover screen has its own
+      // animation controllers; settle would hang.
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+
+      // After: Discover branch is now the active screen. StatefulShellRoute
+      // keeps the previous branch alive offstage, so we assert the active
+      // route by checking the visible screen widget.
+      expect(find.byType(DiscoverScreen), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `test/integration/auth_routing_test.dart` (3 tests) for unauthenticated splash → login redirect and login ↔ signup navigation
- Adds `test/integration/authenticated_navigation_test.dart` (2 tests) for valid-JWT → /timeline routing and bottom-nav StatefulShellRoute branch switching
- Adds `test/integration/_helpers.dart` with a reusable `StubGraphQLLink` (AST-based operation name extraction + debug warning on unmatched ops), `FakeSecureStorage`, and a `pumpApp` helper that handles `TimelineScreen`'s perpetual synapse animation via `pumpAndSettle` with timeout fallback
- Declares `gql: ^1.0.0` in `dev_dependencies` (already a transitive dep) to import `OperationDefinitionNode` cleanly

## Why

PR #262 bootstrapped a single smoke test. Now that the harness is proven, this PR extends coverage to the routing flows every user hits:

- Unauthenticated boot path (storage → splash → /login)
- Login ↔ signup link navigation (catches GoRouter redirect rule regressions)
- Authenticated boot path (storage with JWT → `Me` query → /timeline)
- Bottom-nav branch switching (StatefulShellRoute mounts/unmounts)

These flows are hard to verify with provider unit tests because GoRouter needs a widget context.

## Test plan

- [x] `mise run test_integration` → 6/6 pass (~17s on Chrome)
- [x] `flutter analyze test/integration/` → 0 issues
- [x] Existing test suite unaffected (`mise run test_integration` only runs `test/integration/`; pre-existing 6 VM-side failures in `mise run test` are an existing test-task config issue tracked separately)
- [x] Multi-agent review (security ✓, flutter-ui ✓, graphql ✓, synthesis: Ship)

## Notes for reviewer

- `pumpApp` cannot use bare `pumpAndSettle` because `TimelineScreen` owns a 35-second repeating `AnimationController` for synapse dots; helper wraps `pumpAndSettle` in a 3s timeout and falls back to explicit `pump(200ms) × 4`.
- `StubGraphQLLink` reads operation name from the parsed `OperationDefinitionNode` since graphql_flutter's `Request.operation.operationName` arrives empty on the link side. Unmatched operations log a `debugPrint` warning so test typos surface instead of silently passing.
- `stubClient` uses `FetchPolicy.noCache` deliberately — the comment in the file explains why (avoid PartialDataException policing in integration tests; that's unit-test territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)