### PR TITLE
fix(frontend/mise): run `mise run test` on chrome to match CLAUDE.md

### DIFF
--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -8,6 +8,6 @@ lint_check = { run = ["flutter analyze", "dart format --set-exit-if-changed lib 
 run_web = { run = "flutter run" }
 build = { run = "flutter build web", depends = "clean" }
 pub_get = { run = "flutter pub get" }
-test = { run = "flutter test" }
+test = { run = "flutter test --platform chrome", depends = "pub_get" } # CLAUDE.md: dart:js_interop / package:web を推移的 import するテストは chrome 必須
 test_integration = { run = "flutter test test/integration --platform chrome", depends = "pub_get" } # E2E smoke test（Web only のため widget test 扱い、Chrome 必須）
 clean = { run = "flutter clean" }


### PR DESCRIPTION
## Summary

- Switches `mise run test` from bare `flutter test` to `flutter test --platform chrome` and adds `pub_get` as a dependency

## Why

CLAUDE.md mandates `--platform chrome` for `flutter test` because tests transitively import `dart:js_interop` / `package:web/web.dart` (via `media_upload_provider.dart` → `heic_converter.dart`, `web_file_picker.dart`, `image_sanitizer.dart`). The mise task had never been updated to match. This was discovered while landing #265 — `mise run test` shows 6 failing tests that pass on `--platform chrome`.

## Test plan

- [x] `mise run test` → 288/288 pass (was `247 +6 -6 failed` before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)