### PR TITLE
debug: add DOM-side keyboard HUD (position:fixed) for iPhone Safari

### DIFF
--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -61,6 +61,113 @@
         .catch(function () {});
     }
   </script>
+
+  <!--
+    DOM-side soft-keyboard diagnostics HUD.
+
+    Activated only when the URL contains `?debug=keyboard`. Lives outside the
+    Flutter <flt-glass-pane>, anchored with `position: fixed` so it stays put
+    even when iPhone Safari auto-scrolls the page on input focus (the same
+    auto-scroll that pushes AlertDialogs off the top of the screen — see
+    PR #340 follow-up). The Flutter-side overlay
+    (`lib/utils/keyboard_debug_overlay.dart`) gets clipped/hidden by Safari's
+    scroll, so this DOM HUD is the only reliable readout once the keyboard is
+    up.
+
+    Pass-through when the flag is absent: the script returns immediately, no
+    DOM is added, no listeners are registered. Remove together with the
+    Flutter-side overlay once the root cause is fixed.
+  -->
+  <style>
+    #kb-debug-hud {
+      position: fixed;
+      top: 6px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 2147483647;
+      background: rgba(0, 0, 0, 0.85);
+      color: #fff;
+      padding: 4px 8px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 10px;
+      line-height: 1.3;
+      border: 1px solid #ffeb3b;
+      border-radius: 4px;
+      pointer-events: none;
+      max-width: 92vw;
+      white-space: pre;
+    }
+    #kb-debug-hud .y { color: #ffeb3b; }
+    #kb-debug-hud .b { color: #4fc3f7; }
+  </style>
+  <script>
+    (function () {
+      if (!location.search.includes("debug=keyboard")) return;
+
+      var hud;
+      function ensureHud() {
+        if (hud) return hud;
+        hud = document.createElement("div");
+        hud.id = "kb-debug-hud";
+        document.body.appendChild(hud);
+        return hud;
+      }
+
+      function pad(n, w) { var s = String(n); while (s.length < w) s = " " + s; return s; }
+
+      function update() {
+        var vv = window.visualViewport;
+        var innerH = window.innerHeight;
+        var innerW = window.innerWidth;
+        var docH = (document.documentElement && document.documentElement.clientHeight) || 0;
+        var scrollY = window.scrollY || 0;
+        var pageY = window.pageYOffset || 0;
+        var vvH = vv ? vv.height : 0;
+        var vvW = vv ? vv.width : 0;
+        var vvTop = vv ? vv.offsetTop : 0;
+        var vvLeft = vv ? vv.offsetLeft : 0;
+        var vvScale = vv ? vv.scale : 0;
+        var calcKb = vv ? Math.max(0, innerH - vvH - vvTop) : 0;
+
+        var fmt = function (n) { return Number(n).toFixed(1); };
+        var lines = [
+          '<span class="y">KB DEBUG (DOM)</span>',
+          'win.inner ' + pad(innerW, 4) + ' x ' + pad(innerH, 4),
+          'docEl.cliH ' + pad(docH, 4),
+          'vv.size   ' + fmt(vvW) + ' x ' + fmt(vvH),
+          'vv.offset ' + fmt(vvLeft) + ', ' + fmt(vvTop),
+          'vv.scale  ' + fmt(vvScale),
+          'scrollY   ' + fmt(scrollY) + ' / pageY ' + fmt(pageY),
+          '<span class="y">calc kbH ' + fmt(calcKb) + '</span>',
+          '<span class="b">activeElem ' + (document.activeElement && document.activeElement.tagName || '?') + '</span>',
+        ];
+        ensureHud().innerHTML = lines.join('\n');
+      }
+
+      function start() {
+        update();
+        var vv = window.visualViewport;
+        if (vv) {
+          vv.addEventListener("resize", update);
+          vv.addEventListener("scroll", update);
+        }
+        window.addEventListener("resize", update);
+        window.addEventListener("scroll", update, true);
+        // Some iOS Safari builds don't fire visualViewport events reliably;
+        // a slow tick guarantees we never go stale for more than 250ms.
+        setInterval(update, 250);
+        // Surface focus changes so we can see exactly when the page jumps.
+        document.addEventListener("focusin", update, true);
+        document.addEventListener("focusout", update, true);
+      }
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", start);
+      } else {
+        start();
+      }
+    })();
+  </script>
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>


### PR DESCRIPTION
## Why

User reports that when tapping the track-name input on iPhone Safari, the Flutter-side debug overlay (#339) **disappears the moment the input gains focus**.

That disappearance is itself diagnostic — it confirms **iOS Safari is auto-scrolling the page on input focus**, which is also the most plausible root cause of the "AlertDialog flies off the top of the screen" symptom that PR #340 didn't fix.

To capture readings *during* the keyboard transition, this HUD lives in the **DOM with `position: fixed`** (z-index 2147483647) outside the Flutter glass-pane. `position: fixed` elements stay anchored to the visualViewport on iOS Safari even when the page is auto-scrolled, so the HUD remains visible after the input gains focus.

## What

Same gating as the Flutter overlay: pass-through when the URL has no `?debug=keyboard` query — no DOM added, no listeners attached.

Readings exposed (top-center, monospace):
- `window.innerWidth/innerHeight`
- `documentElement.clientHeight`
- `visualViewport.{width, height, offsetLeft, offsetTop, scale}`
- `window.scrollY / pageYOffset`
- `calc kbH = max(0, innerH − vv.height − vv.offsetTop)`
- `document.activeElement.tagName` — so we can see exactly when focus lands on the Flutter `<input>` proxy

Updates fire on `visualViewport.resize`/`scroll`, `window.resize`/`scroll`, `focusin`/`focusout`, plus a 250ms safety tick.

## How to use

After Cloudflare Pages deploys this branch (or after merge to gleisner.app):

1. Open `https://gleisner.app/?debug=keyboard` (or preview URL with the same query) on iPhone Safari
2. Two HUDs appear: Flutter-side (top-right, blue/yellow text from PR #339) and DOM-side (top-center, on yellow border, this PR)
3. Reproduce the symptom (tap the track-name input in **Manage Tracks** sheet, or tap the input in the **+ New Track** dialog inside Create Post)
4. The Flutter overlay will likely vanish — but the DOM HUD should stay visible. Screenshot it.
5. Pay particular attention to:
   - `vv.offsetTop` jumping to a nonzero value (= Safari scrolled)
   - `scrollY / pageY` becoming nonzero (= page-level scroll)
   - `calc kbH` value at rest vs during keyboard slide-in

## Verification

- `flutter build web --release`: ✅ builds clean
- HTML/JS only — no Dart changes, no test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)