### PR TITLE
refactor(storage): batch A hardening for magic-byte validator (Issue #278)

### DIFF
--- a/backend/src/graphql/__tests__/validators.test.ts
+++ b/backend/src/graphql/__tests__/validators.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// Mock R2 so validateMediaUrl accepts localhost URLs
+// Mock R2 so validateMediaUrl accepts localhost URLs.
+// Also mock `validateUploadedR2Object` so the
+// `assertUploadedR2ObjectsMatch` tests below can drive specific
+// pass / fail outcomes per URL without touching the network.
 vi.mock("../../storage/r2.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../storage/r2.js")>();
   return {
     ...actual,
     isR2Configured: vi.fn(() => false),
+    validateUploadedR2Object: vi.fn(async () => {}),
   };
 });
 
@@ -13,7 +17,16 @@ import {
   ageFromBirthYearMonth,
   validateMediaUrls,
   MAX_IMAGES_PER_POST,
+  assertUploadedR2ObjectsMatch,
+  assertUploadedR2ObjectMatches,
 } from "../validators.js";
+import { GraphQLError } from "graphql";
+import {
+  validateUploadedR2Object,
+  R2ValidationError,
+} from "../../storage/r2.js";
+
+const mockedValidate = vi.mocked(validateUploadedR2Object);
 
 describe("ageFromBirthYearMonth", () => {
   beforeEach(() => {
@@ -96,5 +109,120 @@ describe("validateMediaUrls", () => {
 
   it("rejects invalid URL in array", () => {
     expect(() => validateMediaUrls(["not-a-url"])).toThrow();
+  });
+});
+
+// Issue #278 (item 8) — `Promise.allSettled` semantics + universal
+// `[SECURITY]` logging. Drives the validator with a mocked R2 helper so
+// each URL's outcome is independently controllable.
+describe("assertUploadedR2ObjectsMatch", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockedValidate.mockReset();
+    mockedValidate.mockResolvedValue(undefined);
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("resolves immediately for an empty URL list (no validator calls)", async () => {
+    await expect(assertUploadedR2ObjectsMatch([])).resolves.toBeUndefined();
+    expect(mockedValidate).not.toHaveBeenCalled();
+  });
+
+  it("calls the per-URL validator for every URL", async () => {
+    const urls = [
+      "https://r2.example/a.jpg",
+      "https://r2.example/b.jpg",
+      "https://r2.example/c.jpg",
+    ];
+    await assertUploadedR2ObjectsMatch(urls);
+    expect(mockedValidate).toHaveBeenCalledTimes(3);
+    for (const url of urls) {
+      expect(mockedValidate).toHaveBeenCalledWith(url);
+    }
+  });
+
+  it("does not short-circuit on the first failure (all URLs are awaited)", async () => {
+    // Sequence: fail / pass / fail. Promise.all would short-circuit after
+    // the first; Promise.allSettled awaits all three.
+    mockedValidate
+      .mockRejectedValueOnce(new R2ValidationError("spoof A"))
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new R2ValidationError("spoof C"));
+
+    await expect(
+      assertUploadedR2ObjectsMatch([
+        "https://r2.example/a.jpg",
+        "https://r2.example/b.jpg",
+        "https://r2.example/c.jpg",
+      ]),
+    ).rejects.toBeInstanceOf(GraphQLError);
+
+    expect(mockedValidate).toHaveBeenCalledTimes(3);
+  });
+
+  it("logs every failure with [SECURITY] prefix (multi-URL forensics)", async () => {
+    mockedValidate
+      .mockRejectedValueOnce(new R2ValidationError("spoof A"))
+      .mockRejectedValueOnce(new R2ValidationError("spoof B"));
+
+    await expect(
+      assertUploadedR2ObjectsMatch([
+        "https://r2.example/a.jpg",
+        "https://r2.example/b.jpg",
+      ]),
+    ).rejects.toThrow();
+
+    const securityLogs = consoleErrorSpy.mock.calls.filter(
+      (args: unknown[]) =>
+        typeof args[0] === "string" && args[0].includes("[SECURITY]"),
+    );
+    expect(securityLogs).toHaveLength(2);
+  });
+
+  // Critical fix from PR #282 review: the previous `errors.length > 1`
+  // guard suppressed the [SECURITY] log when only one URL failed —
+  // exactly the single-file spoof case the validator is meant to catch.
+  it("logs even a single-URL failure with [SECURITY] prefix (Critical regression guard)", async () => {
+    mockedValidate.mockRejectedValueOnce(new R2ValidationError("solo spoof"));
+
+    await expect(
+      assertUploadedR2ObjectsMatch(["https://r2.example/only.jpg"]),
+    ).rejects.toThrow();
+
+    const securityLogs = consoleErrorSpy.mock.calls.filter(
+      (args: unknown[]) =>
+        typeof args[0] === "string" && args[0].includes("[SECURITY]"),
+    );
+    expect(securityLogs).toHaveLength(1);
+  });
+
+  it("re-throws the FIRST error (not the last) so the GraphQL caller's contract is preserved", async () => {
+    mockedValidate
+      .mockRejectedValueOnce(new R2ValidationError("first"))
+      .mockRejectedValueOnce(new R2ValidationError("second"));
+
+    let captured: unknown;
+    try {
+      await assertUploadedR2ObjectsMatch([
+        "https://r2.example/a.jpg",
+        "https://r2.example/b.jpg",
+      ]);
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(GraphQLError);
+    expect((captured as GraphQLError).message).toBe("first");
+  });
+
+  it("preserves GraphQLError type when wrapping internal R2ValidationError", async () => {
+    mockedValidate.mockRejectedValueOnce(new R2ValidationError("bad type"));
+    await expect(
+      assertUploadedR2ObjectMatches("https://r2.example/x.jpg"),
+    ).rejects.toBeInstanceOf(GraphQLError);
   });
 });

--- a/backend/src/graphql/validators.ts
+++ b/backend/src/graphql/validators.ts
@@ -125,28 +125,49 @@ export async function assertUploadedR2ObjectMatches(
 /**
  * Apply `assertUploadedR2ObjectMatches` to each URL in parallel.
  *
- * No-op (resolves immediately) when `urls` is empty — `Promise.all([])`
- * resolves synchronously. Callers don't need to length-guard, but most do
- * because they want to skip a separate DB read used to compute the diff.
+ * No-op (resolves immediately) when `urls` is empty.
  *
- * `Promise.all` is intentional over a serial loop: with `MAX_IMAGES_PER_POST = 10`
- * the serial form was up to 10× the round-trip latency, and there's no
- * ordering dependency between per-URL checks. `Promise.all` short-circuits
- * on the first rejection (subsequent in-flight checks are abandoned), which
- * matches the existing semantics — a partial failure already meant the
- * mutation aborts and any successful checks are not persisted.
+ * Per-URL checks run concurrently (serial form was up to 10× the round-trip
+ * latency at MAX_IMAGES_PER_POST = 10, with no ordering dependency).
+ * `Promise.allSettled` is used instead of `Promise.all` so we collect EVERY
+ * failure rather than only the first — under a coordinated multi-file
+ * spoofing attempt this turns one log line into N, which makes forensics
+ * (Issue #230 R2 orphan sweeper) much easier (Issue #278 item 8).
  *
- * Partial-failure consequence: when one URL fails, the other in-flight
- * checks complete in the background. If they detect a mismatch, their
- * fire-and-forget delete still runs. If they detect a match, those R2
- * objects are not deleted because the mutation rolls back (no DB write
- * referencing them). Cleanup of those orphans relies on the future
- * R2-orphan batch job (Issue #230).
+ * The first encountered error is re-thrown so the GraphQL caller still gets
+ * a single rejection. The remaining errors are logged with [SECURITY] prefix
+ * server-side. Latency cost vs `Promise.all`: bounded by the slowest URL's
+ * round-trip (same worst case), not the failure-case short-circuit.
+ *
+ * Partial-failure consequence: each failing URL's R2 object is deleted
+ * fire-and-forget by `validateUploadedR2Object`. Successful URLs that
+ * complete before the mutation aborts remain in R2 — these orphans rely
+ * on the future R2-orphan batch job (Issue #230).
  */
 export async function assertUploadedR2ObjectsMatch(
   urls: string[],
 ): Promise<void> {
-  await Promise.all(urls.map((url) => assertUploadedR2ObjectMatches(url)));
+  if (urls.length === 0) return;
+  const results = await Promise.allSettled(
+    urls.map((url) => assertUploadedR2ObjectMatches(url)),
+  );
+  const errors = results.filter(
+    (r): r is PromiseRejectedResult => r.status === "rejected",
+  );
+  if (errors.length === 0) return;
+
+  // Log every failure so multi-URL spoofing patterns are visible.
+  if (errors.length > 1) {
+    for (const err of errors) {
+      console.error(
+        "[SECURITY][assertUploadedR2ObjectsMatch] partial failure:",
+        err.reason,
+      );
+    }
+  }
+  // Re-throw the first error so the caller's contract (single rejection)
+  // is preserved. GraphQLError vs other types is preserved via re-throw.
+  throw errors[0].reason;
 }
 
 const VALID_POST_VISIBILITY = ["public", "draft"] as const;

--- a/backend/src/graphql/validators.ts
+++ b/backend/src/graphql/validators.ts
@@ -135,9 +135,20 @@ export async function assertUploadedR2ObjectMatches(
  * (Issue #230 R2 orphan sweeper) much easier (Issue #278 item 8).
  *
  * The first encountered error is re-thrown so the GraphQL caller still gets
- * a single rejection. The remaining errors are logged with [SECURITY] prefix
- * server-side. Latency cost vs `Promise.all`: bounded by the slowest URL's
- * round-trip (same worst case), not the failure-case short-circuit.
+ * a single rejection. EVERY failure is logged with [SECURITY] prefix
+ * server-side — including single-URL failures, since a one-file spoof
+ * attempt is just as worth flagging as a multi-file one.
+ *
+ * Latency: in the all-success case, bounded by the slowest URL (same as
+ * `Promise.all`). In the failure case, `Promise.allSettled` waits for ALL
+ * in-flight checks rather than short-circuiting on the first rejection —
+ * at MAX_IMAGES_PER_POST = 10 this can multiply the failure-case response
+ * time by up to 10×. The trade-off is acceptable because (a) failed
+ * mutations don't write any DB state, and (b) the full failure log set
+ * is the primary forensic output. If this becomes an availability
+ * problem (it shouldn't — round-trips target R2's same-AZ HEAD/range
+ * latency), Issue #278 item 4 (per-URL AbortSignal timeout) is the
+ * natural follow-up.
  *
  * Partial-failure consequence: each failing URL's R2 object is deleted
  * fire-and-forget by `validateUploadedR2Object`. Successful URLs that
@@ -156,14 +167,13 @@ export async function assertUploadedR2ObjectsMatch(
   );
   if (errors.length === 0) return;
 
-  // Log every failure so multi-URL spoofing patterns are visible.
-  if (errors.length > 1) {
-    for (const err of errors) {
-      console.error(
-        "[SECURITY][assertUploadedR2ObjectsMatch] partial failure:",
-        err.reason,
-      );
-    }
+  // Log every failure (including the single-error case) so a one-file
+  // spoof attempt still leaves a forensic trail.
+  for (const err of errors) {
+    console.error(
+      "[SECURITY][assertUploadedR2ObjectsMatch] validation failure:",
+      err.reason,
+    );
   }
   // Re-throw the first error so the caller's contract (single rejection)
   // is preserved. GraphQLError vs other types is preserved via re-throw.

--- a/backend/src/storage/__tests__/r2.test.ts
+++ b/backend/src/storage/__tests__/r2.test.ts
@@ -8,6 +8,7 @@ import {
   R2ValidationError,
   isAllowedContentType,
   validateUploadedR2Object,
+  _readFirstBytesForTesting,
   type UploadCategory,
 } from "../r2.js";
 import { env } from "../../env.js";
@@ -260,6 +261,91 @@ describe("r2 utility functions", () => {
           configurable: true,
         });
       }
+    });
+  });
+
+  // Issue #278 (items 1, 2): the runtime-detected helper that buffers
+  // the first ~64 bytes of an SDK response body for magic-byte
+  // inspection. The fast path uses SdkStreamMixin's
+  // `transformToByteArray`, the fallback uses raw ReadableStream.
+  // Both must enforce the byte cap defensively (the Range header
+  // request is not always honoured by intermediaries).
+  describe("readFirstBytes", () => {
+    it("uses transformToByteArray fast path when available and slices to maxBytes", async () => {
+      // 256 bytes returned (server / SDK ignores Range)
+      const fullBytes = new Uint8Array(256);
+      for (let i = 0; i < fullBytes.length; i++) fullBytes[i] = i;
+      const body = {
+        transformToByteArray: async () => fullBytes,
+      };
+      const result = await _readFirstBytesForTesting(body, 64);
+      expect(result.byteLength).toBe(64);
+      expect(result[0]).toBe(0);
+      expect(result[63]).toBe(63);
+    });
+
+    it("falls back to ReadableStream reader when transformToByteArray is missing", async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+          controller.enqueue(new Uint8Array([9, 10, 11, 12]));
+          controller.close();
+        },
+      });
+      const result = await _readFirstBytesForTesting(stream, 64);
+      // Stream had only 12 bytes total; we shouldn't pad.
+      expect(result.byteLength).toBe(12);
+      expect(Array.from(result)).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+      ]);
+    });
+
+    it("trims a ReadableStream chunk that exceeds the remaining budget", async () => {
+      // Single 1024-byte chunk — proxies / SDK chunkers can deliver
+      // far more than the Range request asked for. The fallback must
+      // truncate this to maxBytes without ever holding the full chunk
+      // in the assembled buffer.
+      const oversized = new Uint8Array(1024);
+      for (let i = 0; i < oversized.length; i++) oversized[i] = i & 0xff;
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(oversized);
+          controller.close();
+        },
+      });
+      const result = await _readFirstBytesForTesting(stream, 64);
+      expect(result.byteLength).toBe(64);
+      expect(result[0]).toBe(0);
+      expect(result[63]).toBe(63);
+    });
+
+    it("stops reading once maxBytes is reached even if the stream has more", async () => {
+      let chunksDelivered = 0;
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(40));
+          chunksDelivered++;
+          controller.enqueue(new Uint8Array(40));
+          chunksDelivered++;
+          controller.enqueue(new Uint8Array(40)); // would push us to 120 > 64
+          chunksDelivered++;
+          controller.close();
+        },
+      });
+      const result = await _readFirstBytesForTesting(stream, 64);
+      expect(result.byteLength).toBe(64);
+      // All chunks were enqueued at start time, so the counter advances
+      // — but the helper only consumed enough to reach the 64-byte cap.
+      expect(chunksDelivered).toBe(3);
+    });
+
+    it("rejects bodies that are neither SdkStreamMixin nor ReadableStream", async () => {
+      await expect(_readFirstBytesForTesting({}, 64)).rejects.toBeInstanceOf(
+        R2ValidationError,
+      );
+      await expect(_readFirstBytesForTesting(null, 64)).rejects.toBeInstanceOf(
+        R2ValidationError,
+      );
     });
   });
 });

--- a/backend/src/storage/magic-bytes.ts
+++ b/backend/src/storage/magic-bytes.ts
@@ -70,6 +70,25 @@ function matchesAt(
  * `buffer` should contain at least the first 12 bytes of the file. Callers
  * typically read 64 bytes via R2 ranged GET to leave room for the ftyp box
  * (which lives at offset 4..12) plus a margin for future detection rules.
+ *
+ * **Adding a new format (procedure):**
+ * 1. Add the new MIME to `ALLOWED_CONTENT_TYPES` in `r2.ts` (and to
+ *    `CONTENT_TYPE_EXT` so uploads get a sensible filename suffix).
+ * 2. Define the magic-byte constant or `ftyp` brand here (top of file).
+ * 3. Add a branch to `detectMimeFromMagicBytes` below — keep image / RIFF /
+ *    ftyp / EBML / Ogg / ID3 / MP3 ordering so prefix collisions resolve
+ *    correctly (e.g. RIFF must be checked before WebP/WAV sub-tags).
+ * 4. Add fixtures to `magic-bytes.test.ts` (the
+ *    `ALLOWED_CONTENT_TYPES coverage` table is the safety net — it fails
+ *    if a new MIME is added but never produces a recognised detection).
+ * 5. If the format has cross-MIME equivalence (HEIC/HEIF, video/webm
+ *    accepting audio/webm, etc.), extend `isContentTypeCompatible`
+ *    below.
+ *
+ * **Frontend parity:** `frontend/lib/utils/mime_from_bytes.dart` runs the
+ * same detection on the client. Mirror any rule change there as well —
+ * Issue #278 (item 6) tracks moving the fixture table to a shared
+ * location to make drift CI-detectable.
  */
 export function detectMimeFromMagicBytes(buffer: Uint8Array): string | null {
   if (buffer.length < 12) return null;

--- a/backend/src/storage/r2.ts
+++ b/backend/src/storage/r2.ts
@@ -251,6 +251,13 @@ function extractR2Key(publicUrl: string): string | null {
  *
  * Issue #278 (items 1, 2).
  */
+export async function _readFirstBytesForTesting(
+  body: unknown,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  return readFirstBytes(body, maxBytes);
+}
+
 async function readFirstBytes(
   body: unknown,
   maxBytes: number,
@@ -283,8 +290,17 @@ async function readFirstBytes(
         const { done, value } = await reader.read();
         if (done) break;
         if (!value) continue;
-        chunks.push(value);
-        total += value.byteLength;
+        // Trim each chunk down to the remaining budget so a single
+        // oversized chunk (proxy buffering / SDK chunking that ignores
+        // the Range header) never inflates `chunks` past `maxBytes`.
+        const needed = maxBytes - total;
+        if (value.byteLength <= needed) {
+          chunks.push(value);
+          total += value.byteLength;
+        } else {
+          chunks.push(value.subarray(0, needed));
+          total = maxBytes;
+        }
       }
     } finally {
       // Cancel + release so the SDK doesn't hold the connection open

--- a/backend/src/storage/r2.ts
+++ b/backend/src/storage/r2.ts
@@ -236,6 +236,83 @@ function extractR2Key(publicUrl: string): string | null {
 }
 
 /**
+ * Read at most `maxBytes` from an AWS SDK `Body`. The body shape is loose:
+ *
+ * - Node.js path: `SdkStreamMixin.transformToByteArray()` is monkey-patched
+ *   onto Readable streams by the SDK and is the fast path.
+ * - Edge / future-SDK path: the body is a raw `ReadableStream<Uint8Array>`
+ *   without the mixin. We fall back to a hand-rolled reader and stop as soon
+ *   as the budget is met (cancel the stream so R2 stops sending bytes).
+ *
+ * In both branches we slice to `maxBytes` defensively, so a stream that
+ * delivers more than the requested window can never produce a buffer larger
+ * than the cap. This keeps the worst-case allocation bounded even if the
+ * Range header is dropped or ignored.
+ *
+ * Issue #278 (items 1, 2).
+ */
+async function readFirstBytes(
+  body: unknown,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  // Fast path: SDK v3 SdkStreamMixin
+  if (
+    body !== null &&
+    typeof body === "object" &&
+    typeof (body as { transformToByteArray?: unknown }).transformToByteArray ===
+      "function"
+  ) {
+    const all = await (
+      body as { transformToByteArray: () => Promise<Uint8Array> }
+    ).transformToByteArray();
+    return all.subarray(0, maxBytes);
+  }
+
+  // Fallback: raw ReadableStream — accumulate until we hit maxBytes, then
+  // cancel so the producer stops sending.
+  if (
+    body !== null &&
+    typeof body === "object" &&
+    typeof (body as { getReader?: unknown }).getReader === "function"
+  ) {
+    const reader = (body as ReadableStream<Uint8Array>).getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      while (total < maxBytes) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        chunks.push(value);
+        total += value.byteLength;
+      }
+    } finally {
+      // Cancel + release so the SDK doesn't hold the connection open
+      try {
+        await reader.cancel();
+      } catch {
+        // ignore — best-effort cleanup
+      }
+      reader.releaseLock();
+    }
+    const buf = new Uint8Array(Math.min(total, maxBytes));
+    let offset = 0;
+    for (const chunk of chunks) {
+      const remaining = maxBytes - offset;
+      if (remaining <= 0) break;
+      const slice = chunk.subarray(0, remaining);
+      buf.set(slice, offset);
+      offset += slice.byteLength;
+    }
+    return buf;
+  }
+
+  throw new R2ValidationError(
+    "Uploaded file body is in an unsupported stream shape",
+  );
+}
+
+/**
  * Validate that the object at `publicUrl` actually contains bytes that
  * match its declared `Content-Type`. See ADR 026 / Issue #269.
  *
@@ -275,7 +352,13 @@ export async function validateUploadedR2Object(
   const declared = (response.ContentType ?? "").toLowerCase();
   if (!declared) {
     deleteR2Object(publicUrl).catch((err) =>
-      console.error("[validateUploadedR2Object] cleanup failed:", err),
+      // [SECURITY] tag flags this for the R2 orphan sweeper (Issue #230) —
+      // a delete failure here means a content-type-spoofed object is still
+      // sitting in R2 and needs out-of-band cleanup.
+      console.error(
+        "[SECURITY][validateUploadedR2Object] cleanup failed for spoofed upload:",
+        err,
+      ),
     );
     throw new R2ValidationError("Uploaded file has no content-type");
   }
@@ -284,24 +367,30 @@ export async function validateUploadedR2Object(
   const body = response.Body;
   if (!body) {
     deleteR2Object(publicUrl).catch((err) =>
-      console.error("[validateUploadedR2Object] cleanup failed:", err),
+      // [SECURITY] tag flags this for the R2 orphan sweeper (Issue #230) —
+      // a delete failure here means a content-type-spoofed object is still
+      // sitting in R2 and needs out-of-band cleanup.
+      console.error(
+        "[SECURITY][validateUploadedR2Object] cleanup failed for spoofed upload:",
+        err,
+      ),
     );
     throw new R2ValidationError("Uploaded file is empty");
   }
 
-  // `transformToByteArray` is provided by AWS SDK v3 streams (sdk-stream-mixin).
-  // It works for both Node.js Readable streams and Web ReadableStream.
+  // Buffer the first 64 bytes for magic-byte inspection. The Range header
+  // (`bytes=0-63` above) should keep R2 from sending more than that, but we
+  // also enforce a hard 64-byte cap downstream to keep the worst case bounded
+  // even if R2 ignores Range or the SDK buffers more than expected.
   //
-  // The Range header should keep R2 from sending more than 64 bytes, but we
-  // also `subarray(0, 64)` defensively in case (a) R2 ignores the Range, or
-  // (b) the SDK's stream parser ever buffers more than the requested window.
-  // Issue #278 (item 1, 2) tracks replacing the cast with a runtime guard
-  // and a hand-rolled 64-byte short-circuit for when the SDK helper is
-  // unavailable (Edge Runtime etc.).
-  const rawBytes = await (
-    body as { transformToByteArray: () => Promise<Uint8Array> }
-  ).transformToByteArray();
-  const bytes = rawBytes.subarray(0, 64);
+  // The SDK's `SdkStreamMixin` adds `transformToByteArray` to `Body`, but the
+  // type is declared loosely (`StreamingBlobPayloadOutputTypes`) and Edge
+  // Runtime / future SDK refactors may surface a raw `ReadableStream`
+  // instead. We runtime-detect the helper and fall back to a hand-rolled
+  // ReadableStream reader, which short-circuits as soon as 64 bytes are
+  // collected (guards against pathological large bodies bypassing the
+  // ranged GET).
+  const bytes = await readFirstBytes(body, 64);
 
   const detected = detectMimeFromMagicBytes(bytes);
   if (!detected || !isContentTypeCompatible(declared, detected)) {
@@ -317,7 +406,13 @@ export async function validateUploadedR2Object(
       detected ?? "unrecognised",
     );
     deleteR2Object(publicUrl).catch((err) =>
-      console.error("[validateUploadedR2Object] cleanup failed:", err),
+      // [SECURITY] tag flags this for the R2 orphan sweeper (Issue #230) —
+      // a delete failure here means a content-type-spoofed object is still
+      // sitting in R2 and needs out-of-band cleanup.
+      console.error(
+        "[SECURITY][validateUploadedR2Object] cleanup failed for spoofed upload:",
+        err,
+      ),
     );
     throw new R2ValidationError(
       "Uploaded file does not match its declared type",


### PR DESCRIPTION
## Summary
Items 1, 2, 3, 7, 8 from Issue #278 (post-PR-#277 follow-ups). Defensive coding + observability tweaks; no behavioural change for the happy path.

- **#1+#2** \`r2.ts\` \`readFirstBytes\` helper: runtime-detect \`transformToByteArray\` (fast path) vs raw \`ReadableStream\` (Edge / future-SDK fallback). Hard 64-byte cap in both branches so a stream that ignores Range can't produce a buffer larger than requested. Reader is cancelled + lock released after read.
- **#3** \`[SECURITY]\` log prefix on the spoofing-detected delete-failure path so the R2 orphan sweeper (Issue #230) can pattern-match.
- **#7** Five-step \"adding a new format\" procedure comment on \`detectMimeFromMagicBytes\` + pointer to the frontend parity counterpart.
- **#8** \`assertUploadedR2ObjectsMatch\` switches \`Promise.all\` → \`Promise.allSettled\`. Multi-file spoofing now produces N log lines instead of one. First error is re-thrown so GraphQL caller contract is preserved.

## Out of scope (still in Issue #278)
- **#4** ETag round-trip (Phase 1)
- **#5 + #9** SDK integration tests + diff-skip unit tests — batch B (needs \`aws-sdk-client-mock\`)
- **#6** Cross-language fixture for backend ↔ frontend parity
- **#10** Pre-ADR-026 backfill script (multi-tenant only)

## Test plan
- [x] \`pnpm vitest run\` — 530/530 pass + 1 skipped
- [x] \`pnpm build\` / \`pnpm lint\` / \`pnpm format:check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)