### PR TITLE
debug: surface sanitizer failure stage in image-upload error (Phase 0)

### DIFF
--- a/frontend/lib/providers/media_upload_provider.dart
+++ b/frontend/lib/providers/media_upload_provider.dart
@@ -471,7 +471,11 @@ class MediaUploadNotifier extends Notifier<MediaUploadState>
     final sanitized = await _sanitizer(bytes, contentType: detected);
     if (disposed) return null;
     if (sanitized == null) {
-      state = MediaUploadState(error: l10n.imageProcessingFailed);
+      // Phase 0 launch debugging: surface the failure stage in the
+      // user-visible error so we can diagnose iPhone Safari issues without
+      // remote dev tools. Drop the suffix in Phase 1.
+      final stage = lastSanitizerFailureStage ?? 'unknown';
+      state = MediaUploadState(error: '${l10n.imageProcessingFailed} [$stage]');
       return null;
     }
     return sanitized;

--- a/frontend/lib/utils/image_sanitizer.dart
+++ b/frontend/lib/utils/image_sanitizer.dart
@@ -6,6 +6,13 @@ import 'package:web/web.dart' as web;
 
 import 'image_quality.dart';
 
+/// Diagnostic — last reason `sanitizeImageMetadata` returned null. Set on
+/// every failure path (and cleared on success) so the provider can surface
+/// the stage in the user-visible error during Phase 0 launch debugging.
+/// Phase 1 cleanup: drop this once we have proper structured-error
+/// plumbing through the provider.
+String? lastSanitizerFailureStage;
+
 /// Re-encode image bytes via Canvas API on Web to strip EXIF / XMP / IPTC
 /// metadata (GPS coordinates, camera identifiers, timestamps).
 ///
@@ -31,30 +38,44 @@ Future<({Uint8List bytes, String contentType})?> sanitizeImageMetadata(
   required String contentType,
   double quality = kImageSanitizeJpegQuality,
 }) async {
+  void fail(String stage) {
+    lastSanitizerFailureStage = stage;
+    debugPrint(
+      '[sanitizer] fail at: $stage (contentType=$contentType, '
+      'size=${bytes.length})',
+    );
+  }
+
   if (!kIsWeb) {
-    // JPEG: image_picker's imageQuality (clamped to 1-85 by callers) forces
-    // re-encoding, which drops EXIF.
     if (contentType == 'image/jpeg') {
+      lastSanitizerFailureStage = null;
       return (bytes: bytes, contentType: contentType);
     }
-    // GIF: same metadata-block check as Web (no re-encoding possible).
     if (contentType == 'image/gif') {
-      if (gifContainsMetadataBlocks(bytes)) return null;
+      if (gifContainsMetadataBlocks(bytes)) {
+        fail('native-gif-has-metadata');
+        return null;
+      }
+      lastSanitizerFailureStage = null;
       return (bytes: bytes, contentType: contentType);
     }
-    // PNG / WebP / HEIC / other: no reliable native path yet — reject rather
-    // than silently upload images that may carry GPS. Tracked in Issue #227.
+    fail('native-unsupported-$contentType');
     return null;
   }
 
   if (contentType == 'image/gif') {
-    if (gifContainsMetadataBlocks(bytes)) return null;
+    if (gifContainsMetadataBlocks(bytes)) {
+      fail('web-gif-has-metadata');
+      return null;
+    }
+    lastSanitizerFailureStage = null;
     return (bytes: bytes, contentType: contentType);
   }
 
   if (contentType != 'image/jpeg' &&
       contentType != 'image/png' &&
       contentType != 'image/webp') {
+    fail('web-unsupported-$contentType');
     return null;
   }
 
@@ -63,11 +84,22 @@ Future<({Uint8List bytes, String contentType})?> sanitizeImageMetadata(
     contentType: contentType,
     quality: quality,
   );
-  if (reencoded == null) return null;
+  if (reencoded == null) {
+    // _canvasReencode sets a fine-grained stage; only set fallback if not.
+    lastSanitizerFailureStage ??= 'canvas-reencode-null';
+    return null;
+  }
 
-  if (!_matchesMagicBytes(reencoded, contentType)) return null;
-  if (containsMetadataMarkers(reencoded)) return null;
+  if (!_matchesMagicBytes(reencoded, contentType)) {
+    fail('reencoded-magic-mismatch');
+    return null;
+  }
+  if (containsMetadataMarkers(reencoded)) {
+    fail('reencoded-still-has-markers');
+    return null;
+  }
 
+  lastSanitizerFailureStage = null;
   return (bytes: reencoded, contentType: contentType);
 }
 
@@ -98,6 +130,11 @@ Future<Uint8List?> _canvasReencode(
     completer.complete(result);
   }
 
+  void failStage(String stage) {
+    lastSanitizerFailureStage = stage;
+    debugPrint('[sanitizer.canvas] fail at: $stage');
+  }
+
   try {
     final img = web.HTMLImageElement()..src = blobUrl;
 
@@ -106,13 +143,13 @@ Future<Uint8List?> _canvasReencode(
         var w = img.naturalWidth;
         var h = img.naturalHeight;
         if (w <= 0 || h <= 0) {
+          failStage('image-decoded-zero-size');
           finish(null);
           return;
         }
 
-        // Clamp the longest side to kImageSanitizeMaxDimension. Without
-        // this, 12 MP iPhone photos exceed iOS Safari's per-canvas memory
-        // budget and toBlob silently returns null.
+        final originalW = w;
+        final originalH = h;
         if (w > kImageSanitizeMaxDimension || h > kImageSanitizeMaxDimension) {
           if (w >= h) {
             h = (h * kImageSanitizeMaxDimension / w).round();
@@ -122,6 +159,11 @@ Future<Uint8List?> _canvasReencode(
             h = kImageSanitizeMaxDimension;
           }
         }
+
+        debugPrint(
+          '[sanitizer.canvas] decoded ${originalW}x$originalH '
+          '-> drawing at ${w}x$h (contentType=$contentType)',
+        );
 
         final canvas = web.HTMLCanvasElement()
           ..width = w
@@ -133,6 +175,7 @@ Future<Uint8List?> _canvasReencode(
           ((web.Blob? outBlob) {
             if (completer.isCompleted) return;
             if (outBlob == null) {
+              failStage('toblob-returned-null-${w}x$h');
               finish(null);
               return;
             }
@@ -143,6 +186,7 @@ Future<Uint8List?> _canvasReencode(
               if (result != null) {
                 finish((result as JSArrayBuffer).toDart.asUint8List());
               } else {
+                failStage('filereader-null-result');
                 finish(null);
               }
             });
@@ -151,17 +195,25 @@ Future<Uint8List?> _canvasReencode(
           contentType,
           quality.toJS,
         );
-      } catch (_) {
+      } catch (e) {
+        failStage('drawimage-or-toblob-throw-${e.runtimeType}');
         finish(null);
       }
     });
 
-    onErrorSub = img.onError.listen((_) => finish(null));
+    onErrorSub = img.onError.listen((_) {
+      failStage('image-load-error');
+      finish(null);
+    });
 
-    timeout = Timer(const Duration(seconds: 10), () => finish(null));
+    timeout = Timer(const Duration(seconds: 10), () {
+      failStage('canvas-timeout-10s');
+      finish(null);
+    });
 
     return await completer.future;
-  } catch (_) {
+  } catch (e) {
+    failStage('outer-throw-${e.runtimeType}');
     finish(null);
     return null;
   }


### PR DESCRIPTION
## Summary
Phase 0 launch testing on iPhone Safari hits 「画像を処理できませんでした」 even after the 2560px clamp (PR #306). Mac Safari Web Inspector requires a USB cable + dev-account dance that family-member iPhones aren't set up for, so this PR captures the failure stage in a top-level mutable string and appends it to the user-visible error.

## What the user will see
Instead of:
```
画像を処理できませんでした。別のファイルをお試しください。
```
They will see:
```
画像を処理できませんでした。別のファイルをお試しください。 [toblob-returned-null-2560x1920]
```

The bracketed token tells us which step failed. Possible stages:

| Stage | Meaning |
|-------|---------|
| `image-decoded-zero-size` | HTMLImageElement loaded but reported 0×0 |
| `image-load-error` | onerror fired (browser couldn't decode) |
| `toblob-returned-null-WxH` | Canvas re-encode hit memory budget at WxH |
| `filereader-null-result` | toBlob succeeded but FileReader returned null |
| `canvas-timeout-10s` | Whole pipeline exceeded 10s |
| `drawimage-or-toblob-throw-X` | Synchronous throw with runtime type X |
| `reencoded-magic-mismatch` | Output magic bytes don't match contentType |
| `reencoded-still-has-markers` | Re-encoded bytes still carry EXIF/XMP |
| `web-unsupported-X` / `native-unsupported-X` | contentType outside JPEG/PNG/WebP |

## Why a global mutable
The provider's error state is `String? error` and changing the contract to a structured failure type is too disruptive to ship under launch pressure. A top-level `String? lastSanitizerFailureStage` is read once immediately after the sanitizer returns null, so the race window is microscopic in practice (single-image upload flow). Phase 1 cleanup tracked inline.

## Phase 1 cleanup
- Drop `[stage]` suffix in error message
- Remove `lastSanitizerFailureStage` global
- Pipe structured errors through `MediaUploadState.error` (FooError sealed-class pattern from `frontend-implementation.md`)

## Test plan
- [ ] Pages auto-deploys
- [ ] Family iPhone retries HEIC upload
- [ ] User reports the bracketed stage; we follow up with a targeted fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)