### PR TITLE
fix(frontend): switch to path URL strategy so /@username opens directly

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,11 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'app.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  // Use HTML5 history API (clean URL paths) instead of Flutter Web's
+  // default hash strategy. Without this, https://gleisner.app/@username
+  // opens at GoRouter's initialLocation (/splash) because hash routing
+  // doesn't read the URL path portion — shared public-timeline links
+  // would land on /login. usePathUrlStrategy is a no-op on non-Web
+  // platforms so this stays safe if we ever target iOS/Android.
+  usePathUrlStrategy();
   await initHiveForFlutter();
   runApp(const ProviderScope(child: GleisnerApp()));
 }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -414,7 +414,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -668,6 +668,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -728,18 +736,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1109,26 +1117,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -32,6 +32,8 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
   intl: any
 
   cupertino_icons: ^1.0.9


### PR DESCRIPTION
## Summary
Flutter Web's default URL strategy is **hash-based** (`#/path`). When a visitor opens `https://gleisner.app/@natsukoguitar`, hash routing ignores the path portion entirely — GoRouter falls back to `initialLocation: '/splash'`, the auth-loading branch keeps it there, and once auth resolves to unauthenticated the redirect runs with `path == '/splash'` (not `/@natsukoguitar`) and lands on `/login`.

PR #321 made the redirect logic itself correct; this PR makes the URL **reach** the redirect logic.

## Fix
Call `usePathUrlStrategy()` before `runApp()` so GoRouter reads the browser's actual URL on first paint:

```dart
import 'package:flutter_web_plugins/url_strategy.dart';

void main() async {
  WidgetsFlutterBinding.ensureInitialized();
  usePathUrlStrategy();  // ← HTML5 history API instead of #/...
  await initHiveForFlutter();
  runApp(const ProviderScope(child: GleisnerApp()));
}
```

`flutter_web_plugins` added to pubspec dependencies (was an implicit SDK package; declared explicitly so pub doesn't complain). `usePathUrlStrategy` is a no-op on non-Web platforms so this stays safe if we ever target iOS/Android.

## Hit during
Phase 0 launch testing — natsukoguitar shared her public-timeline link with friends and they hit the login wall instead of her artist page.

## Test plan
- [ ] Pages auto-deploys
- [ ] Open `https://gleisner.app/@natsukoguitar` in **incognito/private** window → public artist timeline renders directly
- [ ] Open `https://gleisner.app/about` in incognito → about page renders
- [ ] Open `https://gleisner.app/timeline` in incognito → still redirects to /login (regression)
- [ ] Authenticated session: bookmarks of `/timeline`, `/discover`, `/profile`, `/@username` all work
- [ ] After this lands, the URL bar shows clean paths (`/discover`, `/@user`) instead of `#/discover`, `#/@user`

## Cloudflare Pages routing
Pages already serves `index.html` for any unmatched path (SPA fallback), so no `_routes.json` change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)