### PR TITLE
fix(frontend): replace MediaQuery.viewInsets.bottom with cross-checked KeyboardHeight on iOS Safari

### DIFF
--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -10,6 +10,7 @@ import 'l10n/l10n.dart';
 import 'theme/gleisner_tokens.dart';
 import 'router.dart';
 import 'utils/keyboard_debug_overlay.dart';
+import 'utils/keyboard_height_observer.dart';
 
 // Cache theme data to avoid rebuilding on every frame.
 final _darkTextTheme = ThemeData.dark().textTheme;
@@ -49,12 +50,18 @@ class GleisnerApp extends ConsumerWidget {
         debugShowCheckedModeBanner: false,
         theme: _gleisnerTheme,
         routerConfig: router,
-        // Diagnostics overlay for the iPhone Safari soft-keyboard issue.
-        // Active only when the URL contains `?debug=keyboard`. Pass-through
-        // (single child) when the flag is absent. Remove together with
-        // `keyboard_debug_overlay.dart` once the root cause is fixed.
-        builder: (context, child) =>
-            KeyboardDebugOverlay(child: child ?? const SizedBox.shrink()),
+        // Two layers, both gated:
+        //   - KeyboardHeightObserver (outer) provides a cross-checked
+        //     soft-keyboard height via `KeyboardHeight.of(context)`. Active
+        //     for all screens.
+        //   - KeyboardDebugOverlay (inner) draws a diagnostics panel on top
+        //     of every screen, but only when the URL has `?debug=keyboard`.
+        //     Pass-through otherwise (no behavior change for normal users).
+        // Inner placement lets the overlay itself read KeyboardHeight if we
+        // later extend it to display that value too.
+        builder: (context, child) => KeyboardHeightObserver(
+          child: KeyboardDebugOverlay(child: child ?? const SizedBox.shrink()),
+        ),
         localizationsDelegates: [
           AppLocalizations.delegate,
           GlobalMaterialLocalizations.delegate,

--- a/frontend/lib/screens/artist/artist_page_screen.dart
+++ b/frontend/lib/screens/artist/artist_page_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../l10n/l10n.dart';
+import '../../utils/keyboard_height_observer.dart';
 import '../../utils/open_url.dart';
 
 import '../../models/artist.dart';
@@ -998,7 +999,7 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
               left: spaceLg,
               right: spaceLg,
               top: spaceLg,
-              bottom: spaceLg + MediaQuery.of(context).viewInsets.bottom,
+              bottom: spaceLg + KeyboardHeight.of(context),
             ),
             title: Text(
               context.l10n.displayName,

--- a/frontend/lib/screens/artist/edit_artist_about_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_about_sheet.dart
@@ -6,6 +6,7 @@ import '../../providers/artist_page_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/edit_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
+import '../../utils/keyboard_height_observer.dart';
 
 class EditArtistAboutSheet extends ConsumerStatefulWidget {
   final Artist artist;
@@ -109,7 +110,7 @@ class _EditArtistAboutSheetState extends ConsumerState<EditArtistAboutSheet> {
               spaceXl,
               spaceLg,
               spaceXl,
-              spaceXl + MediaQuery.of(context).viewInsets.bottom,
+              spaceXl + KeyboardHeight.of(context),
             ),
             child: Column(
               mainAxisSize: MainAxisSize.min,

--- a/frontend/lib/screens/artist/edit_artist_genres_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_genres_sheet.dart
@@ -10,6 +10,7 @@ import '../../providers/artist_page_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/edit_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
+import '../../utils/keyboard_height_observer.dart';
 
 class EditArtistGenresSheet extends ConsumerStatefulWidget {
   final Artist artist;
@@ -146,7 +147,7 @@ class _EditArtistGenresSheetState extends ConsumerState<EditArtistGenresSheet> {
               spaceXl,
               spaceLg,
               spaceXl,
-              spaceXl + MediaQuery.of(context).viewInsets.bottom,
+              spaceXl + KeyboardHeight.of(context),
             ),
             children: [
               Center(

--- a/frontend/lib/screens/artist/edit_artist_links_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_links_sheet.dart
@@ -6,6 +6,7 @@ import '../../providers/artist_page_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/edit_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
+import '../../utils/keyboard_height_observer.dart';
 
 const _linkCategories = [
   'music',
@@ -151,7 +152,7 @@ class _EditArtistLinksSheetState extends ConsumerState<EditArtistLinksSheet> {
               spaceXl,
               spaceLg,
               spaceXl,
-              spaceXl + MediaQuery.of(context).viewInsets.bottom,
+              spaceXl + KeyboardHeight.of(context),
             ),
             children: [
               // Handle bar

--- a/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
@@ -8,6 +8,7 @@ import '../../providers/edit_artist_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/unassigned_posts_provider.dart';
 import '../../theme/gleisner_tokens.dart';
+import '../../utils/keyboard_height_observer.dart';
 
 class EditArtistTracksSheet extends ConsumerStatefulWidget {
   final Artist artist;
@@ -201,7 +202,7 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
               spaceXl,
               spaceLg,
               spaceXl,
-              spaceXl + MediaQuery.of(context).viewInsets.bottom,
+              spaceXl + KeyboardHeight.of(context),
             ),
             children: [
               Center(

--- a/frontend/lib/screens/artist/edit_milestones_sheet.dart
+++ b/frontend/lib/screens/artist/edit_milestones_sheet.dart
@@ -6,6 +6,7 @@ import '../../providers/artist_page_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/edit_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
+import '../../utils/keyboard_height_observer.dart';
 import '../../utils/milestone_category.dart';
 
 class EditMilestonesSheet extends ConsumerStatefulWidget {
@@ -155,7 +156,7 @@ class _EditMilestonesSheetState extends ConsumerState<EditMilestonesSheet> {
             left: spaceLg,
             right: spaceLg,
             top: spaceLg,
-            bottom: spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
+            bottom: spaceLg + KeyboardHeight.of(ctx),
           ),
           title: Text(
             context.l10n.editMilestone,
@@ -375,7 +376,7 @@ class _EditMilestonesSheetState extends ConsumerState<EditMilestonesSheet> {
                     // it here keeps the Add button above the keyboard
                     // (matches the pattern in edit_profile_sheet,
                     // register_artist_wizard, etc.).
-                    bottom: spaceLg + MediaQuery.of(context).viewInsets.bottom,
+                    bottom: spaceLg + KeyboardHeight.of(context),
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -12,6 +12,7 @@ import '../../providers/create_post_provider.dart';
 import '../../providers/timeline_provider.dart';
 import '../../utils/constellation_layout.dart';
 import '../../utils/ime_safe_focus.dart';
+import '../../utils/keyboard_height_observer.dart';
 import '../../widgets/common/connection_type_picker.dart';
 import '../../widgets/common/error_banner.dart';
 import '../../widgets/common/event_at_picker.dart';
@@ -429,7 +430,7 @@ class _TrackStep extends ConsumerWidget {
                 left: spaceLg,
                 right: spaceLg,
                 top: spaceLg,
-                bottom: spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
+                bottom: spaceLg + KeyboardHeight.of(ctx),
               ),
               title: Text(l10n.newTrack),
               content: Column(

--- a/frontend/lib/screens/profile/create_child_sheet.dart
+++ b/frontend/lib/screens/profile/create_child_sheet.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/guardian_provider.dart';
 import '../../theme/gleisner_tokens.dart';
+import '../../utils/keyboard_height_observer.dart';
 
 class CreateChildSheet extends ConsumerStatefulWidget {
   const CreateChildSheet({super.key});
@@ -55,7 +56,7 @@ class _CreateChildSheetState extends ConsumerState<CreateChildSheet> {
               spaceXl,
               spaceXl,
               spaceXl,
-              spaceXl + MediaQuery.of(context).viewInsets.bottom,
+              spaceXl + KeyboardHeight.of(context),
             ),
             children: [
               Center(

--- a/frontend/lib/screens/profile/edit_profile_sheet.dart
+++ b/frontend/lib/screens/profile/edit_profile_sheet.dart
@@ -5,6 +5,7 @@ import '../../l10n/l10n.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/media_upload_provider.dart';
 import '../../theme/gleisner_tokens.dart';
+import '../../utils/keyboard_height_observer.dart';
 import '../../widgets/media/avatar_image.dart';
 
 class EditProfileSheet extends ConsumerStatefulWidget {
@@ -127,7 +128,7 @@ class _EditProfileSheetState extends ConsumerState<EditProfileSheet> {
                 spaceXl,
                 spaceLg,
                 spaceXl,
-                spaceXl + MediaQuery.of(context).viewInsets.bottom,
+                spaceXl + KeyboardHeight.of(context),
               ),
               children: [
                 // Handle bar

--- a/frontend/lib/screens/profile/profile_screen.dart
+++ b/frontend/lib/screens/profile/profile_screen.dart
@@ -15,6 +15,7 @@ import '../../providers/tutorial_provider.dart';
 import '../../providers/unassigned_posts_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../utils/account_switch_helper.dart';
+import '../../utils/keyboard_height_observer.dart';
 import '../../utils/month_names.dart';
 import '../../theme/gleisner_tokens.dart';
 import 'create_child_sheet.dart';
@@ -435,7 +436,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           left: spaceLg,
           right: spaceLg,
           top: spaceLg,
-          bottom: spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
+          bottom: spaceLg + KeyboardHeight.of(ctx),
         ),
         // All l10n lookups inside the dialog use the builder's `ctx` rather
         // than the outer `_showDeleteAccountDialog` `context`. The outer

--- a/frontend/lib/screens/profile/register_artist_wizard.dart
+++ b/frontend/lib/screens/profile/register_artist_wizard.dart
@@ -11,6 +11,7 @@ import '../../models/genre.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/my_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
+import '../../utils/keyboard_height_observer.dart';
 
 /// ADR 013: 4-step artist registration wizard.
 /// Step 1: Intro — feature overview
@@ -498,7 +499,7 @@ class _StepProfile extends StatelessWidget {
         left: spaceXl,
         right: spaceXl,
         top: spaceXl,
-        bottom: MediaQuery.of(context).viewInsets.bottom + spaceXl,
+        bottom: KeyboardHeight.of(context) + spaceXl,
       ),
       child: Form(
         key: formKey,
@@ -671,8 +672,7 @@ class _StepProfile extends StatelessWidget {
                             left: spaceLg,
                             right: spaceLg,
                             top: spaceLg,
-                            bottom:
-                                spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
+                            bottom: spaceLg + KeyboardHeight.of(ctx),
                           ),
                           title: Text(
                             context.l10n.createOwnGenre,
@@ -1052,8 +1052,7 @@ class _TrackChip extends StatelessWidget {
                           left: spaceLg,
                           right: spaceLg,
                           top: spaceLg,
-                          bottom:
-                              spaceLg + MediaQuery.of(ctx).viewInsets.bottom,
+                          bottom: spaceLg + KeyboardHeight.of(ctx),
                         ),
                         title: Text(
                           context.l10n.trackName,

--- a/frontend/lib/utils/keyboard_height_observer.dart
+++ b/frontend/lib/utils/keyboard_height_observer.dart
@@ -1,0 +1,209 @@
+// ignore_for_file: avoid_web_libraries_in_flutter
+//
+// Reliable soft-keyboard height for Flutter Web on iOS Safari.
+//
+// Problem: `MediaQuery.of(context).viewInsets.bottom` is unreliable on
+// Flutter Web in iOS Safari. Long-standing engine issues
+// (flutter/flutter#42211, #56039, #146726, #80253, #135800) cause it to
+// either stay at 0 when the keyboard is visible, lag behind the actual
+// transition, or — when the dynamic toolbar is involved — momentarily
+// report values larger than the keyboard. This breaks every
+// `Padding(EdgeInsets.only(bottom: viewInsets.bottom))` and AlertDialog
+// `insetPadding.bottom` in the app.
+//
+// Strategy: cross-check Flutter's MediaQuery against the DOM-side
+// `window.visualViewport` API and pick the larger plausible value, then
+// clamp to `screenHeight * 0.6` so a transient over-report can't push a
+// dialog off the top of the screen.
+//
+// ```text
+// keyboardHeight = clamp(
+//   max(MediaQuery.viewInsets.bottom, innerHeight − vv.height − vv.offsetTop),
+//   0,
+//   screenHeight * 0.6,
+// )
+// ```
+//
+// Wrap your `MaterialApp.builder` with `KeyboardHeightObserver(child: child)`
+// and read the value via `KeyboardHeight.of(context)` from any descendant.
+// Falls back to `MediaQuery.viewInsets.bottom` when no observer is in scope
+// (tests, isolated widgets), so consumers stay correct even outside the
+// wrapped tree.
+
+import 'dart:js_interop';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:web/web.dart' as web;
+
+/// Maximum keyboard height as a fraction of the screen height. iOS / Android
+/// soft keyboards in portrait take roughly 35–45% of the screen; 60% leaves
+/// generous headroom for the predictive bar and oversized accessory views
+/// while still rejecting clearly bogus over-reports.
+const double _maxKeyboardScreenFraction = 0.6;
+
+/// Wraps the app and exposes the current keyboard height to descendants
+/// through an [InheritedWidget]. Must wrap a subtree that has a [MediaQuery]
+/// (typically placed in `MaterialApp.builder`).
+class KeyboardHeightObserver extends StatefulWidget {
+  final Widget child;
+
+  const KeyboardHeightObserver({super.key, required this.child});
+
+  @override
+  State<KeyboardHeightObserver> createState() => _KeyboardHeightObserverState();
+}
+
+class _KeyboardHeightObserverState extends State<KeyboardHeightObserver>
+    with WidgetsBindingObserver {
+  double _keyboardHeight = 0;
+
+  // JSFunction references are captured so removeEventListener can find them.
+  JSFunction? _vvHandler;
+  JSFunction? _winHandler;
+
+  // Coalesce multiple change signals (didChangeMetrics + visualViewport
+  // resize + window resize all firing in the same frame) into a single
+  // post-frame recompute so we don't thrash setState.
+  bool _recalcScheduled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    if (kIsWeb) {
+      try {
+        _vvHandler = ((web.Event _) => _scheduleRecalculate()).toJS;
+        _winHandler = ((web.Event _) => _scheduleRecalculate()).toJS;
+        final vv = web.window.visualViewport;
+        if (vv != null) {
+          vv.addEventListener('resize', _vvHandler!);
+          vv.addEventListener('scroll', _vvHandler!);
+        }
+        web.window.addEventListener('resize', _winHandler!);
+      } catch (_) {
+        // Best-effort: if DOM hooks fail we still get MediaQuery updates via
+        // didChangeMetrics, so the observer degrades gracefully.
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    if (kIsWeb) {
+      try {
+        final vv = web.window.visualViewport;
+        if (vv != null && _vvHandler != null) {
+          vv.removeEventListener('resize', _vvHandler!);
+          vv.removeEventListener('scroll', _vvHandler!);
+        }
+        if (_winHandler != null) {
+          web.window.removeEventListener('resize', _winHandler!);
+        }
+      } catch (_) {}
+    }
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  // Flutter's view of the keyboard. Fires on both keyboard show/hide and
+  // on URL bar / safe-area changes.
+  @override
+  void didChangeMetrics() {
+    _scheduleRecalculate();
+  }
+
+  void _scheduleRecalculate() {
+    if (_recalcScheduled) return;
+    _recalcScheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _recalcScheduled = false;
+      if (!mounted) return;
+      _recalculate();
+    });
+  }
+
+  void _recalculate() {
+    final mq = MediaQuery.maybeOf(context);
+    final mqBottom = mq?.viewInsets.bottom ?? 0.0;
+    final screenHeight = mq?.size.height ?? 0.0;
+
+    double domBottom = 0.0;
+    if (kIsWeb) {
+      try {
+        final vv = web.window.visualViewport;
+        if (vv != null) {
+          // The visual viewport shrinks when the iOS keyboard appears.
+          // `offsetTop` becomes nonzero if the user has scrolled the page so
+          // an input stays visible above the keyboard; subtracting it keeps
+          // the math correct in that case.
+          final innerH = web.window.innerHeight.toDouble();
+          final vvH = vv.height.toDouble();
+          final vvTop = vv.offsetTop.toDouble();
+          final calc = innerH - vvH - vvTop;
+          if (calc > 0) domBottom = calc;
+        }
+      } catch (_) {}
+    }
+
+    // Clamp each source independently before max-ing so a single bad reading
+    // (e.g. iOS Safari briefly reporting innerHeight > viewport.height + 1000)
+    // can't poison the picked value.
+    final maxAllowed = screenHeight > 0
+        ? screenHeight * _maxKeyboardScreenFraction
+        : 1000.0;
+    final mqClamped = mqBottom.clamp(0.0, maxAllowed);
+    final domClamped = domBottom.clamp(0.0, maxAllowed);
+
+    // Take the larger of the two — whichever channel actually noticed the
+    // keyboard. When both are 0 the keyboard is not visible.
+    final newHeight = mqClamped > domClamped ? mqClamped : domClamped;
+
+    // Threshold avoids re-render storms when iOS Safari's visualViewport
+    // jitters by sub-pixel amounts during the keyboard slide-in animation.
+    if ((newHeight - _keyboardHeight).abs() > 0.5) {
+      setState(() => _keyboardHeight = newHeight);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _KeyboardHeightInherited(
+      keyboardHeight: _keyboardHeight,
+      child: widget.child,
+    );
+  }
+}
+
+class _KeyboardHeightInherited extends InheritedWidget {
+  final double keyboardHeight;
+
+  const _KeyboardHeightInherited({
+    required this.keyboardHeight,
+    required super.child,
+  });
+
+  @override
+  bool updateShouldNotify(_KeyboardHeightInherited old) =>
+      keyboardHeight != old.keyboardHeight;
+}
+
+/// Reads the current soft-keyboard height in logical pixels.
+///
+/// - When wrapped in a [KeyboardHeightObserver] (the normal case via
+///   `MaterialApp.builder`), returns the cross-checked value (max of
+///   MediaQuery + visualViewport, clamped).
+/// - Outside the wrapped tree (tests, isolated widget trees),
+///   transparently falls back to `MediaQuery.of(context).viewInsets.bottom`
+///   so callers keep working without special-casing.
+///
+/// Causes the calling widget to rebuild when the value changes.
+class KeyboardHeight {
+  static double of(BuildContext context) {
+    final inherited = context
+        .dependOnInheritedWidgetOfExactType<_KeyboardHeightInherited>();
+    if (inherited != null) return inherited.keyboardHeight;
+    return MediaQuery.of(context).viewInsets.bottom;
+  }
+}

--- a/frontend/lib/widgets/common/related_post_picker.dart
+++ b/frontend/lib/widgets/common/related_post_picker.dart
@@ -4,6 +4,7 @@ import '../../l10n/l10n.dart';
 import '../../models/post.dart';
 import '../../models/track.dart' show parseHexColor;
 import '../../theme/gleisner_tokens.dart';
+import '../../utils/keyboard_height_observer.dart';
 
 /// Bottom sheet picker for selecting a related post.
 class RelatedPostPicker extends StatefulWidget {
@@ -159,7 +160,7 @@ class _RelatedPostPickerState extends State<RelatedPostPicker> {
                       padding: EdgeInsets.only(
                         left: spaceLg,
                         right: spaceLg,
-                        bottom: MediaQuery.of(context).viewInsets.bottom,
+                        bottom: KeyboardHeight.of(context),
                       ),
                       child: Wrap(
                         spacing: 8,

--- a/frontend/lib/widgets/timeline/post_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/post_detail_sheet.dart
@@ -9,6 +9,7 @@ import '../../models/post.dart';
 import '../../models/track.dart' show parseHexColor;
 import '../../theme/gleisner_tokens.dart';
 import '../../utils/constellation_graph.dart';
+import '../../utils/keyboard_height_observer.dart';
 import '../../utils/open_url.dart';
 import '../../utils/reading_time.dart';
 import '../common/connection_type_picker.dart';
@@ -1021,7 +1022,7 @@ class _PostDetailContentState extends State<PostDetailContent> {
             left: spaceLg,
             right: spaceLg,
             top: spaceLg,
-            bottom: spaceLg + MediaQuery.of(dialogContext).viewInsets.bottom,
+            bottom: spaceLg + KeyboardHeight.of(dialogContext),
           ),
           title: Text(
             existing != null

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -18,6 +18,15 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <!--
+    Explicit viewport meta. Flutter's bootstrap inserts a permissive viewport
+    on its own, but iOS Safari's visualViewport API behaves more predictably
+    when the page declares its viewport up front. Without this, the page is
+    laid out at ~980px on first paint and visualViewport.height jitters as
+    Safari rescales, which breaks the soft-keyboard height calculation in
+    `lib/utils/keyboard_height_observer.dart`.
+  -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <meta name="description" content="Gleisner — Your creative journey, your universe">
 
   <!-- PHASE_0_REVERT: Phase 1 (public launch) 移行時に以下 2 行を削除。docs/phase1-revert-checklist.md 参照 -->


### PR DESCRIPTION
## Why

The track-name-input-hidden-by-keyboard bug has resisted **two prior fixes** (#319, #329) that both relied on `MediaQuery.of(context).viewInsets.bottom`. iPhone Safari reports showed two opposite symptoms:

| Screen | Symptom | What `viewInsets.bottom` likely returns |
|---|---|---|
| Edit Artist Tracks sheet | TextField stays hidden behind the keyboard | too small / 0 |
| Create Post **+ New Track** AlertDialog | Dialog is pushed off the **top** of the screen | too large / oscillating |

Both are consistent with long-standing Flutter Web-on-iOS-Safari keyboard-detection bugs:

- flutter/flutter#42211 — keyboard insets sometimes ignored on Safari
- flutter/flutter#56039 — Web has no bottomInset, native does
- flutter/flutter#146726 — `viewInsets` does not update when keyboard opens
- flutter/flutter#80253 — unexpected value when keyboard opened/closed
- flutter/flutter#135800 — TextField disappears when keyboard opens

This PR **replaces the value source** instead of stacking another workaround on top of the unreliable signal. Decided to ship as a one-shot fix rather than instrument-and-iterate (the alternative diagnostics overlay is held as a fallback in #339) because preview-deploy verification is blocked by CORS and the round-trip cost is not worth the risk-reduction here.

## What changed

### `lib/utils/keyboard_height_observer.dart` (new)

`KeyboardHeightObserver` widget wraps the app via `MaterialApp.builder`. It listens to **both** signal sources and picks the more plausible one:

- Flutter's `WidgetsBindingObserver.didChangeMetrics` (MediaQuery)
- DOM's `window.visualViewport` `resize` + `scroll` and `window.resize`

```text
keyboardHeight = clamp(
  max(MediaQuery.viewInsets.bottom, innerHeight − vv.height − vv.offsetTop),
  0,
  screenHeight × 0.6,
)
```

Why the math works:
- **`max` of two sources** — solves the "MediaQuery says 0 but DOM knows" case (the Edit Artist Tracks symptom).
- **Per-source clamp to `screenHeight × 0.6`** — solves the "viewInsets is bogusly large" case (the AlertDialog-off-top symptom). iOS keyboards top out around 45% of the screen, so 60% is generous headroom that still rejects clearly-broken readings.
- **Coalesced post-frame recompute** — the iOS keyboard slide-in fires 4–6 events in quick succession; collapsing them to one recompute per frame keeps the math stable.
- **0.5px setState threshold** — visualViewport sub-pixel jitter during animation no longer causes re-render storms.

`KeyboardHeight.of(context)` is the read API. Falls back to `MediaQuery.viewInsets.bottom` when no observer is in scope, so tests and isolated widget trees keep working without special-casing.

### Call-site replacement (14 sites)

All `MediaQuery.of(context).viewInsets.bottom` reads in screens, sheets, dialogs, and pickers were replaced with `KeyboardHeight.of(context)`:

- `screens/profile/{create_child_sheet, edit_profile_sheet, profile_screen, register_artist_wizard}.dart` (3 sites in wizard)
- `screens/artist/{artist_page_screen, edit_artist_about_sheet, edit_artist_genres_sheet, edit_artist_links_sheet, edit_artist_tracks_sheet, edit_milestones_sheet}.dart` (2 sites in milestones)
- `screens/create_post/create_post_screen.dart`
- `widgets/common/related_post_picker.dart`
- `widgets/timeline/post_detail_sheet.dart`

### `web/index.html`

Added the explicit viewport meta tag:

```html
<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
```

Flutter's bootstrap inserts a permissive viewport, but iOS Safari's `visualViewport` is more predictable when the page declares its viewport up front. Without it, first paint is at ~980px and `visualViewport.height` jitters as Safari rescales — which breaks the cross-checking math.

## Verification

- `dart analyze lib/`: ✅ no issues
- `flutter test --platform chrome`: ✅ 318 passed, 0 failed
- `flutter build web --release`: ✅ builds clean

Real-device verification will happen post-merge on `gleisner.app` (CORS is configured for the production domain, not preview URLs). If symptoms persist, the diagnostics overlay PR #339 instruments both signal sources in real time so we can see exactly where the math goes wrong on the actual device — at that point we'd revert this PR and iterate from data.

## Out of scope

- Removing the `_handleNameFocusChanged` auto-scroll in `edit_artist_tracks_sheet.dart`: kept as-is. With the keyboard height now reliable, the existing `animateTo(maxScrollExtent)` should work as designed. If real-device testing shows it's now redundant, that's a follow-up cleanup.
- Refactoring `DraggableScrollableSheet` itself: the inner ListView's `padding-bottom: keyboardHeight` should now correctly reserve space for the keyboard. Sheet position adjustment (DraggableScrollableController) is a heavier change reserved for if this turns out insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)