### PR TITLE
fix(frontend): make new-track AlertDialog scrollable so its top edge stops getting clipped on iPhone Safari

### DIFF
--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -421,10 +421,18 @@ class _TrackStep extends ConsumerWidget {
         return StatefulBuilder(
           builder: (ctx, setDialogState) {
             return AlertDialog(
-              // AlertDialog is centered by default and gets covered by the
-              // soft keyboard + predictive bar on iPhone Safari. Push it up
-              // by the keyboard height so the input and Create button stay
-              // visible while typing.
+              // PR #342 made Flutter's automatic insetPadding addition work
+              // on iPhone Safari (by injecting visualViewport into MediaQuery),
+              // so the dialog no longer flies off the top. But on small visible
+              // areas (iPhone Safari with the keyboard up leaves ~358px of
+              // viewport height), the title + TextField + color preview row +
+              // Cancel/Create buttons collectively exceed the available
+              // vertical space, and the top edge of the dialog gets clipped.
+              // `scrollable: true` makes Flutter wrap the title+content+actions
+              // in a scroll view so the whole dialog fits inside the visible
+              // area, with internal scrolling if the user wants to peek at
+              // anything that's offscreen.
+              scrollable: true,
               insetPadding: EdgeInsets.only(
                 left: spaceLg,
                 right: spaceLg,


### PR DESCRIPTION
## Why

PR #342 fixed the worst symptom of the new-track dialog (the whole dialog flying off the top of the screen) by injecting `visualViewport` into `MediaQuery` so the framework's automatic `insetPadding` addition works on iPhone Safari. User confirmed: "ずれる量が減って完全には見切れなくなった".

But the dialog's **top edge is still clipped** when the keyboard is up. With visualViewport at ~358px (iPhone Safari, keyboard open), the dialog's title + TextField + color preview row + Cancel/Create buttons collectively exceed the available vertical space, and the title "新規トラック" disappears off the top.

## What

`scrollable: true` on the AlertDialog. This wraps title+content+actions in a Flutter-managed scroll view so the entire dialog fits inside the visible area, with internal scrolling if the user wants to peek at anything that's offscreen. No layout drama, no custom code paths.

```dart
return AlertDialog(
  scrollable: true,  // ← new
  insetPadding: ...,
  title: Text(l10n.newTrack),
  content: Column(...),
);
```

## Scope

Only the new-track dialog in `create_post_screen.dart` — the exact symptom the user reported. Other AlertDialogs in the codebase (track rename in `register_artist_wizard.dart`, delete account in `profile_screen.dart`) follow the same pattern and could benefit from the same change, but they're left alone for this PR per the user's "症状 2 だけ" instruction. If they hit the same clipping later, a one-line follow-up will fix each.

## Verification

- `dart analyze lib`: ✅ no issues
- `flutter test --platform chrome`: ✅ 318 passed, 0 failed
- `flutter build web --release`: ✅ builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)