### PR TITLE
test(graphql): add production schema smoke test for disabled comment feature (#222)

### DIFF
--- a/backend/src/graphql/__tests__/production-schema.test.ts
+++ b/backend/src/graphql/__tests__/production-schema.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import type { GraphQLObjectType } from "graphql";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { GraphQLObjectType, GraphQLSchema } from "graphql";
 
 // Production schema is defined by importing only `types/index.js`. That file
 // intentionally omits `import "./comment.js"` for Phase 0 (see Issue #221).
@@ -7,47 +7,77 @@ import type { GraphQLObjectType } from "graphql";
 // is not registered in `types/index.js` must not appear in the resulting
 // GraphQL schema.
 //
-// pothos' `builder` is a module-level singleton, so any side-effect import of
-// a type module would pollute these assertions. vitest runs each test file in
-// its own module context (default `isolate: true`), so the comment.test.ts
-// file's individual `import "../types/comment.js"` does not leak here.
+// IMPORTANT — singleton + isolation contract:
+// pothos' `builder` is module-level singleton state, so any side-effect import
+// of a type module would pollute these assertions. This file relies on
+// vitest's `isolate: true` (default; see `backend/vitest.config.ts`) to keep
+// each test file in its own module scope. The sibling `comment.test.ts`
+// individually imports `../types/comment.js` to keep that resolver covered
+// while disabled — that import does NOT leak here only because of isolation.
+// If `vitest.config.ts` ever sets `isolate: false` or switches `pool` away
+// from a worker-isolated pool, this test file becomes load-order-sensitive
+// and must be rewritten (e.g., by spinning up a fresh builder per test, or by
+// running it as a separate vitest project).
 import { builder } from "../builder.js";
 import "../types/index.js";
 
-describe("Production schema hardening", () => {
-  const schema = builder.toSchema();
+const EXCLUDED_MUTATIONS = [
+  "createComment",
+  "updateComment",
+  "deleteComment",
+] as const;
 
-  it("does not expose createComment mutation", () => {
-    expect(
-      schema.getMutationType()?.getFields()["createComment"],
-    ).toBeUndefined();
+const EXCLUDED_QUERIES = ["comments"] as const;
+
+// Object types and any input types that comment resolvers might introduce in
+// future iterations. The input names here are speculative — current Phase 0
+// code uses scalar args, but pinning them now means a future migration to
+// `t.input({...})` style won't quietly leak Comment shapes through inputRef.
+const EXCLUDED_TYPES = [
+  "Comment",
+  "CommentInput",
+  "CreateCommentInput",
+  "UpdateCommentInput",
+] as const;
+
+describe("Production schema hardening (#222)", () => {
+  let schema: GraphQLSchema;
+
+  beforeAll(() => {
+    schema = builder.toSchema();
   });
 
-  it("does not expose updateComment mutation", () => {
-    expect(
-      schema.getMutationType()?.getFields()["updateComment"],
-    ).toBeUndefined();
+  it("Mutation and Query root types are defined", () => {
+    // Without these the per-field assertions below would pass vacuously
+    // (optional chaining returns undefined when the root type is missing).
+    expect(schema.getMutationType(), "Mutation root must exist").toBeDefined();
+    expect(schema.getQueryType(), "Query root must exist").toBeDefined();
   });
 
-  it("does not expose deleteComment mutation", () => {
-    expect(
-      schema.getMutationType()?.getFields()["deleteComment"],
-    ).toBeUndefined();
+  describe.each(EXCLUDED_MUTATIONS)("mutation %s", (name) => {
+    it("does not expose in production schema", () => {
+      expect(schema.getMutationType()!.getFields()[name]).toBeUndefined();
+    });
   });
 
-  it("does not expose comments query", () => {
-    expect(schema.getQueryType()?.getFields()["comments"]).toBeUndefined();
+  describe.each(EXCLUDED_QUERIES)("query %s", (name) => {
+    it("does not expose in production schema", () => {
+      expect(schema.getQueryType()!.getFields()[name]).toBeUndefined();
+    });
   });
 
-  it("Post type does not have a comments field", () => {
+  describe.each(EXCLUDED_TYPES)("type %s", (name) => {
+    it("does not register in production schema", () => {
+      expect(schema.getType(name)).toBeUndefined();
+    });
+  });
+
+  it("Post type does not expose a comments field", () => {
+    // comment.ts attaches `comments` to PostType via builder.objectFields(...),
+    // so a leaked import would manifest as a new field on the existing Post
+    // type rather than a brand-new type registration.
     const postType = schema.getType("Post") as GraphQLObjectType | undefined;
-    expect(postType, "Post type should be registered").toBeDefined();
+    expect(postType, "Post type must be registered").toBeDefined();
     expect(postType!.getFields()["comments"]).toBeUndefined();
-  });
-
-  it("Comment type itself is not registered", () => {
-    // Defence in depth: if Comment object type leaks into the schema,
-    // some other field or input could end up wired to it.
-    expect(schema.getType("Comment")).toBeUndefined();
   });
 });

--- a/backend/src/graphql/__tests__/production-schema.test.ts
+++ b/backend/src/graphql/__tests__/production-schema.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import type { GraphQLObjectType } from "graphql";
+
+// Production schema is defined by importing only `types/index.js`. That file
+// intentionally omits `import "./comment.js"` for Phase 0 (see Issue #221).
+// Loading nothing else here mirrors what production builds: any feature that
+// is not registered in `types/index.js` must not appear in the resulting
+// GraphQL schema.
+//
+// pothos' `builder` is a module-level singleton, so any side-effect import of
+// a type module would pollute these assertions. vitest runs each test file in
+// its own module context (default `isolate: true`), so the comment.test.ts
+// file's individual `import "../types/comment.js"` does not leak here.
+import { builder } from "../builder.js";
+import "../types/index.js";
+
+describe("Production schema hardening", () => {
+  const schema = builder.toSchema();
+
+  it("does not expose createComment mutation", () => {
+    expect(
+      schema.getMutationType()?.getFields()["createComment"],
+    ).toBeUndefined();
+  });
+
+  it("does not expose updateComment mutation", () => {
+    expect(
+      schema.getMutationType()?.getFields()["updateComment"],
+    ).toBeUndefined();
+  });
+
+  it("does not expose deleteComment mutation", () => {
+    expect(
+      schema.getMutationType()?.getFields()["deleteComment"],
+    ).toBeUndefined();
+  });
+
+  it("does not expose comments query", () => {
+    expect(schema.getQueryType()?.getFields()["comments"]).toBeUndefined();
+  });
+
+  it("Post type does not have a comments field", () => {
+    const postType = schema.getType("Post") as GraphQLObjectType | undefined;
+    expect(postType, "Post type should be registered").toBeDefined();
+    expect(postType!.getFields()["comments"]).toBeUndefined();
+  });
+
+  it("Comment type itself is not registered", () => {
+    // Defence in depth: if Comment object type leaks into the schema,
+    // some other field or input could end up wired to it.
+    expect(schema.getType("Comment")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 0 disables the comment GraphQL surface by leaving \`import "./comment.js"\` commented out in \`backend/src/graphql/types/index.ts\`. That single line is the only thing keeping \`createComment\` / \`updateComment\` / \`deleteComment\` / \`comments\` out of the production schema. If it ever gets uncommented by accident (merge conflict fix-up, refactor, automated codemod) CI today does not notice — the feature would ship without the legal review intended for Phase 1+.

This PR adds a CI guard.

## Test added

\`backend/src/graphql/__tests__/production-schema.test.ts\` loads only \`types/index.js\` (mirroring the production build) and asserts:

- \`createComment\` / \`updateComment\` / \`deleteComment\` mutations are absent
- \`comments\` query is absent
- \`Post.comments\` field is absent
- \`Comment\` object type itself is unregistered (defence in depth — if leaked, other inputs/fields could end up wired to it)

## Why this works despite the singleton builder

pothos' \`builder\` is module-level singleton state, so any side-effect import of \`../types/comment.js\` would pollute these assertions. vitest's default \`isolate: true\` runs each test file in its own module scope, so the existing \`comment.test.ts\` (which side-effect-imports \`../types/comment.js\` to keep the resolver covered while disabled) does not leak here.

The test file imports only \`../types/index.js\` and \`../builder.js\`, identical to how the production server builds its schema.

## How the test would fail if comment leaks back in

Uncommenting \`import "./comment.js"\` in \`types/index.ts\` would register the Comment object type and re-attach \`createComment\`/\`updateComment\`/\`deleteComment\` mutations, the \`comments\` query, and the \`Post.comments\` field to the builder — all six assertions would then fail. (The fail-mode is logical, not empirically run; we don't want to commit a temporary broken state to demonstrate it.)

## Test plan

- [x] \`pnpm format:check\` — passes
- [x] \`pnpm lint\` — passes
- [x] \`pnpm test src/graphql/__tests__/production-schema.test.ts\` — 6/6 pass
- [x] \`pnpm test\` (full suite) — 28 files, 370 pass + 1 pre-existing skip (\`public-user.test.ts\` → tracked by Issue #221 Phase 1 restoration checklist)

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)