### PR TITLE
fix(frontend): clear stale upload error on create/edit-post entry

### DIFF
--- a/frontend/lib/providers/media_upload_provider.dart
+++ b/frontend/lib/providers/media_upload_provider.dart
@@ -155,6 +155,15 @@ class MediaUploadNotifier extends Notifier<MediaUploadState>
     return const MediaUploadState();
   }
 
+  /// Reset to the default state. Screens that re-open upload-capable flows
+  /// should call this on mount so a previous error/progress doesn't bleed
+  /// across navigations — the provider is shared (non-autoDispose) so
+  /// state survives create-post → back → create-post.
+  void reset() {
+    if (disposed) return;
+    state = const MediaUploadState();
+  }
+
   /// Pick an image and upload to R2.
   Future<String?> pickAndUploadImage({
     required UploadCategory category,

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -58,6 +58,16 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
   List<String> _mediaUrls = [];
 
   @override
+  void initState() {
+    super.initState();
+    // Clear stale upload error/progress from a previous screen visit. The
+    // provider is shared (non-autoDispose) so state otherwise persists.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) ref.read(mediaUploadProvider.notifier).reset();
+    });
+  }
+
+  @override
   void dispose() {
     _pickMediaGeneration++; // invalidate any in-flight upload
     _titleController.dispose();

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -75,6 +75,11 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
   @override
   void initState() {
     super.initState();
+    // Clear stale upload error/progress from a previous screen visit. The
+    // provider is shared (non-autoDispose) so state otherwise persists.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) ref.read(mediaUploadProvider.notifier).reset();
+    });
     _titleController = TextEditingController(text: widget.post.title ?? '');
     _bodyController = TextEditingController(text: widget.post.body ?? '');
     _mediaUrlController = TextEditingController(


### PR DESCRIPTION
## Summary
`mediaUploadProvider` is a shared `NotifierProvider` (not `autoDispose`), so a previous screen visit's `state.error` survived navigation: 「画像を処理できませんでした」 stayed visible after closing and re-opening the create-post screen with no upload attempted.

Spotted by user during Phase 0 launch testing while debugging the iPhone Safari HEIC issue (PRs #306 / #307).

## Fix
- Add `MediaUploadNotifier.reset()` that snaps `state` back to default
- Call `ref.read(mediaUploadProvider.notifier).reset()` from a post-frame callback in `initState` of both `create_post_screen` and `edit_post_screen`

Post-frame keeps `ref.read` off the synchronous mount path, matching the project's "build()-side avoidance" rule for one-shot provider effects (see frontend-implementation.md "build() 内で「一度だけ消費する値」を扱わない").

Other callers (`edit_profile_sheet`, `artist_page_screen`) call into the provider for avatar/cover uploads only — same provider but the bug surface is the post-creation flow that user reported. We can add `reset()` calls there in a follow-up if the same staleness shows up.

## Why not autoDispose
Multiple surfaces use `mediaUploadProvider` concurrently (artist page, edit profile sheet, post screens) and switching to autoDispose risks dropping in-flight upload state on parent rebuilds. Per-screen `reset()` is the surgical fix.

## Test plan
- [ ] Trigger upload error in create-post (e.g. unsupported file)
- [ ] Close screen, re-open create-post → no error banner shown
- [ ] Same flow in edit-post

🤖 Generated with [Claude Code](https://claude.com/claude-code)