### PR TITLE
fix(db): restore missing 0006_sturdy_dark_beast.sql migration

### DIFF
--- a/backend/drizzle/0006_sturdy_dark_beast.sql
+++ b/backend/drizzle/0006_sturdy_dark_beast.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "milestone_reactions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"milestone_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"emoji" varchar(10) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "milestone_reactions_milestone_id_user_id_emoji_unique" UNIQUE("milestone_id","user_id","emoji")
+);
+--> statement-breakpoint
+ALTER TABLE "posts" ADD COLUMN "event_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "posts" ADD COLUMN "thumbnail_url" text;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "birth_year_month" varchar(7);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "guardian_id" uuid;--> statement-breakpoint
+ALTER TABLE "milestone_reactions" ADD CONSTRAINT "milestone_reactions_milestone_id_artist_milestones_id_fk" FOREIGN KEY ("milestone_id") REFERENCES "public"."artist_milestones"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "milestone_reactions" ADD CONSTRAINT "milestone_reactions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_guardian_id_users_id_fk" FOREIGN KEY ("guardian_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;


### PR DESCRIPTION
## Summary
PR #154 (Add milestone nodes to timeline with diamond design) added `drizzle/meta/0006_snapshot.json` and updated `_journal.json` with `{ idx: 6, tag: "0006_sturdy_dark_beast" }` but **never committed the actual SQL file**.

This made `drizzle-kit migrate` throw on any fresh DB:

```
Error: No file ./drizzle/0006_sturdy_dark_beast.sql found in ./drizzle folder
```

Dev environments using `db:push` were unaffected (because db:push doesn't read migration files), which is why this stayed silent.

## Reconstruction

Reconstructed by diffing `meta/0005_snapshot.json` vs `0006_snapshot.json`:

- `CREATE TABLE milestone_reactions` (id, milestone_id FK→artist_milestones, user_id FK→users, emoji, created_at, UNIQUE(milestone_id,user_id,emoji))
- `ALTER TABLE posts ADD event_at, thumbnail_url`
- `ALTER TABLE users ADD birth_year_month, guardian_id` (FK self-ref to users.id, ON DELETE CASCADE)

Cross-verified against `src/db/schema/{milestone-reaction,post,user}.ts` — types and constraints match.

## Verified

Ran `drizzle-kit migrate` against production (empty DB after Phase 0 deploy) — all 14 migrations (0000–0013) apply cleanly. ✓

## Test plan
- [ ] CI builds and tests pass
- [ ] After merge, the `preDeployCommand: pnpm db:migrate` on Railway will work for future deploys (tested manually already)

🤖 Generated with [Claude Code](https://claude.com/claude-code)