### PR TITLE
fix(frontend): iOS Safari video fullscreen v2 — feature detect + drop playsinline

### DIFF
--- a/frontend/lib/widgets/timeline/post_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/post_detail_sheet.dart
@@ -2298,14 +2298,29 @@ class _VideoPlayerState extends State<_VideoPlayer> {
     if (videos.length == 0) return;
     final video = videos.item(videos.length - 1) as web.HTMLVideoElement;
 
-    // iOS Safari refuses the standard Element.requestFullscreen API but
-    // ships a webkit-prefixed variant on HTMLVideoElement that hands the
-    // video to the native iOS player. Try it first; if it isn't there
-    // (everything else: desktop Safari, Chrome, Firefox) fall through to
-    // the standard API.
-    final ext = _VideoFullscreenJSExt(video);
-    if (ext.hasWebkitEnterFullscreen) {
+    // iOS Safari does not honour the standard Element.requestFullscreen
+    // API for embedded videos. Detect via `webkitSupportsFullscreen`
+    // (true on iOS Safari, undefined elsewhere) and call the
+    // webkit-prefixed `webkitEnterFullscreen()` to hand playback to the
+    // native iOS fullscreen player. If `playsinline` is set the video
+    // refuses fullscreen unless we clear it first; flutter
+    // video_player_web sets it on so we toggle it temporarily.
+    final ext = _IOSVideoExt(video);
+    final iosCanFullscreen = ext.webkitSupportsFullscreen;
+    if (iosCanFullscreen == true) {
+      // Flutter Web sets the playsinline attribute; iOS Safari treats
+      // playsinline as "stay embedded", which suppresses the fullscreen
+      // request. Remove it for the call, then restore on exit.
+      final hadPlaysinline = video.hasAttribute('playsinline');
+      if (hadPlaysinline) video.removeAttribute('playsinline');
       ext.webkitEnterFullscreen();
+      // Restore on the next frame so the fullscreen player has time
+      // to take over.
+      if (hadPlaysinline) {
+        Future.delayed(const Duration(milliseconds: 100), () {
+          if (mounted) video.setAttribute('playsinline', '');
+        });
+      }
       return;
     }
     video.requestFullscreen().toDart.catchError((_) => null);
@@ -2426,21 +2441,21 @@ class _VideoPlayerState extends State<_VideoPlayer> {
   }
 }
 
-// JS interop wrapper for the iOS-Safari-only `webkitEnterFullscreen` on
-// `<video>`. The standard `Element.requestFullscreen` API does not work on
-// iOS Safari for embedded media; the webkit-prefixed method on the video
-// element itself hands playback to the native fullscreen player.
+// JS interop wrapper for the iOS-Safari-only fullscreen path on `<video>`.
+// The standard `Element.requestFullscreen` API does not work on iOS
+// Safari for embedded media; the webkit-prefixed method on the video
+// element hands playback to the native fullscreen player.
 //
-// Using a getter for the property and a static method call separately so
-// we can feature-detect cleanly: on browsers that don't expose the
-// prefix the property is `undefined`, and `hasProperty` returns false.
-extension type _VideoFullscreenJSExt._(web.HTMLVideoElement _video)
+// Feature-detect via `webkitSupportsFullscreen` — defined on every
+// iOS-Safari `<video>` (true once metadata loads) and `undefined`
+// elsewhere. Reading an undefined JS property through an `external`
+// getter typed as a nullable `bool` returns `null` in Dart, which is
+// exactly the discriminator we want.
+extension type _IOSVideoExt._(web.HTMLVideoElement _video)
     implements web.HTMLVideoElement {
-  external JSAny? get webkitEnterFullscreen_; // probe; null on non-iOS
-  bool get hasWebkitEnterFullscreen => webkitEnterFullscreen_ != null;
-  @JS('webkitEnterFullscreen')
+  external bool? get webkitSupportsFullscreen;
   external void webkitEnterFullscreen();
-  _VideoFullscreenJSExt(web.HTMLVideoElement v) : this._(v);
+  _IOSVideoExt(web.HTMLVideoElement v) : this._(v);
 }
 
 // ── Audio Player ──


### PR DESCRIPTION
## Summary
PR #311 didn't actually fire on iOS Safari. Two reasons:

1. **Wrong feature-detect symbol.** `webkitEnterFullscreen_` (trailing underscore) mapped to a JS property literally named `webkitEnterFullscreen_`, not `webkitEnterFullscreen`. Feature detection always returned false on iOS Safari and the webkit call was never invoked. The standard `requestFullscreen` path was always taken, which iOS Safari ignores for embedded videos.

2. **`playsinline` blocks the request.** Flutter `video_player_web` sets the `playsinline` attribute on the `<video>` so videos play inline rather than auto-fullscreening. iOS Safari treats this as "stay embedded" and suppresses fullscreen requests even via `webkitEnterFullscreen()`.

## Fix
- Detect via `webkitSupportsFullscreen` — defined on every iOS-Safari `<video>` (becomes `true` once metadata loads, undefined elsewhere → `null` in Dart). Properly-typed `external bool?` getter so the JS-name → Dart-name mapping is exact.
- Call `webkitEnterFullscreen()` directly via the extension type's `external` method (no underscore-suffixed probe).
- Temporarily clear `playsinline` before the call, restore on the next frame so we don't fight the fullscreen player's own attribute juggling.

## Test plan
- [ ] Pages auto-deploys
- [ ] iPhone Safari → tap fullscreen icon on a video post → enters native iOS player
- [ ] Exit fullscreen → video resumes inline (playsinline restored)
- [ ] Desktop Safari → standard fullscreen still works (regression check)
- [ ] Chrome on Android / Firefox → standard path (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)