### PR TITLE
fix(frontend): keep form inputs above the soft keyboard in sheets and dialogs

### DIFF
--- a/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
@@ -26,18 +26,53 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
   String? _error;
   final _nameController = TextEditingController();
   final _addFormKey = GlobalKey<FormState>();
+  late final FocusNode _nameFocusNode;
+  bool _focusScrollPending = false;
   ScrollController? _scrollController;
 
   @override
   void initState() {
     super.initState();
     _tracks = List.from(widget.artist.tracks);
+    _nameFocusNode = FocusNode()
+      // Keep the input visible above the soft keyboard. Inside a
+      // DraggableScrollableSheet, Flutter's default focus auto-scroll is
+      // unreliable: the initial scroll-to-bottom runs before the keyboard
+      // appears, so the form ends up hidden behind the IME on the first
+      // focus. Re-running animateTo on focus uses the post-keyboard
+      // maxScrollExtent and reveals the field.
+      ..addListener(_handleNameFocusChanged);
   }
 
   @override
   void dispose() {
+    _nameFocusNode
+      ..removeListener(_handleNameFocusChanged)
+      ..dispose();
     _nameController.dispose();
     super.dispose();
+  }
+
+  void _handleNameFocusChanged() {
+    if (!_nameFocusNode.hasFocus || !_showAddForm) return;
+    // Guard against re-entrancy: focus events can fire several times in
+    // quick succession while the soft keyboard animates in, and we only
+    // need a single animateTo per burst. Without this, multiple concurrent
+    // animateTo calls compete inside the DraggableScrollableSheet.
+    if (_focusScrollPending) return;
+    final controller = _scrollController;
+    if (controller == null || !controller.hasClients) return;
+    _focusScrollPending = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusScrollPending = false;
+      if (!mounted) return;
+      if (!controller.hasClients) return;
+      controller.animateTo(
+        controller.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    });
   }
 
   Future<void> _addTrack() async {
@@ -243,6 +278,7 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
                       const SizedBox(height: spaceMd),
                       TextFormField(
                         controller: _nameController,
+                        focusNode: _nameFocusNode,
                         maxLength: 30,
                         style: const TextStyle(color: colorTextPrimary),
                         decoration: InputDecoration(

--- a/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
@@ -27,6 +27,13 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
   final _nameController = TextEditingController();
   final _addFormKey = GlobalKey<FormState>();
   late final FocusNode _nameFocusNode;
+
+  /// True while a focus-driven scroll-to-bottom is in flight. Set when an
+  /// animateTo is queued, cleared inside `whenComplete` once the animation
+  /// finishes (or via the early-out paths). Guards against concurrent
+  /// animateTo calls when focus events fire repeatedly during the keyboard
+  /// slide-in animation, and prevents reuse of a stale post-frame callback
+  /// after dispose.
   bool _focusScrollPending = false;
   ScrollController? _scrollController;
 
@@ -64,14 +71,29 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
     if (controller == null || !controller.hasClients) return;
     _focusScrollPending = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _focusScrollPending = false;
-      if (!mounted) return;
-      if (!controller.hasClients) return;
-      controller.animateTo(
-        controller.position.maxScrollExtent,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeOut,
-      );
+      if (!mounted) {
+        // Widget was disposed before the post-frame callback ran. Reset the
+        // flag in case the State is somehow reused; mounted is false after
+        // dispose so any further focus events would early-out anyway.
+        _focusScrollPending = false;
+        return;
+      }
+      if (!controller.hasClients) {
+        _focusScrollPending = false;
+        return;
+      }
+      controller
+          .animateTo(
+            controller.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 220),
+            curve: Curves.easeOutCubic,
+          )
+          .whenComplete(() {
+            // Release the guard only after animateTo settles, so a focus
+            // event arriving mid-animation does not schedule a second one.
+            // Skip the reset if we were disposed during the animation.
+            if (mounted) _focusScrollPending = false;
+          });
     });
   }
 

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -419,8 +419,18 @@ class _TrackStep extends ConsumerWidget {
         }
 
         return StatefulBuilder(
-          builder: (context, setDialogState) {
+          builder: (ctx, setDialogState) {
             return AlertDialog(
+              // AlertDialog is centered by default and gets covered by the
+              // soft keyboard + predictive bar on iPhone Safari. Push it up
+              // by the keyboard height so the input and Create button stay
+              // visible while typing.
+              insetPadding: EdgeInsets.only(
+                left: spaceLg,
+                right: spaceLg,
+                top: spaceLg,
+                bottom: spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
+              ),
               title: Text(l10n.newTrack),
               content: Column(
                 mainAxisSize: MainAxisSize.min,
@@ -452,7 +462,7 @@ class _TrackStep extends ConsumerWidget {
                       const SizedBox(width: spaceSm),
                       Text(
                         l10n.colorAutoAssigned,
-                        style: Theme.of(context).textTheme.labelSmall,
+                        style: Theme.of(ctx).textTheme.labelSmall,
                       ),
                     ],
                   ),

--- a/frontend/lib/screens/profile/create_child_sheet.dart
+++ b/frontend/lib/screens/profile/create_child_sheet.dart
@@ -48,7 +48,15 @@ class _CreateChildSheetState extends ConsumerState<CreateChildSheet> {
           key: _formKey,
           child: ListView(
             controller: scrollController,
-            padding: const EdgeInsets.all(spaceXl),
+            // Add viewInsets.bottom so the password field at the bottom of
+            // the form stays above the soft keyboard. Matches the pattern
+            // used in edit_artist_links_sheet, edit_milestones_sheet, etc.
+            padding: EdgeInsets.fromLTRB(
+              spaceXl,
+              spaceXl,
+              spaceXl,
+              spaceXl + MediaQuery.of(context).viewInsets.bottom,
+            ),
             children: [
               Center(
                 child: Container(

--- a/frontend/lib/screens/profile/profile_screen.dart
+++ b/frontend/lib/screens/profile/profile_screen.dart
@@ -437,8 +437,15 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           top: spaceLg,
           bottom: spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
         ),
+        // All l10n lookups inside the dialog use the builder's `ctx` rather
+        // than the outer `_showDeleteAccountDialog` `context`. The outer
+        // context can become stale during deletion: authProvider.deleteAccount
+        // logs out, the router redirects to /login, and the parent Profile
+        // widget is unmounted while this AlertDialog is still on screen.
+        // The outer `context` is reserved for post-dialog `mounted` checks
+        // and ScaffoldMessenger.of(context) below.
         title: Text(
-          context.l10n.deleteAccountConfirmTitle,
+          ctx.l10n.deleteAccountConfirmTitle,
           style: const TextStyle(color: colorTextPrimary),
         ),
         content: Column(
@@ -446,7 +453,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              context.l10n.cannotBeUndone,
+              ctx.l10n.cannotBeUndone,
               style: const TextStyle(
                 color: colorTextPrimary,
                 fontWeight: weightSemibold,
@@ -454,12 +461,12 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
             ),
             const SizedBox(height: spaceSm),
             Text(
-              context.l10n.deleteAccountWarning,
+              ctx.l10n.deleteAccountWarning,
               style: const TextStyle(color: colorTextSecondary),
             ),
             const SizedBox(height: spaceXs),
             Text(
-              context.l10n.deleteAccountDetails,
+              ctx.l10n.deleteAccountDetails,
               style: const TextStyle(
                 color: colorTextSecondary,
                 fontSize: fontSizeSm,
@@ -471,7 +478,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
               controller: passwordController,
               obscureText: true,
               decoration: InputDecoration(
-                labelText: context.l10n.enterPasswordToConfirm,
+                labelText: ctx.l10n.enterPasswordToConfirm,
                 border: const OutlineInputBorder(),
               ),
             ),
@@ -480,12 +487,12 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
-            child: Text(context.l10n.cancel),
+            child: Text(ctx.l10n.cancel),
           ),
           TextButton(
             onPressed: () => Navigator.pop(ctx, true),
             child: Text(
-              context.l10n.deleteAccount,
+              ctx.l10n.deleteAccount,
               style: const TextStyle(color: colorError),
             ),
           ),

--- a/frontend/lib/screens/profile/profile_screen.dart
+++ b/frontend/lib/screens/profile/profile_screen.dart
@@ -427,6 +427,16 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
       context: context,
       builder: (ctx) => AlertDialog(
         backgroundColor: colorSurface1,
+        // AlertDialog is centered by default and gets covered by the soft
+        // keyboard + predictive bar on iPhone Safari. Push it up by the
+        // keyboard height so the password field and Delete button stay
+        // visible while typing.
+        insetPadding: EdgeInsets.only(
+          left: spaceLg,
+          right: spaceLg,
+          top: spaceLg,
+          bottom: spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
+        ),
         title: Text(
           context.l10n.deleteAccountConfirmTitle,
           style: const TextStyle(color: colorTextPrimary),

--- a/frontend/lib/widgets/common/related_post_picker.dart
+++ b/frontend/lib/widgets/common/related_post_picker.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../l10n/l10n.dart';
 import '../../models/post.dart';
 import '../../models/track.dart' show parseHexColor;
+import '../../theme/gleisner_tokens.dart';
 
 /// Bottom sheet picker for selecting a related post.
 class RelatedPostPicker extends StatefulWidget {
@@ -153,7 +154,13 @@ class _RelatedPostPickerState extends State<RelatedPostPicker> {
                     )
                   : SingleChildScrollView(
                       controller: scrollController,
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      // Reserve space for the soft keyboard so the search
+                      // field above stays visible while typing.
+                      padding: EdgeInsets.only(
+                        left: spaceLg,
+                        right: spaceLg,
+                        bottom: MediaQuery.of(context).viewInsets.bottom,
+                      ),
                       child: Wrap(
                         spacing: 8,
                         runSpacing: 8,


### PR DESCRIPTION
## 背景・症状

本番で「アーティスト編集 → トラック追加」のフローでトラック名入力欄が iOS/Android のソフトウェアキーボードに完全に隠れる問題が発生。同種問題は過去に他の sheet (edit_milestones_sheet / edit_profile_sheet / register_artist_sheet / post_detail_sheet 等) で `MediaQuery.viewInsets.bottom` を padding に追加して解決済みだったが、`DraggableScrollableSheet + ListView` 内でフォームを動的展開して TextField を置くパターン（edit_artist_tracks）では、padding は入っていても TextField フォーカス時のスクロール再計算が効かず、依然として隠れていた。

報告は 1 箇所だけだったが、横断点検の結果、追加で 4 箇所が同種バグ／予防修正対象だったため同 PR でまとめて修正。

## 根本原因

`DraggableScrollableSheet` 内では Flutter 標準の TextField フォーカス時 auto-scroll が効きにくい。フォーム展開時の `addPostFrameCallback` での `animateTo(maxScrollExtent)` は一度しか走らず、キーボード表示後の再レイアウト位置を反映できない。

加えて `AlertDialog` は中央寄せがデフォルトで `resizeToAvoidBottomInset` の恩恵を受けず、`insetPadding` 未指定だとキーボード上に押し上げられない。

## 変更内容

| ファイル | 修正 |
|---|---|
| `frontend/lib/screens/artist/edit_artist_tracks_sheet.dart` | `FocusNode` を `initState/dispose` で管理。フォーカス時に `_scrollController.animateTo(maxScrollExtent)` を再実行し、`_focusScrollPending` フラグで二重発火を防止 |
| `frontend/lib/screens/profile/create_child_sheet.dart` | ListView padding に `MediaQuery.viewInsets.bottom` を加算（password field が隠れていた） |
| `frontend/lib/widgets/common/related_post_picker.dart` | SingleChildScrollView padding に `viewInsets.bottom` を加算。ついでに `16` ハードコードを `spaceLg` トークンに統一 |
| `frontend/lib/screens/create_post/create_post_screen.dart` | 新規トラック作成 AlertDialog に `insetPadding`（`edit_milestones_sheet` パターン）。StatefulBuilder builder を `(ctx, ...)` に統一 |
| `frontend/lib/screens/profile/profile_screen.dart` | アカウント削除確認 AlertDialog に同様の `insetPadding` |

## 点検した sheet 一覧

横断点検（`DraggableScrollableSheet` / `showModalBottomSheet` / `AlertDialog` + `TextField` 系）:

- ✅ 既に対応済み: `edit_milestones_sheet`, `edit_profile_sheet`, `register_artist_sheet`, `post_detail_sheet`, `edit_artist_links_sheet`, `edit_artist_genres_sheet`, `edit_artist_about_sheet`, `register_artist_wizard`, `login_screen`, `signup_screen`, `create_post_screen`(本体), `edit_post_screen`, `discover_screen`, `link_form_fields`(共通 widget)
- ⚠️ 本 PR で対応: `edit_artist_tracks_sheet`, `create_child_sheet`, `related_post_picker`, `create_post_screen`(track AlertDialog), `profile_screen`(delete AlertDialog)

## Before / After

- Before: 入力欄にフォーカスすると、ソフトウェアキーボードが入力欄を完全に覆い、何を入力しているか見えない。送信ボタンも隠れる
- After: フォーカス時に画面が自動スクロール、または Dialog がキーボード分上に押し上げられて入力欄と送信ボタンが常に可視

## 手動検証手順

| 環境 | 検証フロー | 期待挙動 |
|---|---|---|
| iOS Safari (本番) | アーティスト編集 → 「トラック追加」→ 名前入力 | 入力欄と Add ボタンがキーボードの上に出ている |
| iOS Safari | プロフィール → アカウント削除 → パスワード入力 | パスワード欄と Delete ボタンが見える |
| iOS Safari | 投稿作成 → 新規トラック作成 ダイアログ → 名前入力 | 入力欄と Create ボタンが見える |
| iOS Safari | 投稿編集/作成 → 関連投稿 picker → 検索入力 | 検索欄と一部リストが見える |
| iOS Safari | プロフィール → 子アカウント追加 → 各フィールド入力 | 全フィールド（特にパスワード）と Create ボタンが見える |
| Android Chrome | 同上の各シナリオ | 同上 |
| Web Chrome | 同上の各シナリオ（仮想キーボード or DevTools のレスポンシブ表示） | 同上 |

## 検証

- ✅ `mise run lint_check` (frontend 全体: analyze 0 issues + format check)
- ✅ `mise run test` (Chrome: 318/318 passed)
- ✅ `dart analyze` 修正ファイル全 5 個: No issues found
- ✅ `dart format --set-exit-if-changed`: 整形差分なし
- ✅ Multi-agent review (security / Flutter UI / GraphQL) → synthesis-reviewer 「マージ可能」「Critical/Important 該当なし」

## レビューで挙がった PR スコープ外の指摘（別 Issue 化予定）

本 PR に直接起因しないが、レビューで併発的に指摘された既存コードの改善ポイント:

1. `create_child_sheet.dart` の guardian password が空チェックのみで最小長検証がない → Phase 1 までに 8 文字以上などのバリデーション追加
2. `profile_screen.dart` で `passwordController.dispose()` 前に `clear()` を呼んで平文を即時消去（防御深化）
3. backend `deleteAccount` resolver の `MAX_PASSWORD_LENGTH` チェック欠落（`createChildAccount` には存在）

Issue 化してフォローします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)