### PR TITLE
fix(frontend): inject visualViewport-derived keyboard height into MediaQuery (data-driven fix)

### DIFF
--- a/frontend/lib/screens/artist/artist_page_screen.dart
+++ b/frontend/lib/screens/artist/artist_page_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../l10n/l10n.dart';
-import '../../utils/keyboard_height_observer.dart';
 import '../../utils/open_url.dart';
 
 import '../../models/artist.dart';
@@ -999,7 +998,7 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
               left: spaceLg,
               right: spaceLg,
               top: spaceLg,
-              bottom: spaceLg + KeyboardHeight.of(context),
+              bottom: spaceLg,
             ),
             title: Text(
               context.l10n.displayName,

--- a/frontend/lib/screens/artist/edit_artist_about_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_about_sheet.dart
@@ -6,7 +6,6 @@ import '../../providers/artist_page_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/edit_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
-import '../../utils/keyboard_height_observer.dart';
 
 class EditArtistAboutSheet extends ConsumerStatefulWidget {
   final Artist artist;
@@ -106,12 +105,7 @@ class _EditArtistAboutSheetState extends ConsumerState<EditArtistAboutSheet> {
         child: Form(
           key: _formKey,
           child: SingleChildScrollView(
-            padding: EdgeInsets.fromLTRB(
-              spaceXl,
-              spaceLg,
-              spaceXl,
-              spaceXl + KeyboardHeight.of(context),
-            ),
+            padding: EdgeInsets.fromLTRB(spaceXl, spaceLg, spaceXl, spaceXl),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [

--- a/frontend/lib/screens/artist/edit_artist_genres_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_genres_sheet.dart
@@ -10,7 +10,6 @@ import '../../providers/artist_page_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/edit_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
-import '../../utils/keyboard_height_observer.dart';
 
 class EditArtistGenresSheet extends ConsumerStatefulWidget {
   final Artist artist;
@@ -143,12 +142,7 @@ class _EditArtistGenresSheetState extends ConsumerState<EditArtistGenresSheet> {
           ),
           child: ListView(
             controller: scrollController,
-            padding: EdgeInsets.fromLTRB(
-              spaceXl,
-              spaceLg,
-              spaceXl,
-              spaceXl + KeyboardHeight.of(context),
-            ),
+            padding: EdgeInsets.fromLTRB(spaceXl, spaceLg, spaceXl, spaceXl),
             children: [
               Center(
                 child: Container(

--- a/frontend/lib/screens/artist/edit_artist_links_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_links_sheet.dart
@@ -6,7 +6,6 @@ import '../../providers/artist_page_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/edit_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
-import '../../utils/keyboard_height_observer.dart';
 
 const _linkCategories = [
   'music',
@@ -148,12 +147,7 @@ class _EditArtistLinksSheetState extends ConsumerState<EditArtistLinksSheet> {
           ),
           child: ListView(
             controller: scrollController,
-            padding: EdgeInsets.fromLTRB(
-              spaceXl,
-              spaceLg,
-              spaceXl,
-              spaceXl + KeyboardHeight.of(context),
-            ),
+            padding: EdgeInsets.fromLTRB(spaceXl, spaceLg, spaceXl, spaceXl),
             children: [
               // Handle bar
               Center(

--- a/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
@@ -8,7 +8,6 @@ import '../../providers/edit_artist_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/unassigned_posts_provider.dart';
 import '../../theme/gleisner_tokens.dart';
-import '../../utils/keyboard_height_observer.dart';
 
 class EditArtistTracksSheet extends ConsumerStatefulWidget {
   final Artist artist;
@@ -198,12 +197,7 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
           ),
           child: ListView(
             controller: scrollController,
-            padding: EdgeInsets.fromLTRB(
-              spaceXl,
-              spaceLg,
-              spaceXl,
-              spaceXl + KeyboardHeight.of(context),
-            ),
+            padding: EdgeInsets.fromLTRB(spaceXl, spaceLg, spaceXl, spaceXl),
             children: [
               Center(
                 child: Container(

--- a/frontend/lib/screens/artist/edit_milestones_sheet.dart
+++ b/frontend/lib/screens/artist/edit_milestones_sheet.dart
@@ -6,7 +6,6 @@ import '../../providers/artist_page_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/edit_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
-import '../../utils/keyboard_height_observer.dart';
 import '../../utils/milestone_category.dart';
 
 class EditMilestonesSheet extends ConsumerStatefulWidget {
@@ -156,7 +155,7 @@ class _EditMilestonesSheetState extends ConsumerState<EditMilestonesSheet> {
             left: spaceLg,
             right: spaceLg,
             top: spaceLg,
-            bottom: spaceLg + KeyboardHeight.of(ctx),
+            bottom: spaceLg,
           ),
           title: Text(
             context.l10n.editMilestone,
@@ -376,7 +375,7 @@ class _EditMilestonesSheetState extends ConsumerState<EditMilestonesSheet> {
                     // it here keeps the Add button above the keyboard
                     // (matches the pattern in edit_profile_sheet,
                     // register_artist_wizard, etc.).
-                    bottom: spaceLg + KeyboardHeight.of(context),
+                    bottom: spaceLg,
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -12,7 +12,6 @@ import '../../providers/create_post_provider.dart';
 import '../../providers/timeline_provider.dart';
 import '../../utils/constellation_layout.dart';
 import '../../utils/ime_safe_focus.dart';
-import '../../utils/keyboard_height_observer.dart';
 import '../../widgets/common/connection_type_picker.dart';
 import '../../widgets/common/error_banner.dart';
 import '../../widgets/common/event_at_picker.dart';
@@ -430,7 +429,7 @@ class _TrackStep extends ConsumerWidget {
                 left: spaceLg,
                 right: spaceLg,
                 top: spaceLg,
-                bottom: spaceLg + KeyboardHeight.of(ctx),
+                bottom: spaceLg,
               ),
               title: Text(l10n.newTrack),
               content: Column(

--- a/frontend/lib/screens/profile/create_child_sheet.dart
+++ b/frontend/lib/screens/profile/create_child_sheet.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/guardian_provider.dart';
 import '../../theme/gleisner_tokens.dart';
-import '../../utils/keyboard_height_observer.dart';
 
 class CreateChildSheet extends ConsumerStatefulWidget {
   const CreateChildSheet({super.key});
@@ -52,12 +51,7 @@ class _CreateChildSheetState extends ConsumerState<CreateChildSheet> {
             // Add viewInsets.bottom so the password field at the bottom of
             // the form stays above the soft keyboard. Matches the pattern
             // used in edit_artist_links_sheet, edit_milestones_sheet, etc.
-            padding: EdgeInsets.fromLTRB(
-              spaceXl,
-              spaceXl,
-              spaceXl,
-              spaceXl + KeyboardHeight.of(context),
-            ),
+            padding: EdgeInsets.fromLTRB(spaceXl, spaceXl, spaceXl, spaceXl),
             children: [
               Center(
                 child: Container(

--- a/frontend/lib/screens/profile/edit_profile_sheet.dart
+++ b/frontend/lib/screens/profile/edit_profile_sheet.dart
@@ -5,7 +5,6 @@ import '../../l10n/l10n.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/media_upload_provider.dart';
 import '../../theme/gleisner_tokens.dart';
-import '../../utils/keyboard_height_observer.dart';
 import '../../widgets/media/avatar_image.dart';
 
 class EditProfileSheet extends ConsumerStatefulWidget {
@@ -124,12 +123,7 @@ class _EditProfileSheetState extends ConsumerState<EditProfileSheet> {
             key: _formKey,
             child: ListView(
               controller: scrollController,
-              padding: EdgeInsets.fromLTRB(
-                spaceXl,
-                spaceLg,
-                spaceXl,
-                spaceXl + KeyboardHeight.of(context),
-              ),
+              padding: EdgeInsets.fromLTRB(spaceXl, spaceLg, spaceXl, spaceXl),
               children: [
                 // Handle bar
                 Center(

--- a/frontend/lib/screens/profile/profile_screen.dart
+++ b/frontend/lib/screens/profile/profile_screen.dart
@@ -15,7 +15,6 @@ import '../../providers/tutorial_provider.dart';
 import '../../providers/unassigned_posts_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../utils/account_switch_helper.dart';
-import '../../utils/keyboard_height_observer.dart';
 import '../../utils/month_names.dart';
 import '../../theme/gleisner_tokens.dart';
 import 'create_child_sheet.dart';
@@ -436,7 +435,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           left: spaceLg,
           right: spaceLg,
           top: spaceLg,
-          bottom: spaceLg + KeyboardHeight.of(ctx),
+          bottom: spaceLg,
         ),
         // All l10n lookups inside the dialog use the builder's `ctx` rather
         // than the outer `_showDeleteAccountDialog` `context`. The outer

--- a/frontend/lib/screens/profile/register_artist_wizard.dart
+++ b/frontend/lib/screens/profile/register_artist_wizard.dart
@@ -11,7 +11,6 @@ import '../../models/genre.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/my_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
-import '../../utils/keyboard_height_observer.dart';
 
 /// ADR 013: 4-step artist registration wizard.
 /// Step 1: Intro — feature overview
@@ -499,7 +498,7 @@ class _StepProfile extends StatelessWidget {
         left: spaceXl,
         right: spaceXl,
         top: spaceXl,
-        bottom: KeyboardHeight.of(context) + spaceXl,
+        bottom: spaceXl,
       ),
       child: Form(
         key: formKey,
@@ -672,7 +671,7 @@ class _StepProfile extends StatelessWidget {
                             left: spaceLg,
                             right: spaceLg,
                             top: spaceLg,
-                            bottom: spaceLg + KeyboardHeight.of(ctx),
+                            bottom: spaceLg,
                           ),
                           title: Text(
                             context.l10n.createOwnGenre,
@@ -1052,7 +1051,7 @@ class _TrackChip extends StatelessWidget {
                           left: spaceLg,
                           right: spaceLg,
                           top: spaceLg,
-                          bottom: spaceLg + KeyboardHeight.of(ctx),
+                          bottom: spaceLg,
                         ),
                         title: Text(
                           context.l10n.trackName,

--- a/frontend/lib/utils/keyboard_height_observer.dart
+++ b/frontend/lib/utils/keyboard_height_observer.dart
@@ -169,9 +169,34 @@ class _KeyboardHeightObserverState extends State<KeyboardHeightObserver>
 
   @override
   Widget build(BuildContext context) {
-    return _KeyboardHeightInherited(
-      keyboardHeight: _keyboardHeight,
-      child: widget.child,
+    final mq = MediaQuery.of(context);
+
+    // Inject our cross-checked keyboard height into MediaQuery's viewInsets so
+    // every descendant — Scaffold's resizeToAvoidBottomInset,
+    // DraggableScrollableSheet, BottomSheet, AlertDialog, anything that reads
+    // viewInsets.bottom directly — sees the value Flutter would normally
+    // provide on native. Flutter Web on iOS Safari fails to propagate
+    // visualViewport changes to viewInsets.bottom (it stays at 0 even while
+    // the soft keyboard occupies ~50% of the screen, see
+    // flutter/flutter#42211, #56039, #146726). Live readings on iPhone
+    // Safari with the DOM HUD (PR #341) confirmed this exact divergence:
+    // visualViewport.height collapses from 695 to 358 (= 337px keyboard) while
+    // MediaQuery.viewInsets.bottom remains 0.
+    //
+    // Without this override, no amount of `viewInsets.bottom`-based padding
+    // helps because the framework still lays out at `MediaQuery.size.height`
+    // pixels and pins sheets/dialogs to the bottom of that taller-than-visible
+    // box — pushing their lower halves behind the keyboard.
+    final patchedMq = mq.copyWith(
+      viewInsets: mq.viewInsets.copyWith(bottom: _keyboardHeight),
+    );
+
+    return MediaQuery(
+      data: patchedMq,
+      child: _KeyboardHeightInherited(
+        keyboardHeight: _keyboardHeight,
+        child: widget.child,
+      ),
     );
   }
 }

--- a/frontend/lib/widgets/common/related_post_picker.dart
+++ b/frontend/lib/widgets/common/related_post_picker.dart
@@ -4,7 +4,6 @@ import '../../l10n/l10n.dart';
 import '../../models/post.dart';
 import '../../models/track.dart' show parseHexColor;
 import '../../theme/gleisner_tokens.dart';
-import '../../utils/keyboard_height_observer.dart';
 
 /// Bottom sheet picker for selecting a related post.
 class RelatedPostPicker extends StatefulWidget {
@@ -160,7 +159,7 @@ class _RelatedPostPickerState extends State<RelatedPostPicker> {
                       padding: EdgeInsets.only(
                         left: spaceLg,
                         right: spaceLg,
-                        bottom: KeyboardHeight.of(context),
+                        bottom: 0,
                       ),
                       child: Wrap(
                         spacing: 8,

--- a/frontend/lib/widgets/timeline/post_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/post_detail_sheet.dart
@@ -9,7 +9,6 @@ import '../../models/post.dart';
 import '../../models/track.dart' show parseHexColor;
 import '../../theme/gleisner_tokens.dart';
 import '../../utils/constellation_graph.dart';
-import '../../utils/keyboard_height_observer.dart';
 import '../../utils/open_url.dart';
 import '../../utils/reading_time.dart';
 import '../common/connection_type_picker.dart';
@@ -1022,7 +1021,7 @@ class _PostDetailContentState extends State<PostDetailContent> {
             left: spaceLg,
             right: spaceLg,
             top: spaceLg,
-            bottom: spaceLg + KeyboardHeight.of(dialogContext),
+            bottom: spaceLg,
           ),
           title: Text(
             existing != null


### PR DESCRIPTION
## Why

Three prior fixes (#319, #329, #340) all failed for the same underlying reason that DOM-side instrumentation (#341) finally surfaced. Live readings on iPhone Safari during keyboard slide-in:

```text
win.inner   393 x 695
vv.size     393 x 358    ← visualViewport correctly shrinks (kbH = 337)
vv.offset   0, 0         ← Safari is NOT auto-scrolling the page (my prior hypothesis was wrong)
scrollY     0, pageY 0   ← page-level scroll stays at 0
MediaQuery.viewInsets.bottom    0   ← Flutter's value is wrong
```

So the truth is:

- iOS Safari's `visualViewport` correctly shrinks when the keyboard appears (337px = real keyboard height)
- Flutter Web's iOS Safari embedder **fails to propagate that change to `MediaQuery.viewInsets.bottom`** — known bugs flutter/flutter#42211, #56039, #146726
- PR #340 added a cross-checked `KeyboardHeight` that *did* return the right value (337) — but only via a custom `InheritedWidget`. The framework itself (`Scaffold.resizeToAvoidBottomInset`, `DraggableScrollableSheet`, `showModalBottomSheet`'s auto-padding when `isScrollControlled: true`, `AlertDialog`'s automatic `insetPadding` addition) **all still asked `MediaQuery` directly and got 0**
- So the layout machinery laid the sheet out at the full 695px height, pinned it to the bottom of that taller-than-visible box, and the lower 337px disappeared behind the keyboard
- Adding `KeyboardHeight` to the inner ListView padding only padded space that was **already off-screen**

## What

`KeyboardHeightObserver.build` now wraps its subtree in a `MediaQuery` that **overrides `viewInsets.bottom`** with the cross-checked keyboard height:

```dart
final patchedMq = mq.copyWith(
  viewInsets: mq.viewInsets.copyWith(bottom: _keyboardHeight),
);
return MediaQuery(data: patchedMq, child: ...);
```

From any descendant's perspective, Flutter Web on iOS Safari now behaves like native: `viewInsets.bottom` equals the real keyboard height, and **the framework's own resize/inset machinery does the right thing automatically**.

The 14 call sites that previously added `+ KeyboardHeight.of(context)` to padding values were simplified to the base inset only — otherwise we'd double-count, because:

- `showModalBottomSheet(isScrollControlled: true)` adds `EdgeInsets.only(bottom: viewInsets.bottom)` outside the builder
- `AlertDialog` adds `MediaQuery.viewInsetsOf(context)` to its `insetPadding`
- `Scaffold` shrinks its body when `resizeToAvoidBottomInset: true`

…all of which now see the injected `viewInsets.bottom` and react.

## Files

- `lib/utils/keyboard_height_observer.dart`: wrap child in `MediaQuery` with patched `viewInsets` in addition to the existing `_KeyboardHeightInherited`. The `InheritedWidget` API is kept for any future call sites that want the raw value, but no production code reads it now.
- 13 files: removed `+ KeyboardHeight.of(context)` / equivalent from padding expressions and pruned the now-unused imports.

## Verification

- `dart analyze lib`: ✅ no issues
- `flutter test --platform chrome`: ✅ 318 passed, 0 failed
- `flutter build web --release`: ✅ builds clean

After merge, real-device verification on `gleisner.app` (iPhone Safari):
1. Manage Tracks → **+** → tap track-name TextField → input should stay visible above the keyboard
2. Create Post → **+ New Track** chip → AlertDialog should not fly off the top (the framework will now inset-pad it correctly)

If symptoms persist, the DOM HUD from #341 (now in main) lets us re-instrument with `?debug=keyboard` and iterate from data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)