### PR TITLE
chore(backend): move drizzle-kit and tsx to dependencies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,13 +26,15 @@
     "@hono/node-server": "^2.0.0",
     "@pothos/core": "^4.12.0",
     "dotenv": "^17.4.2",
+    "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
     "graphql": "^16.13.2",
     "graphql-yoga": "^5.21.0",
     "hono": "^4.12.15",
     "htmlparser2": "^12.0.0",
     "jose": "^6.2.3",
-    "postgres": "^3.4.9"
+    "postgres": "^3.4.9",
+    "tsx": "^4.21.0"
   },
   "pnpm": {
     "overrides": {
@@ -44,12 +46,10 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.6.0",
-    "drizzle-kit": "^0.31.10",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-drizzle": "^0.2.3",
     "prettier": "^3.8.3",
-    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.1",
     "vitest": "^4.1.4"

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(postgres@3.4.9)
@@ -52,6 +55,9 @@ importers:
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -59,9 +65,6 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
-      drizzle-kit:
-        specifier: ^0.31.10
-        version: 0.31.10
       eslint:
         specifier: ^10.2.0
         version: 10.2.0
@@ -74,9 +77,6 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary
Move `drizzle-kit` and `tsx` from `devDependencies` to `dependencies` so they remain in the Railway runtime image after `pnpm install --prod` pruning.

## Why
Railway / Railpack default behavior strips devDependencies from the runtime image. The deployed container needs to run:
- `pnpm db:migrate` (uses `drizzle-kit`) — wired up as `preDeployCommand`
- `pnpm admin:setup` (uses `tsx`) — invoked via `railway run`

Both fail with `command not found` if these tools aren't in the runtime image.

## Cost
~50MB added to the production image — acceptable trade-off for being able to run migrations and one-off ops scripts inside the deploy container.

## Test plan
- [ ] `pnpm install --frozen-lockfile && pnpm build` still passes locally
- [ ] After merge, Railway redeploy: `preDeployCommand: pnpm db:migrate` runs successfully (initial migration applies all schema)
- [ ] `railway run -- pnpm admin:setup ...` works against the production service

🤖 Generated with [Claude Code](https://claude.com/claude-code)