### PR TITLE
chore(frontend): unregister service worker on page load (Phase 0)

### DIFF
--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -35,6 +35,23 @@
 
   <title>gleisner_web</title>
   <link rel="manifest" href="manifest.json">
+
+  <!--
+    PHASE_0: unregister any service worker that earlier deploys registered.
+    Combined with `flutter build web --pwa-strategy=none` on Cloudflare
+    Pages, this ensures each visitor's next reload fetches main.dart.js
+    fresh from the network — iPhone Safari was caching old JS very
+    aggressively after a stale SW landed during launch testing, and only
+    "Clear History and Data" worked. Tracked in Phase 1 PWA strategy issue.
+  -->
+  <script>
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .getRegistrations()
+        .then(function (regs) { regs.forEach(function (r) { r.unregister(); }); })
+        .catch(function () {});
+    }
+  </script>
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>


### PR DESCRIPTION
## Summary
iPhone Safari caches the Flutter PWA's `main.dart.js` so aggressively that "2 reloads" — the standard Flutter SW activation cycle — does **not** deliver new builds. Family-member testing during Phase 0 launch showed only "Clear History and Data" cleared the stale JS, which we cannot ask testers to do for every fix.

## Two-part fix
1. **This PR** — `web/index.html` snippet that unregisters any service worker on every page load. Existing SWs installed during the launch dry-run get cleaned up on the next visit.
2. **Cloudflare Pages dashboard change** (manual, not in this PR) — append `--pwa-strategy=none` to the build command so future builds ship an empty (no-op) `flutter_service_worker.js`. Combined with this snippet, the SW chain stops cleanly.

## Why disable instead of fix
SW caching is the right primitive but iOS Safari's PWA semantics under-deliver — `skipWaiting()` + `clients.claim()` should solve update lag in theory but iOS-side caches still serve stale JS in practice. Phase 0 launch is family-only; the "fresh fetch on every reload" trade-off is acceptable for the bandwidth involved (~5 MB once per session).

## Phase 1 follow-up
- Revisit caching strategy (skipWaiting + claim, or per-deploy cache-bust) once we have headroom to validate SW upgrades on real iOS devices
- Drop both this snippet and the `--pwa-strategy=none` flag if the new strategy works
- Tracked in: (will open issue after merge)

## Test plan
- [ ] Pages build command updated with `--pwa-strategy=none`
- [ ] Pages auto-deploys
- [ ] Existing iPhone tester reloads once → SW gets unregistered, JS fresh
- [ ] Subsequent fix PRs (e.g. #309) take effect on next reload (no "Clear History" required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)