### PR TITLE
refactor(frontend): extract VideoMediaPreview shared widget (#178 / #174)

### DIFF
--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -23,6 +23,7 @@ import '../../providers/media_upload_provider.dart';
 import '../../utils/media_limits.dart' show maxImagesPerPost, uploadHintFor;
 import '../../widgets/common/image_grid_widgets.dart';
 import '../../widgets/media/upload_placeholder.dart';
+import '../../widgets/media/video_media_preview.dart';
 import '../../widgets/timeline/seed_art_painter.dart';
 import '../../l10n/l10n.dart';
 
@@ -1074,94 +1075,8 @@ class _FormStep extends ConsumerWidget {
       return _buildImageGrid();
     }
 
-    final showThumbnail =
-        mediaType == MediaType.video &&
-        thumbnailUrl != null &&
-        thumbnailUrl!.isNotEmpty;
-    final displayUrl = thumbnailUrl ?? '';
-
-    return Stack(
-      children: [
-        if (showThumbnail)
-          ClipRRect(
-            borderRadius: BorderRadius.circular(radiusLg),
-            child: Image.network(
-              displayUrl,
-              width: double.infinity,
-              height: 240,
-              fit: BoxFit.cover,
-              loadingBuilder: (context, child, loadingProgress) {
-                if (loadingProgress == null) return child;
-                return Container(
-                  height: 240,
-                  decoration: BoxDecoration(
-                    color: colorSurface2,
-                    borderRadius: BorderRadius.circular(radiusLg),
-                  ),
-                );
-              },
-              errorBuilder: (_, _, _) => Container(
-                height: 240,
-                decoration: BoxDecoration(
-                  color: colorSurface2,
-                  borderRadius: BorderRadius.circular(radiusLg),
-                ),
-                child: const Center(
-                  child: Icon(
-                    Icons.broken_image_outlined,
-                    size: 40,
-                    color: colorTextMuted,
-                  ),
-                ),
-              ),
-            ),
-          )
-        else
-          Container(
-            height: 200,
-            decoration: BoxDecoration(
-              color: colorSurface2,
-              borderRadius: BorderRadius.circular(radiusLg),
-            ),
-            child: const Center(
-              child: Icon(
-                Icons.videocam_outlined,
-                size: 48,
-                color: colorAccentGold,
-              ),
-            ),
-          ),
-        // Replace badge
-        Positioned(
-          top: spaceSm,
-          right: spaceSm,
-          child: Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: spaceSm,
-              vertical: spaceXs,
-            ),
-            decoration: BoxDecoration(
-              color: Colors.black.withValues(alpha: 0.5),
-              borderRadius: BorderRadius.circular(radiusSm),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(Icons.swap_horiz, size: 14, color: Colors.white70),
-                const SizedBox(width: spaceXs),
-                Text(
-                  context.l10n.replace,
-                  style: const TextStyle(
-                    color: Colors.white70,
-                    fontSize: fontSizeXs,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ],
-    );
+    // Video: shared widget (also used by edit_post_screen)
+    return VideoMediaPreview(thumbnailUrl: thumbnailUrl);
   }
 
   Widget _buildImageGrid() {

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -12,6 +12,7 @@ import '../../providers/media_upload_provider.dart';
 import '../../utils/media_limits.dart' show maxImagesPerPost, uploadHintFor;
 import '../../widgets/common/image_grid_widgets.dart';
 import '../../widgets/media/upload_placeholder.dart';
+import '../../widgets/media/video_media_preview.dart';
 import '../../providers/timeline_provider.dart';
 import '../../providers/unassigned_posts_provider.dart';
 import '../../theme/gleisner_tokens.dart';
@@ -756,94 +757,8 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
       return _buildImageGrid();
     }
 
-    final showThumbnail =
-        mediaType == MediaType.video &&
-        _thumbnailUrl != null &&
-        _thumbnailUrl!.isNotEmpty;
-    final displayUrl = _thumbnailUrl ?? '';
-
-    return Stack(
-      children: [
-        if (showThumbnail)
-          ClipRRect(
-            borderRadius: BorderRadius.circular(radiusLg),
-            child: Image.network(
-              displayUrl,
-              width: double.infinity,
-              height: 240,
-              fit: BoxFit.cover,
-              loadingBuilder: (context, child, loadingProgress) {
-                if (loadingProgress == null) return child;
-                return Container(
-                  height: 240,
-                  decoration: BoxDecoration(
-                    color: colorSurface2,
-                    borderRadius: BorderRadius.circular(radiusLg),
-                  ),
-                );
-              },
-              errorBuilder: (_, _, _) => Container(
-                height: 240,
-                decoration: BoxDecoration(
-                  color: colorSurface2,
-                  borderRadius: BorderRadius.circular(radiusLg),
-                ),
-                child: const Center(
-                  child: Icon(
-                    Icons.broken_image_outlined,
-                    size: 40,
-                    color: colorTextMuted,
-                  ),
-                ),
-              ),
-            ),
-          )
-        else
-          Container(
-            height: 200,
-            decoration: BoxDecoration(
-              color: colorSurface2,
-              borderRadius: BorderRadius.circular(radiusLg),
-            ),
-            child: const Center(
-              child: Icon(
-                Icons.videocam_outlined,
-                size: 48,
-                color: colorAccentGold,
-              ),
-            ),
-          ),
-        // Replace badge
-        Positioned(
-          top: spaceSm,
-          right: spaceSm,
-          child: Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: spaceSm,
-              vertical: spaceXs,
-            ),
-            decoration: BoxDecoration(
-              color: Colors.black.withValues(alpha: 0.5),
-              borderRadius: BorderRadius.circular(radiusSm),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(Icons.swap_horiz, size: 14, color: Colors.white70),
-                const SizedBox(width: spaceXs),
-                Text(
-                  context.l10n.replace,
-                  style: const TextStyle(
-                    color: Colors.white70,
-                    fontSize: fontSizeXs,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ],
-    );
+    // Video: shared widget (also used by create_post_screen)
+    return VideoMediaPreview(thumbnailUrl: _thumbnailUrl);
   }
 
   Widget _buildAudioPreview() {

--- a/frontend/lib/widgets/media/video_media_preview.dart
+++ b/frontend/lib/widgets/media/video_media_preview.dart
@@ -26,20 +26,31 @@ class VideoMediaPreview extends StatelessWidget {
   /// frame extraction has completed).
   final String? thumbnailUrl;
 
+  /// Thumbnail height matches the 16:9 aspect of a typical video frame at
+  /// the form's content width — the captured first frame fills the box
+  /// without letterboxing on the common case (1280×720 → ~430×240).
   static const double _thumbnailHeight = 240;
-  static const double _placeholderHeight = 200;
 
-  bool get _hasThumbnail => thumbnailUrl != null && thumbnailUrl!.isNotEmpty;
+  /// Placeholder is shorter (no image content to balance) so the form
+  /// doesn't reserve unused vertical space while the thumbnail is being
+  /// generated.
+  static const double _placeholderHeight = 200;
 
   @override
   Widget build(BuildContext context) {
+    // Bind to a local so the type promotes from `String?` to `String`
+    // inside the `if (url != null)` branch — no `!` null assertion and
+    // no second read of the property when the field is non-null.
+    final url = thumbnailUrl;
+    final hasThumbnail = url != null && url.isNotEmpty;
+
     return Stack(
       children: [
-        if (_hasThumbnail)
+        if (hasThumbnail)
           ClipRRect(
             borderRadius: BorderRadius.circular(radiusLg),
             child: Image.network(
-              thumbnailUrl!,
+              url,
               width: double.infinity,
               height: _thumbnailHeight,
               fit: BoxFit.cover,

--- a/frontend/lib/widgets/media/video_media_preview.dart
+++ b/frontend/lib/widgets/media/video_media_preview.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/l10n.dart';
+import '../../theme/gleisner_tokens.dart';
+
+/// Video media preview shown in create-post / edit-post forms.
+///
+/// Displays the captured thumbnail (when available) inside a rounded
+/// container, falling back to a video-camera icon placeholder when no
+/// thumbnail has been generated yet. A "Replace" badge sits at the top-
+/// right; the form's container is the tap target so we don't gesture-
+/// detect here — the badge is purely informational.
+///
+/// This widget intentionally has no awareness of upload state /
+/// progress / error messaging — those layers belong to the form. It
+/// renders whatever URL it's handed, with `Image.network`'s
+/// loadingBuilder/errorBuilder providing a consistent skeleton.
+///
+/// Issues #174 / #178 — extracted from \`_buildMediaPreview\` in
+/// create_post_screen and edit_post_screen, which were byte-identical.
+class VideoMediaPreview extends StatelessWidget {
+  const VideoMediaPreview({super.key, this.thumbnailUrl});
+
+  /// URL of the captured first-frame thumbnail. When null or empty, a
+  /// video-camera icon placeholder is shown instead (e.g. before the
+  /// frame extraction has completed).
+  final String? thumbnailUrl;
+
+  static const double _thumbnailHeight = 240;
+  static const double _placeholderHeight = 200;
+
+  bool get _hasThumbnail => thumbnailUrl != null && thumbnailUrl!.isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        if (_hasThumbnail)
+          ClipRRect(
+            borderRadius: BorderRadius.circular(radiusLg),
+            child: Image.network(
+              thumbnailUrl!,
+              width: double.infinity,
+              height: _thumbnailHeight,
+              fit: BoxFit.cover,
+              loadingBuilder: (context, child, loadingProgress) {
+                if (loadingProgress == null) return child;
+                return Container(
+                  height: _thumbnailHeight,
+                  decoration: BoxDecoration(
+                    color: colorSurface2,
+                    borderRadius: BorderRadius.circular(radiusLg),
+                  ),
+                );
+              },
+              errorBuilder: (_, _, _) => Container(
+                height: _thumbnailHeight,
+                decoration: BoxDecoration(
+                  color: colorSurface2,
+                  borderRadius: BorderRadius.circular(radiusLg),
+                ),
+                child: const Center(
+                  child: Icon(
+                    Icons.broken_image_outlined,
+                    size: 40,
+                    color: colorTextMuted,
+                  ),
+                ),
+              ),
+            ),
+          )
+        else
+          Container(
+            height: _placeholderHeight,
+            decoration: BoxDecoration(
+              color: colorSurface2,
+              borderRadius: BorderRadius.circular(radiusLg),
+            ),
+            child: const Center(
+              child: Icon(
+                Icons.videocam_outlined,
+                size: 48,
+                color: colorAccentGold,
+              ),
+            ),
+          ),
+        Positioned(
+          top: spaceSm,
+          right: spaceSm,
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: spaceSm,
+              vertical: spaceXs,
+            ),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.5),
+              borderRadius: BorderRadius.circular(radiusSm),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.swap_horiz, size: 14, color: Colors.white70),
+                const SizedBox(width: spaceXs),
+                Text(
+                  context.l10n.replace,
+                  style: const TextStyle(
+                    color: Colors.white70,
+                    fontSize: fontSizeXs,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/test/widgets/media/video_media_preview_test.dart
+++ b/frontend/test/widgets/media/video_media_preview_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gleisner_web/l10n/app_localizations.dart';
+import 'package:gleisner_web/widgets/media/video_media_preview.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+  locale: const Locale('en'),
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(body: child),
+);
+
+void main() {
+  group('VideoMediaPreview', () {
+    testWidgets('shows the videocam placeholder when thumbnailUrl is null', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(const VideoMediaPreview(thumbnailUrl: null)),
+      );
+      await tester.pumpAndSettle();
+
+      // Placeholder branch: videocam icon, no Image.network.
+      expect(find.byIcon(Icons.videocam_outlined), findsOneWidget);
+      expect(find.byType(Image), findsNothing);
+
+      // Replace badge is always shown so the user can tap to swap.
+      expect(find.byIcon(Icons.swap_horiz), findsOneWidget);
+      expect(find.text('Replace'), findsOneWidget);
+    });
+
+    testWidgets(
+      'shows the videocam placeholder when thumbnailUrl is empty (treated same as null)',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(const VideoMediaPreview(thumbnailUrl: '')),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.videocam_outlined), findsOneWidget);
+        expect(find.byType(Image), findsNothing);
+      },
+    );
+
+    testWidgets('renders the network thumbnail when thumbnailUrl is set', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const VideoMediaPreview(
+            thumbnailUrl: 'http://localhost:4000/thumb.jpg',
+          ),
+        ),
+      );
+      // Don't pumpAndSettle — the Image.network would try to load and
+      // hang the test. The first frame is enough to verify the branch.
+      await tester.pump();
+
+      // Thumbnail branch: Image.network rendered, no placeholder icon.
+      expect(find.byType(Image), findsOneWidget);
+      expect(find.byIcon(Icons.videocam_outlined), findsNothing);
+
+      // Replace badge is still shown.
+      expect(find.byIcon(Icons.swap_horiz), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The video branch of \`_buildMediaPreview\` was byte-identical between \`create_post_screen.dart\` and \`edit_post_screen.dart\` — same Stack, ClipRRect, loadingBuilder, errorBuilder, placeholder fallback, and replace badge. Moved into \`lib/widgets/media/video_media_preview.dart\` as \`VideoMediaPreview(thumbnailUrl:)\`. Both screens now read \`VideoMediaPreview(thumbnailUrl: thumbnailUrl);\`.

The audio and image branches stay per-screen — their helpers (\`_buildAudioPreview\` / \`_buildImageGrid\`) reference per-screen state (audio controller, multi-image grid state, \`onMediaUrlsChanged\` callback shape) that aren't yet aligned enough to share without a deeper refactor. Out of scope.

Net diff: +124 / -176.

## Test plan
- [x] \`dart format\` clean
- [x] \`dart analyze lib/\` — No issues found
- [x] \`flutter test --platform chrome\` — 305 / 305 pass

Closes #178 #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)