### PR TITLE
chore: declare Railway build/deploy config

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "pnpm install --frozen-lockfile && pnpm build"
+  },
+  "deploy": {
+    "startCommand": "node dist/index.js",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
## Summary
- Add `backend/railway.json` to declare build/deploy config for Railway
- Builder: Railpack (Nixpacks is deprecated)
- Build: `pnpm install --frozen-lockfile && pnpm build`
- Start: `node dist/index.js`
- Healthcheck: `/health` (existing Hono route — returns 503 when DB is disconnected, 30s timeout)
- Restart on failure with 10 retries

## Why
Phase 0 production deploy. Declaring config in-repo avoids manual dashboard tweaks and makes the deploy reproducible. Railway picks up `backend/railway.json` automatically when the service's Root Directory is set to `backend`.

## Test plan
- [ ] Set Root Directory to `backend` in Railway service settings (one-time UI action)
- [ ] Trigger Redeploy — verify Railpack builder + build/start commands match
- [ ] After JWT keys are set, `/health` should return `{"status":"ok","db":"connected"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)