### PR TITLE
fix(ogp): use Mozilla-compatible bot UA so YouTube returns full OGP

### DIFF
--- a/backend/src/ogp/ssrf-guard.ts
+++ b/backend/src/ogp/ssrf-guard.ts
@@ -151,7 +151,13 @@ export async function safeFetch(url: string): Promise<string> {
         signal: controller.signal,
         redirect: "manual",
         headers: {
-          "User-Agent": "Gleisner-OGP-Fetcher/1.0",
+          // Identify as a Mozilla-compatible bot so sites that withhold
+          // OGP metadata from unrecognised UAs (notably YouTube, which
+          // serves a stripped HTML page to plain "Gleisner-OGP-Fetcher")
+          // return the full <head>. Includes our identifier + URL so
+          // operators can attribute traffic and contact us.
+          "User-Agent":
+            "Mozilla/5.0 (compatible; GleisnerBot/1.0; +https://gleisner.app)",
           Accept: "text/html",
         },
       });


### PR DESCRIPTION
## Summary
The fetcher identified itself as `Gleisner-OGP-Fetcher/1.0` — a UA YouTube does not recognise. YouTube responds to unknown UAs with a stripped HTML page that omits `og:image` / `og:title` meta tags, so posts linking to YouTube videos showed no thumbnail in the link preview card.

## Fix
Switch to a Mozilla-compatible identifier that keeps our bot name and contact URL visible so site operators can attribute traffic:

```
Mozilla/5.0 (compatible; GleisnerBot/1.0; +https://gleisner.app)
```

This shape is the standard for OGP/link-preview fetchers (Twitterbot, facebookexternalhit, opengraph.io all follow `Mozilla/5.0 + identifier`) and is recognised by YouTube, Twitter, Instagram, and most major sites that gate OGP behind UA detection.

## Hit during
Phase 0 launch testing — YouTube link post showed no thumbnail.

## Test plan
- [ ] Post a YouTube link → preview card shows thumbnail + title
- [ ] Post a Twitter / Instagram link → preview card shows thumbnail
- [ ] Post a generic blog link (e.g. dev.to) → preview card unchanged (those sites already worked)
- [ ] Backend logs show our UA on outbound fetches

## Why not facebookexternalhit/Twitterbot
Pretending to be a verified bot from another service is mildly deceptive and doesn't work everywhere — YouTube cross-checks IP ranges for the heavily-impersonated bots. The Mozilla-compatible self-identification is enough for YouTube while staying honest about our origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)