### PR TITLE
fix: jwt keygen — pass extractable: true to generateKeyPair

### DIFF
--- a/backend/scripts/generate-jwt-keys.ts
+++ b/backend/scripts/generate-jwt-keys.ts
@@ -6,7 +6,9 @@
 import { generateKeyPair, exportPKCS8, exportSPKI } from "jose";
 
 async function main() {
-  const { privateKey, publicKey } = await generateKeyPair("EdDSA");
+  const { privateKey, publicKey } = await generateKeyPair("EdDSA", {
+    extractable: true,
+  });
   const privPem = await exportPKCS8(privateKey);
   const pubPem = await exportSPKI(publicKey);
 


### PR DESCRIPTION
## Summary
Newer Node / jose combinations return non-extractable `CryptoKey` objects by default, which makes `exportPKCS8` / `exportSPKI` throw:

```
TypeError: CryptoKey is not extractable
    at genericExport (.../jose/dist/webapi/lib/asn1.js:20:15)
```

The whole purpose of this script is to print PEM-encoded keys for `.env` or Railway env vars, so opt in to extractability.

Hit while generating production JWT keys for Phase 0 deploy.

## Test plan
- [ ] `pnpm tsx scripts/generate-jwt-keys.ts` prints `JWT_PRIVATE_KEY=` / `JWT_PUBLIC_KEY=` lines without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)