### PR TITLE
fix(frontend): move share button from Profile to artist pages

### DIFF
--- a/frontend/lib/screens/artist/artist_page_screen.dart
+++ b/frontend/lib/screens/artist/artist_page_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -179,6 +180,22 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
                             ),
                             onPressed: () => context.pop(),
                           ),
+                          // Public-link copy. Shown for every artist
+                          // (own + others, authenticated + visitor) so
+                          // anyone can share the page.
+                          actions: [
+                            IconButton(
+                              tooltip: context.l10n.copyPublicLink,
+                              icon: const Icon(
+                                Icons.link,
+                                color: colorTextPrimary,
+                              ),
+                              onPressed: () => _copyPublicLink(
+                                context,
+                                artist.artistUsername,
+                              ),
+                            ),
+                          ],
                           flexibleSpace: FlexibleSpaceBar(
                             background: Stack(
                               fit: StackFit.expand,
@@ -801,6 +818,25 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
                 ],
               ],
             ),
+    );
+  }
+
+  Future<void> _copyPublicLink(
+    BuildContext context,
+    String artistUsername,
+  ) async {
+    // Build from the running origin so dev/prod and *.pages.dev
+    // preview URLs all produce a valid shareable link without
+    // hard-coding gleisner.app.
+    final url = '${Uri.base.origin}/@$artistUsername';
+    await Clipboard.setData(ClipboardData(text: url));
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.publicLinkCopied),
+        duration: const Duration(seconds: 2),
+        behavior: SnackBarBehavior.floating,
+      ),
     );
   }
 

--- a/frontend/lib/screens/profile/profile_screen.dart
+++ b/frontend/lib/screens/profile/profile_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../graphql/client.dart';
@@ -68,14 +67,6 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           style: const TextStyle(color: colorTextPrimary),
         ),
         actions: [
-          // Public-link copy. Only shown when the user has registered as
-          // an artist — the only path with a public, shareable URL.
-          if (artist != null)
-            IconButton(
-              tooltip: context.l10n.copyPublicLink,
-              icon: const Icon(Icons.link, color: colorTextSecondary),
-              onPressed: () => _copyPublicLink(context, artist.artistUsername),
-            ),
           IconButton(
             icon: const Icon(Icons.edit_outlined, color: colorTextSecondary),
             onPressed: () => _showEditSheet(context, user),
@@ -578,25 +569,6 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
 
   static String _formatJoinDate(BuildContext context, DateTime date) {
     return '${monthShort(context, date.month)} ${date.year}';
-  }
-
-  Future<void> _copyPublicLink(
-    BuildContext context,
-    String artistUsername,
-  ) async {
-    // Build from the running origin so dev/prod and Pages preview URLs
-    // (e.g. <hash>.gleisner.pages.dev) all produce a valid shareable
-    // link without hard-coding gleisner.app.
-    final url = '${Uri.base.origin}/@$artistUsername';
-    await Clipboard.setData(ClipboardData(text: url));
-    if (!context.mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(context.l10n.publicLinkCopied),
-        duration: const Duration(seconds: 2),
-        behavior: SnackBarBehavior.floating,
-      ),
-    );
   }
 
   void _showEditSheet(BuildContext context, User user) {

--- a/frontend/lib/screens/timeline/public_timeline_screen.dart
+++ b/frontend/lib/screens/timeline/public_timeline_screen.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
@@ -121,6 +122,13 @@ class _PublicTimelineScreenState extends ConsumerState<PublicTimelineScreen>
           ],
         ),
         actions: [
+          // Public-link copy. Visible to everyone — visitors share the
+          // page they're already looking at, owner shares their own.
+          IconButton(
+            tooltip: context.l10n.copyPublicLink,
+            icon: const Icon(Icons.link, color: colorTextPrimary),
+            onPressed: () => _copyPublicLink(context, widget.username),
+          ),
           // Tune In button (ADR 013) — not shown on own timeline
           if (isAuthenticated && artistId != null && !isSelf)
             Padding(
@@ -430,6 +438,25 @@ class _PublicTimelineScreenState extends ConsumerState<PublicTimelineScreen>
 
     if (focusedNode != null) nodes.add(focusedNode);
     return nodes;
+  }
+
+  Future<void> _copyPublicLink(
+    BuildContext context,
+    String artistUsername,
+  ) async {
+    // Build from the running origin so dev/prod and *.pages.dev
+    // preview URLs all produce a valid shareable link without
+    // hard-coding gleisner.app.
+    final url = '${Uri.base.origin}/@$artistUsername';
+    await Clipboard.setData(ClipboardData(text: url));
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.publicLinkCopied),
+        duration: const Duration(seconds: 2),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
   }
 
   void _handleNodeTap(String postId) {


### PR DESCRIPTION
## Summary
The shareable URL **is** the artist page (`/@<username>`), so the copy button belongs there, not on Profile. Moving it also makes it available to visitors who want to spread the link, not just the artist viewing their own Profile (per user feedback during Phase 0 launch testing).

## Changes
- **Remove** the share button + `_copyPublicLink` helper from `profile_screen.dart` (added in PR #320)
- **Add** share button to `artist_page_screen.dart` `SliverAppBar.actions` (authenticated path: `/artist/:username`, opened from Discover)
- **Add** share button to `public_timeline_screen.dart` `AppBar.actions` (unauthenticated path: `/@:username`, the actual share target)

Both pages render the same artist profile from different routes; patching both ensures the button is present whether the visitor is authenticated (Discover → artist page) or arrived via the shared link.

## i18n
Reuses the existing `copyPublicLink` / `publicLinkCopied` keys added in PR #320 — no new strings needed.

## Test plan
- [ ] Pages auto-deploys
- [ ] Profile screen: AppBar has only the Edit icon (regression — share button gone)
- [ ] Discover → tap artist tile (authenticated) → SliverAppBar shows link icon → copy → paste in new tab → public timeline loads
- [ ] Open `https://gleisner.app/@natsukoguitar` in incognito → AppBar shows link icon → copy → paste back → still works
- [ ] Tooltip on hover: 「公開リンクをコピー」 / "Copy public link"
- [ ] SnackBar after copy: 「公開リンクをコピーしました」 / "Public link copied"

🤖 Generated with [Claude Code](https://claude.com/claude-code)