### PR TITLE
fix(frontend): keyboard-safe insets for milestone form + 4 dialogs

### DIFF
--- a/frontend/lib/screens/artist/artist_page_screen.dart
+++ b/frontend/lib/screens/artist/artist_page_screen.dart
@@ -958,6 +958,12 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
         return StatefulBuilder(
           builder: (context, setDialogState) => AlertDialog(
             backgroundColor: colorSurface1,
+            insetPadding: EdgeInsets.only(
+              left: spaceLg,
+              right: spaceLg,
+              top: spaceLg,
+              bottom: spaceLg + MediaQuery.of(context).viewInsets.bottom,
+            ),
             title: Text(
               context.l10n.displayName,
               style: const TextStyle(color: colorTextPrimary),

--- a/frontend/lib/screens/artist/edit_milestones_sheet.dart
+++ b/frontend/lib/screens/artist/edit_milestones_sheet.dart
@@ -147,6 +147,16 @@ class _EditMilestonesSheetState extends ConsumerState<EditMilestonesSheet> {
       builder: (ctx) => StatefulBuilder(
         builder: (ctx, setDialogState) => AlertDialog(
           backgroundColor: colorSurface1,
+          // AlertDialog is centered by default and gets covered by the
+          // soft keyboard + predictive bar on iPhone Safari. Push it up
+          // by the keyboard height so the inputs and Save button stay
+          // visible while typing.
+          insetPadding: EdgeInsets.only(
+            left: spaceLg,
+            right: spaceLg,
+            top: spaceLg,
+            bottom: spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
+          ),
           title: Text(
             context.l10n.editMilestone,
             style: const TextStyle(color: colorTextPrimary),
@@ -345,157 +355,182 @@ class _EditMilestonesSheetState extends ConsumerState<EditMilestonesSheet> {
                   ),
                 ),
               ),
-            // Add form
+            // Add form. Hide the milestones list while open so the form
+            // can scroll freely on small screens — Add button + date
+            // picker would otherwise drop below the soft keyboard +
+            // predictive bar on iOS Safari and become unreachable.
             if (_showAddForm)
-              Padding(
-                padding: const EdgeInsets.all(spaceLg),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    // Category chips
-                    Wrap(
-                      spacing: spaceXs,
-                      children: milestoneCategoryKeys.map((key) {
-                        final selected = _selectedCategory == key;
-                        return ChoiceChip(
-                          label: Text(milestoneCategoryName(context, key)),
-                          avatar: Icon(milestoneCategoryIcon(key), size: 16),
-                          selected: selected,
-                          onSelected: (_) =>
-                              setState(() => _selectedCategory = key),
-                          visualDensity: VisualDensity.compact,
-                        );
-                      }).toList(),
-                    ),
-                    const SizedBox(height: spaceMd),
-                    TextFormField(
-                      controller: _titleController,
-                      style: const TextStyle(color: colorTextPrimary),
-                      decoration: InputDecoration(
-                        labelText: context.l10n.title,
-                        border: const OutlineInputBorder(),
+              Expanded(
+                child: SingleChildScrollView(
+                  // Drag is handled by the SingleChildScrollView; pass
+                  // the DraggableScrollableSheet's controller so the
+                  // sheet can still expand/dismiss naturally as the
+                  // user pulls.
+                  controller: scrollController,
+                  padding: EdgeInsets.only(
+                    left: spaceLg,
+                    right: spaceLg,
+                    top: spaceLg,
+                    // viewInsets.bottom = soft-keyboard height. Adding
+                    // it here keeps the Add button above the keyboard
+                    // (matches the pattern in edit_profile_sheet,
+                    // register_artist_sheet, etc.).
+                    bottom: spaceLg + MediaQuery.of(context).viewInsets.bottom,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Category chips
+                      Wrap(
+                        spacing: spaceXs,
+                        children: milestoneCategoryKeys.map((key) {
+                          final selected = _selectedCategory == key;
+                          return ChoiceChip(
+                            label: Text(milestoneCategoryName(context, key)),
+                            avatar: Icon(milestoneCategoryIcon(key), size: 16),
+                            selected: selected,
+                            onSelected: (_) =>
+                                setState(() => _selectedCategory = key),
+                            visualDensity: VisualDensity.compact,
+                          );
+                        }).toList(),
                       ),
-                      maxLength: 255,
-                    ),
-                    const SizedBox(height: spaceSm),
-                    TextFormField(
-                      controller: _descriptionController,
-                      style: const TextStyle(color: colorTextPrimary),
-                      decoration: InputDecoration(
-                        labelText: context.l10n.descriptionOptional,
-                        border: const OutlineInputBorder(),
+                      const SizedBox(height: spaceMd),
+                      TextFormField(
+                        controller: _titleController,
+                        style: const TextStyle(color: colorTextPrimary),
+                        decoration: InputDecoration(
+                          labelText: context.l10n.title,
+                          border: const OutlineInputBorder(),
+                        ),
+                        maxLength: 255,
                       ),
-                      maxLines: 2,
-                    ),
-                    const SizedBox(height: spaceMd),
-                    OutlinedButton.icon(
-                      onPressed: _pickDate,
-                      icon: const Icon(Icons.calendar_today, size: 16),
-                      label: Text(
-                        '${_selectedDate.year}/${_selectedDate.month.toString().padLeft(2, '0')}/${_selectedDate.day.toString().padLeft(2, '0')}',
+                      const SizedBox(height: spaceSm),
+                      TextFormField(
+                        controller: _descriptionController,
+                        style: const TextStyle(color: colorTextPrimary),
+                        decoration: InputDecoration(
+                          labelText: context.l10n.descriptionOptional,
+                          border: const OutlineInputBorder(),
+                        ),
+                        maxLines: 2,
                       ),
-                    ),
-                    const SizedBox(height: spaceMd),
-                    FilledButton(
-                      onPressed: _isSubmitting ? null : _addMilestone,
-                      child: _isSubmitting
-                          ? const SizedBox(
-                              height: 16,
-                              width: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : Text(context.l10n.add),
-                    ),
-                  ],
+                      const SizedBox(height: spaceMd),
+                      OutlinedButton.icon(
+                        onPressed: _pickDate,
+                        icon: const Icon(Icons.calendar_today, size: 16),
+                        label: Text(
+                          '${_selectedDate.year}/${_selectedDate.month.toString().padLeft(2, '0')}/${_selectedDate.day.toString().padLeft(2, '0')}',
+                        ),
+                      ),
+                      const SizedBox(height: spaceMd),
+                      FilledButton(
+                        onPressed: _isSubmitting ? null : _addMilestone,
+                        child: _isSubmitting
+                            ? const SizedBox(
+                                height: 16,
+                                width: 16,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : Text(context.l10n.add),
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            const Divider(height: 1, color: colorBorder),
-            // Milestones list
-            Expanded(
-              child: _milestones.isEmpty
-                  ? Center(
-                      child: Text(
-                        context.l10n.milestones,
-                        style: const TextStyle(color: colorTextMuted),
-                      ),
-                    )
-                  : ListView.separated(
-                      controller: scrollController,
-                      padding: const EdgeInsets.all(spaceLg),
-                      itemCount: _milestones.length,
-                      separatorBuilder: (_, _) =>
-                          const SizedBox(height: spaceMd),
-                      itemBuilder: (context, index) {
-                        final m = _milestones[index];
-                        return GestureDetector(
-                          onTap: () => _editMilestone(m),
-                          child: Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Icon(
-                                milestoneCategoryIcon(m.category),
-                                size: 20,
-                                color: colorAccentGold,
-                              ),
-                              const SizedBox(width: spaceMd),
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      m.title,
-                                      style: const TextStyle(
-                                        color: colorTextPrimary,
-                                        fontWeight: weightMedium,
+            if (!_showAddForm) const Divider(height: 1, color: colorBorder),
+            // Milestones list — hidden while the add form is open so the
+            // form can occupy the full sheet height + scroll above the
+            // soft keyboard.
+            if (!_showAddForm)
+              Expanded(
+                child: _milestones.isEmpty
+                    ? Center(
+                        child: Text(
+                          context.l10n.milestones,
+                          style: const TextStyle(color: colorTextMuted),
+                        ),
+                      )
+                    : ListView.separated(
+                        controller: scrollController,
+                        padding: const EdgeInsets.all(spaceLg),
+                        itemCount: _milestones.length,
+                        separatorBuilder: (_, _) =>
+                            const SizedBox(height: spaceMd),
+                        itemBuilder: (context, index) {
+                          final m = _milestones[index];
+                          return GestureDetector(
+                            onTap: () => _editMilestone(m),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Icon(
+                                  milestoneCategoryIcon(m.category),
+                                  size: 20,
+                                  color: colorAccentGold,
+                                ),
+                                const SizedBox(width: spaceMd),
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        m.title,
+                                        style: const TextStyle(
+                                          color: colorTextPrimary,
+                                          fontWeight: weightMedium,
+                                        ),
                                       ),
-                                    ),
-                                    const SizedBox(height: spaceXxs),
-                                    Text(
-                                      m.date.substring(0, 7),
-                                      style: const TextStyle(
-                                        color: colorTextMuted,
-                                        fontSize: fontSizeXs,
-                                      ),
-                                    ),
-                                    if (m.description != null) ...[
                                       const SizedBox(height: spaceXxs),
                                       Text(
-                                        m.description!,
+                                        m.date.substring(0, 7),
                                         style: const TextStyle(
-                                          color: colorTextSecondary,
-                                          fontSize: fontSizeSm,
+                                          color: colorTextMuted,
+                                          fontSize: fontSizeXs,
                                         ),
-                                        maxLines: 2,
-                                        overflow: TextOverflow.ellipsis,
                                       ),
+                                      if (m.description != null) ...[
+                                        const SizedBox(height: spaceXxs),
+                                        Text(
+                                          m.description!,
+                                          style: const TextStyle(
+                                            color: colorTextSecondary,
+                                            fontSize: fontSizeSm,
+                                          ),
+                                          maxLines: 2,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                      ],
                                     ],
-                                  ],
+                                  ),
                                 ),
-                              ),
-                              IconButton(
-                                icon: const Icon(
-                                  Icons.edit_outlined,
-                                  size: 18,
-                                  color: colorInteractive,
+                                IconButton(
+                                  icon: const Icon(
+                                    Icons.edit_outlined,
+                                    size: 18,
+                                    color: colorInteractive,
+                                  ),
+                                  onPressed: () => _editMilestone(m),
+                                  visualDensity: VisualDensity.compact,
                                 ),
-                                onPressed: () => _editMilestone(m),
-                                visualDensity: VisualDensity.compact,
-                              ),
-                              IconButton(
-                                icon: const Icon(
-                                  Icons.delete_outline,
-                                  size: 18,
-                                  color: colorTextMuted,
+                                IconButton(
+                                  icon: const Icon(
+                                    Icons.delete_outline,
+                                    size: 18,
+                                    color: colorTextMuted,
+                                  ),
+                                  onPressed: () => _deleteMilestone(m),
+                                  visualDensity: VisualDensity.compact,
                                 ),
-                                onPressed: () => _deleteMilestone(m),
-                                visualDensity: VisualDensity.compact,
-                              ),
-                            ],
-                          ),
-                        );
-                      },
-                    ),
-            ),
+                              ],
+                            ),
+                          );
+                        },
+                      ),
+              ),
           ],
         ),
       ),

--- a/frontend/lib/screens/profile/register_artist_wizard.dart
+++ b/frontend/lib/screens/profile/register_artist_wizard.dart
@@ -663,6 +663,13 @@ class _StepProfile extends StatelessWidget {
                         context: context,
                         builder: (ctx) => AlertDialog(
                           backgroundColor: colorSurface1,
+                          insetPadding: EdgeInsets.only(
+                            left: spaceLg,
+                            right: spaceLg,
+                            top: spaceLg,
+                            bottom:
+                                spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
+                          ),
                           title: Text(
                             context.l10n.createOwnGenre,
                             style: const TextStyle(color: colorTextPrimary),
@@ -1037,6 +1044,13 @@ class _TrackChip extends StatelessWidget {
                       context: context,
                       builder: (ctx) => AlertDialog(
                         backgroundColor: colorSurface1,
+                        insetPadding: EdgeInsets.only(
+                          left: spaceLg,
+                          right: spaceLg,
+                          top: spaceLg,
+                          bottom:
+                              spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
+                        ),
                         title: Text(
                           context.l10n.trackName,
                           style: const TextStyle(color: colorTextPrimary),

--- a/frontend/lib/widgets/timeline/post_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/post_detail_sheet.dart
@@ -1017,6 +1017,12 @@ class _PostDetailContentState extends State<PostDetailContent> {
       builder: (dialogContext) {
         return AlertDialog(
           backgroundColor: colorBorder,
+          insetPadding: EdgeInsets.only(
+            left: spaceLg,
+            right: spaceLg,
+            top: spaceLg,
+            bottom: spaceLg + MediaQuery.of(dialogContext).viewInsets.bottom,
+          ),
           title: Text(
             existing != null
                 ? context.l10n.nameConstellation


### PR DESCRIPTION
## Summary
Phase 0 launch testing on iPhone Safari surfaced two related mobile UX bugs:

1. **Milestone Add button cut off** — the Add form in the EditMilestonesSheet was a static Column without scroll, so when the soft keyboard opened the date picker + Add button dropped below the predictive bar and became unreachable.
2. **Input fields generally covered by soft keyboard + predictive bar** — across several modal dialogs.

## Fix part 1 — milestone form (`edit_milestones_sheet.dart`)

Wrap the Add form in `Expanded(SingleChildScrollView)` and hide the milestones list while the form is open so the form can occupy the full sheet height. The form's bottom padding includes `MediaQuery.viewInsets.bottom` so the Add button stays above the keyboard.

This matches the established pattern used by:
- `edit_profile_sheet.dart`
- `register_artist_sheet.dart`
- `edit_artist_links_sheet.dart`
- `edit_artist_about_sheet.dart`
- `edit_artist_tracks_sheet.dart`
- `edit_artist_genres_sheet.dart`
- `register_artist_wizard.dart`

`edit_milestones_sheet.dart` was the only sheet missing it.

## Fix part 2 — `AlertDialog`s with `TextField` inputs (4 sites)

`AlertDialog` stays vertically centered on screen by default; the keyboard covers it on mobile. Add `insetPadding` with `viewInsets.bottom` to push the dialog up by the keyboard height.

Patched dialogs:
- `edit_milestones_sheet.dart` — edit-milestone dialog
- `register_artist_wizard.dart` — create-genre + track-name dialogs
- `artist_page_screen.dart` — displayName edit dialog
- `post_detail_sheet.dart` — constellation-name dialog

## Verified
- `dart analyze`: clean
- `dart format`: clean

## Test plan
- [ ] Pages auto-deploys
- [ ] iPhone Safari → open Edit Milestones sheet → tap +Add → form scrolls; keyboard pops; Add button stays visible above keyboard; submit works
- [ ] iPhone Safari → tap pencil icon on existing milestone → edit dialog with title input + keyboard → Save button stays visible
- [ ] Same for: register-artist wizard create-genre + track-name flows, artist-page displayName edit, post-detail constellation-name dialog
- [ ] Desktop / iPad: layout unchanged (regression check)

## Out of scope
Other input surfaces (e.g., create-post text fields in a Scaffold body rather than a dialog/sheet) handle the keyboard via Flutter's default `resizeToAvoidBottomInset` and weren't reported as broken. If the user reports additional places we'll patch them as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)