### PR TITLE
ci: tighten frontend-lint-and-format to fail on warnings/infos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,7 @@ jobs:
           channel: stable
           cache: true
       - run: flutter pub get
-      # NOTE: 既存コードベースに warning/info レベルの lint が 84 件残っている
-      # ため `--no-fatal-warnings --no-fatal-infos` でエラーのみゲート。新規
-      # コード由来の error（コンパイル不能・型不整合等）は引き続き検出する。
-      # 既存 lint クリーンアップは別 PR で対応。
-      - run: flutter analyze --no-fatal-warnings --no-fatal-infos
+      - run: flutter analyze
       - run: dart format --set-exit-if-changed lib test
 
   frontend-test:


### PR DESCRIPTION
## Summary
PR #267（CI 配線）で導入した `--no-fatal-warnings --no-fatal-infos` 緩和を、PR #268（lint クリーンアップ）完了に伴い解除。

これで `frontend-lint-and-format` ジョブは error / warning / info の全レベルでゲートする厳格モードになり、新規 lint が CI で検出される。

## Diff
```diff
-      # NOTE: 既存コードベースに warning/info レベルの lint が 84 件残っている
-      # ため `--no-fatal-warnings --no-fatal-infos` でエラーのみゲート。新規
-      # コード由来の error（コンパイル不能・型不整合等）は引き続き検出する。
-      # 既存 lint クリーンアップは別 PR で対応。
-      - run: flutter analyze --no-fatal-warnings --no-fatal-infos
+      - run: flutter analyze
```

## Test plan
- [ ] `frontend-lint-and-format` が green（PR #268 で 0 issues 達成済み）
- [ ] 他 5 ジョブ regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)