### PR TITLE
feat(frontend): copy-public-link IconButton in Profile AppBar

### DIFF
--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -568,5 +568,14 @@
   "monthNovember": "November",
   "@monthNovember": { "description": "Full name of the eleventh month of the year" },
   "monthDecember": "December",
-  "@monthDecember": { "description": "Full name of the twelfth month of the year" }
+  "@monthDecember": { "description": "Full name of the twelfth month of the year" },
+
+  "copyPublicLink": "Copy public link",
+  "@copyPublicLink": {
+    "description": "Tooltip / accessibility label for the IconButton in the Profile AppBar that copies the artist's public-timeline URL (https://gleisner.app/@username) to the clipboard. Only shown when the user has registered as an artist."
+  },
+  "publicLinkCopied": "Public link copied",
+  "@publicLinkCopied": {
+    "description": "SnackBar message confirming that the artist's public-timeline URL was placed on the clipboard."
+  }
 }

--- a/frontend/lib/l10n/app_ja.arb
+++ b/frontend/lib/l10n/app_ja.arb
@@ -414,5 +414,8 @@
   "monthSeptember": "9月",
   "monthOctober": "10月",
   "monthNovember": "11月",
-  "monthDecember": "12月"
+  "monthDecember": "12月",
+
+  "copyPublicLink": "公開リンクをコピー",
+  "publicLinkCopied": "公開リンクをコピーしました"
 }

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -2329,6 +2329,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'December'**
   String get monthDecember;
+
+  /// Tooltip / accessibility label for the IconButton in the Profile AppBar that copies the artist's public-timeline URL (https://gleisner.app/@username) to the clipboard. Only shown when the user has registered as an artist.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy public link'**
+  String get copyPublicLink;
+
+  /// SnackBar message confirming that the artist's public-timeline URL was placed on the clipboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Public link copied'**
+  String get publicLinkCopied;
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -1253,4 +1253,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get monthDecember => 'December';
+
+  @override
+  String get copyPublicLink => 'Copy public link';
+
+  @override
+  String get publicLinkCopied => 'Public link copied';
 }

--- a/frontend/lib/l10n/app_localizations_ja.dart
+++ b/frontend/lib/l10n/app_localizations_ja.dart
@@ -1214,4 +1214,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get monthDecember => '12月';
+
+  @override
+  String get copyPublicLink => '公開リンクをコピー';
+
+  @override
+  String get publicLinkCopied => '公開リンクをコピーしました';
 }

--- a/frontend/lib/screens/profile/profile_screen.dart
+++ b/frontend/lib/screens/profile/profile_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../graphql/client.dart';
@@ -67,6 +68,14 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           style: const TextStyle(color: colorTextPrimary),
         ),
         actions: [
+          // Public-link copy. Only shown when the user has registered as
+          // an artist — the only path with a public, shareable URL.
+          if (artist != null)
+            IconButton(
+              tooltip: context.l10n.copyPublicLink,
+              icon: const Icon(Icons.link, color: colorTextSecondary),
+              onPressed: () => _copyPublicLink(context, artist.artistUsername),
+            ),
           IconButton(
             icon: const Icon(Icons.edit_outlined, color: colorTextSecondary),
             onPressed: () => _showEditSheet(context, user),
@@ -569,6 +578,25 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
 
   static String _formatJoinDate(BuildContext context, DateTime date) {
     return '${monthShort(context, date.month)} ${date.year}';
+  }
+
+  Future<void> _copyPublicLink(
+    BuildContext context,
+    String artistUsername,
+  ) async {
+    // Build from the running origin so dev/prod and Pages preview URLs
+    // (e.g. <hash>.gleisner.pages.dev) all produce a valid shareable
+    // link without hard-coding gleisner.app.
+    final url = '${Uri.base.origin}/@$artistUsername';
+    await Clipboard.setData(ClipboardData(text: url));
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.publicLinkCopied),
+        duration: const Duration(seconds: 2),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
   }
 
   void _showEditSheet(BuildContext context, User user) {


### PR DESCRIPTION
## Summary
The authenticated artist's own timeline lives at the private `/timeline` route, so copying the address bar URL on `gleisner.app` returns a non-shareable internal link. The public-facing URL is `https://gleisner.app/@<artist_username>` but there was no UI surface to copy it without typing manually.

## Fix
Add an IconButton (link icon, tooltip = "Copy public link") to the Profile AppBar, visible only when the user has registered as an artist (`artist != null`). Tap →

- `Clipboard.setData(ClipboardData(text: '${Uri.base.origin}/@<username>'))`
- Floating SnackBar: 「公開リンクをコピーしました」 / "Public link copied"

URL is built from `Uri.base.origin` so dev / prod / `*.pages.dev` preview URLs all produce a valid link without hardcoding `gleisner.app`.

## i18n
- `app_en.arb`: `copyPublicLink`, `publicLinkCopied`
- `app_ja.arb`: same keys, JA translations
- `flutter gen-l10n` regenerated app_localizations*.dart

## Hit during
Phase 0 family launch — artist (natsukoguitar) wanted to share their public timeline with friends and asked how.

## Test plan
- [ ] As a non-artist user → AppBar has only Edit icon (no link icon)
- [ ] Register as artist → AppBar shows link icon next to Edit
- [ ] Tap link → clipboard contains `https://gleisner.app/@<username>`, SnackBar shows
- [ ] Paste into a new tab / browser → public timeline loads
- [ ] iPhone Safari: same flow works (clipboard + SnackBar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)