### PR TITLE
refactor(ogp): extract ogpUpdateSet helper (Issue #189)

### DIFF
--- a/backend/src/graphql/__tests__/post.test.ts
+++ b/backend/src/graphql/__tests__/post.test.ts
@@ -16,9 +16,17 @@ vi.mock("../../storage/r2.js", async (importOriginal) => {
 // path (which chains `.then`) still works for non-OGP tests. Individual
 // fetchOgp tests configure specific responses with mockResolvedValueOnce.
 // `vi.mock` is hoisted by vitest, so this runs before any imports below.
-vi.mock("../../ogp/fetcher.js", () => ({
-  fetchOgpMetadata: vi.fn(async () => null),
-}));
+// `importOriginal` is used to keep the real `ogpUpdateSet` (Issue #189) —
+// it's a pure function the resolver calls inline and would break the
+// mutation if undefined.
+vi.mock("../../ogp/fetcher.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../ogp/fetcher.js")>();
+  return {
+    ...actual,
+    fetchOgpMetadata: vi.fn(async () => null),
+  };
+});
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { sql } from "drizzle-orm";

--- a/backend/src/graphql/__tests__/post.test.ts
+++ b/backend/src/graphql/__tests__/post.test.ts
@@ -20,8 +20,7 @@ vi.mock("../../storage/r2.js", async (importOriginal) => {
 // it's a pure function the resolver calls inline and would break the
 // mutation if undefined.
 vi.mock("../../ogp/fetcher.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../ogp/fetcher.js")>();
+  const actual = await importOriginal<typeof import("../../ogp/fetcher.js")>();
   return {
     ...actual,
     fetchOgpMetadata: vi.fn(async () => null),

--- a/backend/src/graphql/types/post.ts
+++ b/backend/src/graphql/types/post.ts
@@ -24,7 +24,7 @@ import {
   assertUploadedR2ObjectsMatch,
 } from "../validators.js";
 import { checkArtistAccess } from "../access.js";
-import { fetchOgpMetadata } from "../../ogp/fetcher.js";
+import { fetchOgpMetadata, ogpUpdateSet } from "../../ogp/fetcher.js";
 import { deleteR2Object } from "../../storage/r2.js";
 
 /** Media types that require a file upload (mediaUrl must be non-null). */
@@ -606,7 +606,8 @@ builder.mutationFields((t) => ({
       }
 
       // Fire-and-forget OGP fetch for link-type posts.
-      // Always update ogFetchedAt (even on null) to prevent repeated fetches.
+      // `ogpUpdateSet` always writes ogFetchedAt (negative cache) and
+      // preserves existing fields when the fetcher returns null.
       if (args.mediaType === "link" && args.mediaUrl) {
         const postId = post.id;
         const mediaUrl = args.mediaUrl;
@@ -614,17 +615,7 @@ builder.mutationFields((t) => ({
           .then(async (ogp) => {
             await db
               .update(posts)
-              .set({
-                ...(ogp
-                  ? {
-                      ogTitle: ogp.ogTitle,
-                      ogDescription: ogp.ogDescription,
-                      ogImage: ogp.ogImage,
-                      ogSiteName: ogp.ogSiteName,
-                    }
-                  : {}),
-                ogFetchedAt: new Date(),
-              })
+              .set(ogpUpdateSet(ogp))
               .where(eq(posts.id, postId));
           })
           .catch((err) => {
@@ -1329,17 +1320,7 @@ builder.mutationFields((t) => ({
 
       const [updated] = await db
         .update(posts)
-        .set({
-          ...(ogData
-            ? {
-                ogTitle: ogData.ogTitle,
-                ogDescription: ogData.ogDescription,
-                ogImage: ogData.ogImage,
-                ogSiteName: ogData.ogSiteName,
-              }
-            : {}),
-          ogFetchedAt: new Date(),
-        })
+        .set(ogpUpdateSet(ogData))
         .where(eq(posts.id, args.postId))
         .returning();
 

--- a/backend/src/ogp/fetcher.ts
+++ b/backend/src/ogp/fetcher.ts
@@ -77,6 +77,38 @@ function sanitizeImageUrl(url: string | null): string | null {
 }
 
 /**
+ * Build the `db.update(posts).set(...)` payload for persisting an OGP
+ * fetch outcome. Always sets `ogFetchedAt` (negative cache — prevents
+ * the resolver from re-running the fetch on every render). The four
+ * og_* fields are only written when the fetcher returned data, so a
+ * null response from a temporarily-broken site preserves any
+ * previously-cached metadata rather than clearing it.
+ *
+ * Used by both `createPost` (fire-and-forget) and `fetchOgp` to remove
+ * the duplicated `{ ...(ogp ? {...} : {}), ogFetchedAt: new Date() }`
+ * literal — Issue #189.
+ */
+export function ogpUpdateSet(metadata: OgpMetadata | null): {
+  ogTitle?: string | null;
+  ogDescription?: string | null;
+  ogImage?: string | null;
+  ogSiteName?: string | null;
+  ogFetchedAt: Date;
+} {
+  return {
+    ...(metadata
+      ? {
+          ogTitle: metadata.ogTitle,
+          ogDescription: metadata.ogDescription,
+          ogImage: metadata.ogImage,
+          ogSiteName: metadata.ogSiteName,
+        }
+      : {}),
+    ogFetchedAt: new Date(),
+  };
+}
+
+/**
  * Fetch OGP metadata from a URL.
  * Returns null if the URL is unreachable, blocked by SSRF guard,
  * or doesn't contain OGP tags.


### PR DESCRIPTION
## Summary
Extract the OGP-update \`set(...)\` payload builder into \`ogpUpdateSet(metadata)\` in \`src/ogp/fetcher.ts\`. Both \`createPost\` (fire-and-forget) and the \`fetchOgp\` mutation now read \`db.update(posts).set(ogpUpdateSet(ogp))\` instead of the inline conditional spread.

The contract — *always set \`ogFetchedAt\`, only overwrite the four \`og_\*\` fields when the fetcher returned data* — now lives in one doc-commented helper instead of two near-identical literals. This is the Phase 0 negative-cache contract that PR #279 already started asserting in tests.

The existing \`post.test.ts\` mock for \`../../ogp/fetcher.js\` switches to \`importOriginal\` so the new \`ogpUpdateSet\` export reaches the resolver — without it the mutation would call \`set(undefined)\` and fail.

## Test plan
- [x] \`pnpm vitest run\` — 530/530 pass + 1 skipped
- [x] \`pnpm build\` / \`pnpm lint\` / \`pnpm format:check\` — clean

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)