### PR TITLE
fix(router): skip /splash bounce for public routes during auth load

### DIFF
--- a/frontend/lib/router.dart
+++ b/frontend/lib/router.dart
@@ -45,14 +45,20 @@ final routerProvider = Provider<GoRouter>((ref) {
       final path = state.uri.path;
       final status = authNotifier.value;
 
-      if (status == AuthStatus.loading) {
-        return path == '/splash' ? null : '/splash';
-      }
-
       final isAuthRoute = path == '/login' || path == '/signup';
       final isPublicProfile = _publicProfilePattern.hasMatch(path);
       final isPublicPage = path == '/about' || path == '/discover';
       final isOnboarding = path == '/onboarding';
+
+      if (status == AuthStatus.loading) {
+        // Public routes render without auth — skip the splash bounce so
+        // the original URL isn't lost. Otherwise an unauthenticated visitor
+        // landing on /@username would be redirected to /splash, then once
+        // auth resolves the redirect re-runs with path == /splash (no
+        // memory of /@username) and falls through to /login.
+        if (isAuthRoute || isPublicProfile || isPublicPage) return null;
+        return path == '/splash' ? null : '/splash';
+      }
 
       if (status == AuthStatus.unauthenticated) {
         return (isAuthRoute || isPublicProfile || isPublicPage)


### PR DESCRIPTION
## Summary
Opening `https://gleisner.app/@<username>` in an unauthenticated browser landed on the login page instead of the public artist timeline.

## Root cause
Two-stage redirect that lost the original URL:

1. Initial navigation: path = `/@username`, `AuthStatus = loading` → redirect returns `/splash` → URL changes
2. Auth state resolves to `unauthenticated` → redirect re-runs, but `state.uri.path` is now `/splash` (the original `/@username` is gone)
3. `/splash` is not an auth route or public route → falls through to `'/login'`

## Fix
Compute the `isPublicProfile` / `isPublicPage` / `isAuthRoute` flags **before** the loading branch and short-circuit the splash bounce for any path that doesn't depend on auth resolving:

```dart
if (status == AuthStatus.loading) {
  if (isAuthRoute || isPublicProfile || isPublicPage) return null;
  return path == '/splash' ? null : '/splash';
}
```

Public timelines (`/@username`), `/about`, `/discover`, and the auth screens (`/login`, `/signup`) now render directly without detouring through `/splash` — the URL the visitor opened is the URL they see.

## Hit during
Phase 0 launch testing — artist tried to share a public timeline link and friends saw the login wall instead.

## Test plan
- [ ] Pages auto-deploys
- [ ] Open `https://gleisner.app/@natsukoguitar` in a private/incognito window → public artist timeline renders, no login wall
- [ ] Open `https://gleisner.app/about` in a private window → about page renders
- [ ] Open `https://gleisner.app/discover` in a private window → discover renders
- [ ] Open `https://gleisner.app/timeline` in a private window → still redirects to `/login` (regression check — private routes still gated)
- [ ] Authenticated session → `/@username` still works (regression check)
- [ ] Authenticated session → `/login` still redirects to `/timeline` (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)