### PR TITLE
fix(frontend): make 'Discover More Artists' banner text link to /discover

### DIFF
--- a/frontend/lib/screens/timeline/public_timeline_screen.dart
+++ b/frontend/lib/screens/timeline/public_timeline_screen.dart
@@ -344,9 +344,19 @@ class _PublicTimelineScreenState extends ConsumerState<PublicTimelineScreen>
                   ),
                   const SizedBox(width: spaceMd),
                   Expanded(
-                    child: Text(
-                      context.l10n.discoverMoreArtists,
-                      style: textHeading.copyWith(fontSize: 13),
+                    child: InkWell(
+                      onTap: () => context.go('/discover'),
+                      borderRadius: BorderRadius.circular(radiusSm),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: spaceXs),
+                        child: Text(
+                          context.l10n.discoverMoreArtists,
+                          style: textHeading.copyWith(
+                            fontSize: 13,
+                            color: colorInteractive,
+                          ),
+                        ),
+                      ),
                     ),
                   ),
                   FilledButton.tonal(


### PR DESCRIPTION
## Summary
The "もっとアーティストを探す" / "Discover More Artists" text on the unauthenticated public-timeline banner was a plain `Text` widget with no tap handler. It looked like a CTA but tapping it did nothing. `/discover` is already a public route (router allows unauthenticated access) so linking there is the right destination.

## Fix
Wrap the `Text` in an `InkWell` that navigates to `/discover`:

```dart
Expanded(
  child: InkWell(
    onTap: () => context.go('/discover'),
    borderRadius: BorderRadius.circular(radiusSm),
    child: Padding(
      padding: const EdgeInsets.symmetric(vertical: spaceXs),
      child: Text(
        context.l10n.discoverMoreArtists,
        style: textHeading.copyWith(
          fontSize: 13,
          color: colorInteractive,  // affordance: matches Sign Up / Login buttons
        ),
      ),
    ),
  ),
),
```

- Vertical padding gives a comfortable tap target on mobile
- `colorInteractive` text tint signals it's interactive

## Hit during
Phase 0 launch testing — visitor on natsukoguitar's public page reported the prompt was visible but unresponsive.

## Test plan
- [ ] Pages auto-deploys
- [ ] Open `https://gleisner.app/@natsukoguitar` in incognito → banner visible
- [ ] Tap the "Discover More Artists" text → navigates to /discover
- [ ] Sign Up / Login buttons next to it still work (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)