### PR TITLE
fix(timeline): re-dispatch computeLayout when layout is missing despite items (#160)

### DIFF
--- a/frontend/lib/providers/timeline_provider.dart
+++ b/frontend/lib/providers/timeline_provider.dart
@@ -890,7 +890,13 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
   void _recomputeLayout() {
     final milestones = state.artist?.milestones ?? [];
     if ((state.posts.isEmpty && milestones.isEmpty) || _lastWidth == 0) {
-      state = state.copyWith(layout: null);
+      // Skip the state write when layout is already null. Otherwise every
+      // call here re-emits an identical state, which feeds the Issue #160
+      // re-dispatch path in timeline_screen.dart and can amplify into a
+      // build → notify → re-dispatch loop.
+      if (state.layout != null) {
+        state = state.copyWith(layout: null);
+      }
       return;
     }
     final timelineItems = <TimelineItem>[

--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -38,6 +38,11 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
     with SingleTickerProviderStateMixin {
   double? _lastWidth;
   double? _lastHeight;
+  // Issue #160 recovery path: when layout is null but items exist (Notifier
+  // rebuild zeroed _lastWidth), schedule a single computeLayout dispatch.
+  // The flag prevents addPostFrameCallback from being re-registered every
+  // build until the Notifier publishes a non-null layout.
+  bool _layoutDispatchInFlight = false;
   final ScrollController _scrollController = ScrollController();
   double _scrollOffset = 0;
   String? _focusedPostId;
@@ -55,6 +60,15 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
     _dotController.dispose();
     _scrollController.dispose();
     super.dispose();
+  }
+
+  void _scheduleComputeLayout(double width, double height, bool useHorizontal) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!context.mounted) return;
+      ref
+          .read(timelineProvider.notifier)
+          .computeLayout(width, height: height, horizontal: useHorizontal);
+    });
   }
 
   @override
@@ -492,22 +506,41 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                                           false);
                                   final layoutMissing =
                                       timeline.layout == null && hasItems;
-                                  if (_lastWidth != width ||
-                                      _lastHeight != height ||
-                                      layoutMissing) {
+                                  final viewportChanged =
+                                      _lastWidth != width ||
+                                      _lastHeight != height;
+                                  if (viewportChanged) {
+                                    // Viewport actually changed — always
+                                    // redispatch and reset the recovery flag
+                                    // so the next missing-layout state can
+                                    // dispatch again.
                                     _lastWidth = width;
                                     _lastHeight = height;
-                                    WidgetsBinding.instance
-                                        .addPostFrameCallback((_) {
-                                          if (!context.mounted) return;
-                                          ref
-                                              .read(timelineProvider.notifier)
-                                              .computeLayout(
-                                                width,
-                                                height: height,
-                                                horizontal: useHorizontal,
-                                              );
-                                        });
+                                    _layoutDispatchInFlight = false;
+                                    _scheduleComputeLayout(
+                                      width,
+                                      height,
+                                      useHorizontal,
+                                    );
+                                  } else if (layoutMissing &&
+                                      !_layoutDispatchInFlight) {
+                                    // Recovery path: dispatch exactly once per
+                                    // missing-layout episode. The flag clears
+                                    // when the Notifier produces a non-null
+                                    // layout (next build the guard sees
+                                    // !layoutMissing) or when the viewport
+                                    // changes.
+                                    _layoutDispatchInFlight = true;
+                                    _scheduleComputeLayout(
+                                      width,
+                                      height,
+                                      useHorizontal,
+                                    );
+                                  } else if (!layoutMissing &&
+                                      _layoutDispatchInFlight) {
+                                    // Notifier has published a layout — recovery
+                                    // is complete, allow future re-arms.
+                                    _layoutDispatchInFlight = false;
                                   }
 
                                   final layout = timeline.layout;

--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -478,8 +478,23 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                                   final width = constraints.maxWidth;
                                   final height = constraints.maxHeight;
                                   final useHorizontal = isDesktop(width);
+                                  // Re-dispatch when layout is missing despite
+                                  // having items: TimelineNotifier loses its
+                                  // viewport (_lastWidth=0) on Riverpod rebuild
+                                  // — e.g. guardianProvider.switchToChild
+                                  // invalidates graphqlClientProvider, which
+                                  // chains to timelineProvider. The widget-side
+                                  // width/height haven't changed so the prior
+                                  // guard skipped re-dispatch (Issue #160).
+                                  final hasItems =
+                                      timeline.posts.isNotEmpty ||
+                                      (timeline.artist?.milestones.isNotEmpty ??
+                                          false);
+                                  final layoutMissing =
+                                      timeline.layout == null && hasItems;
                                   if (_lastWidth != width ||
-                                      _lastHeight != height) {
+                                      _lastHeight != height ||
+                                      layoutMissing) {
                                     _lastWidth = width;
                                     _lastHeight = height;
                                     WidgetsBinding.instance

--- a/frontend/test/providers/timeline_provider_test.dart
+++ b/frontend/test/providers/timeline_provider_test.dart
@@ -332,6 +332,36 @@ void main() {
       // Layout is now computed and the timeline can render.
       expect(container.read(timelineProvider).layout, isNotNull);
     });
+
+    // Regression test for the re-dispatch loop hazard discussed in PR #272
+    // review (Issue #160 follow-up). `_recomputeLayout` used to write
+    // `state.copyWith(layout: null)` unconditionally on its early-return
+    // path. Combined with the widget-side recovery dispatch
+    // (layoutMissing → computeLayout), this could amplify into a build →
+    // notify → re-dispatch loop because every dispatch produced a fresh
+    // state instance even when nothing actually changed. The Notifier
+    // now skips the write when layout is already null.
+    test('Issue #160 followup: _recomputeLayout skips redundant state write '
+        'when layout is already null', () {
+      final container = _createContainer(client: _clientWith());
+      addTearDown(container.dispose);
+
+      final notifier = container.read(timelineProvider.notifier);
+
+      // Empty posts + no viewport — recomputeLayout would early-return
+      // and (previously) write layout: null to state every call.
+      // computeLayout(0) is the public path that triggers _recomputeLayout
+      // with _lastWidth still 0 because computeLayout assigns the arg
+      // first, so width=0 keeps _lastWidth at 0.
+      final original = container.read(timelineProvider);
+      expect(original.layout, isNull);
+
+      notifier.computeLayout(0.0);
+
+      final after = container.read(timelineProvider);
+      // No state change at all — Riverpod's listener bus stays quiet.
+      expect(identical(original, after), isTrue);
+    });
   });
 
   // Regression tests for Issue #191. The backend fires OGP fetch

--- a/frontend/test/providers/timeline_provider_test.dart
+++ b/frontend/test/providers/timeline_provider_test.dart
@@ -289,6 +289,49 @@ void main() {
         't2',
       });
     });
+
+    // Regression test for Issue #160. When guardianProvider.switchToChild
+    // invalidates graphqlClientProvider, timelineProvider rebuilds with a
+    // fresh Notifier instance whose private viewport (_lastWidth) is 0.
+    // loadArtist then runs but _recomputeLayout skips because of the zero
+    // width, leaving state.layout null even though posts loaded. The widget
+    // (timeline_screen) guards by re-dispatching computeLayout when
+    // (posts.isNotEmpty && layout == null), which feeds the viewport back
+    // to the Notifier and unblocks layout. This test exercises the Notifier
+    // half of that recovery: layout stays null without a viewport, and
+    // computeLayout produces a layout once the widget supplies one.
+    test('Issue #160: computeLayout recovers layout after Notifier rebuild', () {
+      final container = _createContainer(client: _clientWith());
+      addTearDown(container.dispose);
+
+      final notifier = container.read(timelineProvider.notifier);
+
+      // Simulate state after a fresh Notifier instance has finished loadArtist:
+      // posts populated by the backend, but layout still null because the
+      // internal _lastWidth is 0 (instance was just rebuilt).
+      final post = _linkPost(id: 'recovery-post');
+      notifier.debugSetState(
+        const TimelineState(
+          artist: Artist(
+            id: 'a1',
+            artistUsername: 'child',
+            tunedInCount: 0,
+            tracks: [],
+          ),
+        ).copyWith(posts: [post]),
+      );
+
+      // Before the widget re-dispatches computeLayout, the user sees
+      // posts but no constellation — the Issue #160 symptom.
+      expect(container.read(timelineProvider).layout, isNull);
+      expect(container.read(timelineProvider).posts, hasLength(1));
+
+      // Widget detects layoutMissing and calls computeLayout with its width.
+      notifier.computeLayout(800.0);
+
+      // Layout is now computed and the timeline can render.
+      expect(container.read(timelineProvider).layout, isNotNull);
+    });
   });
 
   // Regression tests for Issue #191. The backend fires OGP fetch


### PR DESCRIPTION
## Summary

Fix Issue #160: switching to a child account that has never been loaded shows an empty timeline. Pull-to-refresh or tab switch was the only workaround.

## Root cause

\`guardianProvider.switchToChild\` calls \`ref.invalidate(graphqlClientProvider)\`. \`timelineProvider\` watches that client, so it rebuilds with a fresh \`TimelineNotifier\` instance — and the new instance starts with \`_lastWidth = 0\`. \`loadArtist()\` then populates \`state.posts\`, but its internal \`_recomputeLayout()\` short-circuits on \`_lastWidth == 0\` and leaves \`state.layout\` null.

The existing widget-side guard re-dispatches \`computeLayout\` only when \`width\` or \`height\` change. After a child switch the viewport hasn't changed, so the guard never fires, and the user sees a perpetual loading spinner under \`if (layout == null) CircularProgressIndicator\`.

## Fix

\`timeline_screen.dart\` \`LayoutBuilder\` builder now also re-dispatches when \`layout == null\` but the timeline has items (posts or milestones). The Notifier's own short-circuit handles the empty-timeline case, so no spurious dispatches.

\`\`\`dart
final hasItems =
    timeline.posts.isNotEmpty ||
    (timeline.artist?.milestones.isNotEmpty ?? false);
final layoutMissing = timeline.layout == null && hasItems;
if (_lastWidth != width || _lastHeight != height || layoutMissing) {
  // ...computeLayout...
}
\`\`\`

I considered and rejected the other two options Issue #160 suggested:
- **Move \`_lastWidth\` into \`TimelineState\`** — \`build()\` returns \`const TimelineState()\` on each rebuild, so the new instance still starts with zero viewport. To survive rebuild we'd need \`stateOrNull\`-based viewport preservation in \`build()\`, which expands the change surface and depends on Riverpod 3.x semantics that aren't relied on elsewhere in this codebase.
- **Move \`_lastWidth\` into a separate \`StateProvider\`** — adds a parallel viewport state that the rest of the Notifier doesn't observe; harder to reason about than the widget-guard fix.

The widget-guard approach is the smallest change that closes the gap and the comment in the code points future maintainers at the rebuild chain so the rationale doesn't rot.

## Test plan

- [x] \`dart format --set-exit-if-changed lib/screens/timeline/timeline_screen.dart test/providers/timeline_provider_test.dart\`
- [x] \`dart analyze lib/screens/timeline/timeline_screen.dart test/providers/timeline_provider_test.dart\` — No issues
- [x] \`flutter test --platform chrome test/providers/timeline_provider_test.dart\` — 20/20 pass (1 new)
  - New: \`TimelineNotifier > Issue #160: computeLayout recovers layout after Notifier rebuild\` — verifies that a Notifier with posts but no viewport keeps \`layout == null\`, and that calling \`computeLayout\` (mimicking the widget re-dispatch) produces a non-null layout.
- [ ] Manual verification (post-merge): log in → switch to a child account that hasn't been opened in the current session → timeline renders without pull-to-refresh.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)