### PR TITLE
refactor(frontend): extract JPEG quality constants (#175 / #179)

### DIFF
--- a/frontend/lib/providers/media_upload_provider.dart
+++ b/frontend/lib/providers/media_upload_provider.dart
@@ -10,6 +10,7 @@ import '../l10n/l10n.dart';
 import '../models/post.dart' show MediaType;
 import '../utils/media_limits.dart';
 import '../utils/heic_converter.dart';
+import '../utils/image_quality.dart';
 import '../utils/image_sanitizer.dart';
 import '../utils/video_thumbnail.dart';
 import '../utils/audio_duration.dart';
@@ -132,8 +133,10 @@ final imageSanitizerProvider = Provider<ImageSanitizer>(
 
 /// Maximum JPEG/WebP quality passed to image_picker. Above 85 some platforms
 /// skip re-encoding, which would leave EXIF intact. Clamping here enforces
-/// re-encoding regardless of caller-provided quality.
-const _maxImageQuality = 85;
+/// re-encoding regardless of caller-provided quality. Re-export from
+/// `utils/image_quality.dart` so the rationale lives in one place
+/// (Issues #175 / #179).
+const _maxImageQuality = kImagePickerMaxQuality;
 
 // ── Notifier ──
 

--- a/frontend/lib/utils/heic_converter.dart
+++ b/frontend/lib/utils/heic_converter.dart
@@ -4,12 +4,14 @@ import 'dart:typed_data';
 
 import 'package:web/web.dart' as web;
 
+import 'image_quality.dart';
+
 /// Convert HEIC/HEIF image bytes to JPEG using the browser's Canvas API.
 /// Works on Safari (macOS/iOS) which supports HEIC decoding natively.
 /// Returns JPEG bytes on success, or null if the browser can't decode HEIC.
 Future<Uint8List?> convertHeicToJpeg(
   Uint8List heicBytes, {
-  double quality = 0.85,
+  double quality = kHeicConversionJpegQuality,
   int maxDimension = 1280,
 }) async {
   final completer = Completer<Uint8List?>();

--- a/frontend/lib/utils/image_quality.dart
+++ b/frontend/lib/utils/image_quality.dart
@@ -1,0 +1,39 @@
+/// JPEG quality presets used by the upload pipeline.
+///
+/// Two distinct settings: thumbnails are aggressively compressed because
+/// they're decorative and bandwidth-sensitive (Timeline / Discover scrolling
+/// loads many at once); full-image conversions trade size for fidelity
+/// because the user is going to view them at native resolution.
+///
+/// Values are double-precision JPEG quality in 0.0..1.0 (Web Canvas API
+/// convention). For the `image_picker` `imageQuality` 1..100 integer scale,
+/// multiply by 100 and clamp to 1..85 (`image_picker` ignores values >=
+/// 85 on iOS; clamping forces re-encode + EXIF strip).
+///
+/// Related: ADR 022 (EXIF metadata removal), Issues #175 / #179.
+library;
+
+/// Video first-frame thumbnail. Goes onto Timeline cards behind the play
+/// icon — visible but small. 0.75 keeps file size in the ~30 KB range while
+/// remaining indistinguishable from 0.9 at thumbnail scale.
+const double kThumbnailJpegQuality = 0.75;
+
+/// HEIC → JPEG conversion for full-size images uploaded from Apple
+/// devices. The output is shown at native resolution in the post detail
+/// view, so we keep more detail. 0.85 is the standard "good quality"
+/// preset that most still photo libraries default to.
+const double kHeicConversionJpegQuality = 0.85;
+
+/// Canvas-API metadata-stripping re-encode (EXIF / XMP / IPTC scrubbing).
+/// Same fidelity rationale as the HEIC conversion path — full-size image,
+/// shown at native resolution. Kept as a separate constant so each path's
+/// rationale is documented even when the numbers happen to coincide.
+const double kImageSanitizeJpegQuality = 0.85;
+
+/// Upper bound for `image_picker.pickImage(imageQuality: ...)`.
+///
+/// `image_picker`'s `imageQuality` accepts 1..100 but only triggers a
+/// re-encode below ~85 on iOS — values >= 85 may pass the original bytes
+/// through (per `image_picker` issue tracker). Clamp callers to 85 max so
+/// EXIF is always stripped via re-encode.
+const int kImagePickerMaxQuality = 85;

--- a/frontend/lib/utils/image_sanitizer.dart
+++ b/frontend/lib/utils/image_sanitizer.dart
@@ -4,6 +4,8 @@ import 'dart:js_interop';
 import 'package:flutter/foundation.dart';
 import 'package:web/web.dart' as web;
 
+import 'image_quality.dart';
+
 /// Re-encode image bytes via Canvas API on Web to strip EXIF / XMP / IPTC
 /// metadata (GPS coordinates, camera identifiers, timestamps).
 ///
@@ -27,7 +29,7 @@ import 'package:web/web.dart' as web;
 Future<({Uint8List bytes, String contentType})?> sanitizeImageMetadata(
   Uint8List bytes, {
   required String contentType,
-  double quality = 0.85,
+  double quality = kImageSanitizeJpegQuality,
 }) async {
   if (!kIsWeb) {
     // JPEG: image_picker's imageQuality (clamped to 1-85 by callers) forces

--- a/frontend/lib/utils/video_thumbnail.dart
+++ b/frontend/lib/utils/video_thumbnail.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 
 import 'package:web/web.dart' as web;
 
+import 'image_quality.dart';
+
 /// Result of video metadata extraction and thumbnail capture.
 typedef VideoMeta = ({Uint8List? thumbnail, int? durationSeconds});
 
@@ -95,7 +97,7 @@ Future<VideoMeta> captureVideoThumbnail(
           reader.readAsArrayBuffer(blob);
         }).toJS,
         'image/jpeg',
-        0.75.toJS,
+        kThumbnailJpegQuality.toJS,
       );
     } catch (_) {
       finish(null);


### PR DESCRIPTION
## Summary
Three hardcoded / per-file JPEG quality values flagged in PR #173 review (Issues #175 + #179) collapse into one \`lib/utils/image_quality.dart\`:

- \`kThumbnailJpegQuality = 0.75\` — video first-frame thumbnails (\`video_thumbnail.dart\`)
- \`kHeicConversionJpegQuality = 0.85\` — Canvas-decoded HEIC (\`heic_converter.dart\`)
- \`kImageSanitizeJpegQuality = 0.85\` — Canvas EXIF/XMP/IPTC strip (\`image_sanitizer.dart\`)
- \`kImagePickerMaxQuality = 85\` — image_picker re-encode threshold (\`media_upload_provider.dart\`)

The two 0.85 constants share a value but document distinct intents (HEIC decode-and-re-encode vs metadata strip). Keeping them named separately means a future tweak to one path doesn't ripple unintentionally.

## Test plan
- [x] \`dart format\` clean
- [x] \`dart analyze lib/\` — No issues found
- [x] \`flutter test --platform chrome\` — all 305 tests pass

Closes #175 #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)