### PR TITLE
chore(frontend): no-cache headers for app-shell on Cloudflare Pages

### DIFF
--- a/frontend/web/_headers
+++ b/frontend/web/_headers
@@ -1,0 +1,33 @@
+# Cloudflare Pages _headers
+# https://developers.cloudflare.com/pages/configuration/headers/
+#
+# App-shell files (HTML and JS bootstrap) must NEVER be cached at the
+# browser level — iPhone Safari otherwise serves a stale main.dart.js
+# even when the underlying file has changed, and the only user-side
+# escape is "Settings → Safari → Clear History and Data" (Issue #315).
+#
+# `no-cache, must-revalidate` keeps the file in the cache but forces a
+# revalidation request on every load. Cloudflare's CDN uses the ETag
+# to return 304 when nothing changed, so the bandwidth cost is a few
+# bytes per page-load instead of a full 5 MB redownload.
+#
+# Static assets (canvaskit, fonts, icons) are content-addressed by
+# Flutter's build output and safe to cache for a long time.
+
+/main.dart.js
+  Cache-Control: no-cache, max-age=0, must-revalidate
+
+/flutter_bootstrap.js
+  Cache-Control: no-cache, max-age=0, must-revalidate
+
+/flutter_service_worker.js
+  Cache-Control: no-cache, max-age=0, must-revalidate
+
+/index.html
+  Cache-Control: no-cache, max-age=0, must-revalidate
+
+/
+  Cache-Control: no-cache, max-age=0, must-revalidate
+
+/version.json
+  Cache-Control: no-cache, max-age=0, must-revalidate


### PR DESCRIPTION
## Summary
Issue #315 — iPhone Safari aggressively caches `main.dart.js` even when the bytes have changed. The only user-side recovery is "Settings → Safari → Clear History and Data". For Phase 0 family testing we ask for that, but it's not viable post-launch.

## Fix
Add `web/_headers` (Flutter copies `web/` verbatim into `build/web/`) so Cloudflare Pages serves the app-shell files with `no-cache, must-revalidate`:

- `/main.dart.js`
- `/flutter_bootstrap.js`
- `/flutter_service_worker.js`
- `/index.html`
- `/`
- `/version.json`

Cloudflare's edge uses the ETag for revalidation:
- **Unchanged build**: client sends `If-None-Match: <etag>`, edge returns 304 with a tiny header response (no body)
- **Changed build**: edge returns the new bytes immediately

So the bandwidth penalty is small (a few hundred bytes per page-load) and we get same-day reflection of fixes on iOS Safari.

Static asset directories (canvaskit/, icons/, fonts/, assets/) are content-addressed by Flutter's build output (different filenames between deploys) and safe to keep at default cache, so they aren't listed here.

## Pairs with
- PR #310 — disabled service worker (`--pwa-strategy=none`) and added an SW unregister snippet
- Together: SW + HTTP cache both forced to revalidate

## Test plan
- [ ] Pages auto-deploys
- [ ] `curl -i https://gleisner.app/main.dart.js` → header includes `cache-control: no-cache, max-age=0, must-revalidate`
- [ ] On iPhone Safari (without clearing history), reload after a known PR merge → new code reflects on first reload
- [ ] No regression on first-page-load latency (single 304 instead of full 5 MB on second visit)

## Closes
Issue #315 (option 2: per-asset Cache-Control via `_headers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)