### PR TITLE
feat(frontend): allow deleting unassigned posts from the list view

### DIFF
--- a/frontend/lib/providers/unassigned_posts_provider.dart
+++ b/frontend/lib/providers/unassigned_posts_provider.dart
@@ -19,6 +19,10 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
     with DisposableNotifier {
   late GraphQLClient _client;
 
+  /// Tracks postIds whose deletion mutation is in flight, so a tap-storm on
+  /// the trash button does not fire the mutation twice for the same post.
+  final Set<String> _inFlightDeletes = <String>{};
+
   @override
   UnassignedPostsState build() {
     _client = ref.watch(graphqlClientProvider);
@@ -135,6 +139,37 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
     state = UnassignedPostsState(
       posts: state.posts.where((p) => p.id != postId).toList(),
     );
+  }
+
+  /// Delete an unassigned post via the GraphQL `deletePost` mutation.
+  /// Returns true on success, false on validation/IDOR/race/network failure.
+  ///
+  /// Defenses layered on top of the server-side `authorId` check:
+  /// 1. The post must currently exist in `state.posts` (prevents callers from
+  ///    issuing deletes against arbitrary IDs that were never rendered).
+  /// 2. `_inFlightDeletes` blocks duplicate concurrent mutations for the same
+  ///    postId while the network call is pending.
+  Future<bool> deletePost(String postId) async {
+    if (!state.posts.any((p) => p.id == postId)) return false;
+    if (!_inFlightDeletes.add(postId)) return false;
+    try {
+      final result = await _client.mutate(
+        MutationOptions(
+          document: gql(deletePostMutation),
+          variables: {'id': postId},
+        ),
+      );
+      if (disposed) return false;
+      if (result.hasException) return false;
+      removePost(postId);
+      return true;
+    } catch (e) {
+      debugPrint('[UnassignedPosts] deletePost error: $e');
+      if (disposed) return false;
+      return false;
+    } finally {
+      _inFlightDeletes.remove(postId);
+    }
   }
 }
 

--- a/frontend/lib/screens/unassigned_posts/unassigned_posts_screen.dart
+++ b/frontend/lib/screens/unassigned_posts/unassigned_posts_screen.dart
@@ -51,6 +51,7 @@ class UnassignedPostsScreen extends ConsumerWidget {
                   onTap: () => _openDetail(context, ref, post),
                   onAssign: (trackId) =>
                       _assignToTrack(context, ref, post.id, trackId),
+                  onDelete: () => _deletePost(context, ref, post.id),
                 );
               },
             ),
@@ -70,6 +71,21 @@ class UnassignedPostsScreen extends ConsumerWidget {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(context.l10n.failedAssignPost)));
+    }
+  }
+
+  Future<void> _deletePost(
+    BuildContext context,
+    WidgetRef ref,
+    String postId,
+  ) async {
+    final success = await ref
+        .read(unassignedPostsProvider.notifier)
+        .deletePost(postId);
+    if (!success && context.mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(context.l10n.failedDeletePost)));
     }
   }
 
@@ -106,12 +122,14 @@ class _PostTile extends StatelessWidget {
   final List<Track> tracks;
   final VoidCallback onTap;
   final ValueChanged<String> onAssign;
+  final Future<void> Function() onDelete;
 
   const _PostTile({
     required this.post,
     required this.tracks,
     required this.onTap,
     required this.onAssign,
+    required this.onDelete,
   });
 
   @override
@@ -174,10 +192,52 @@ class _PostTile extends StatelessWidget {
                 size: 18,
                 color: colorInteractiveMuted,
               ),
+            IconButton(
+              icon: const Icon(
+                Icons.delete_outline,
+                size: 20,
+                color: colorTextMuted,
+              ),
+              onPressed: () => _confirmDelete(context),
+              tooltip: context.l10n.delete,
+              visualDensity: VisualDensity.compact,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+            ),
           ],
         ),
       ),
     );
+  }
+
+  Future<void> _confirmDelete(BuildContext context) async {
+    final l10n = context.l10n;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: colorSurface1,
+        title: Text(
+          l10n.deletePostConfirm,
+          style: const TextStyle(color: colorTextPrimary),
+        ),
+        content: Text(
+          l10n.cannotBeUndone,
+          style: const TextStyle(color: colorTextSecondary),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(l10n.delete, style: const TextStyle(color: colorError)),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !context.mounted) return;
+    await onDelete();
   }
 
   void _showTrackPicker(BuildContext context) {


### PR DESCRIPTION
## What

Add a delete button (trash icon) to each post tile on the **Unassigned Posts** screen, so users can clean up posts that have no track yet without going through edit/reassign first.

User feedback: 「トラック未割り当てになった投稿の一覧から、投稿削除のUIがないので未割り当て投稿を消せない。消せたほうが良い」

## Why

Unassigned posts (where `track_id IS NULL`) currently only support reassignment to a track — there is no way to delete them from this screen. Users had to either find another path or leave orphan posts forever.

## How

- **Notifier** (`unassigned_posts_provider.dart`): new `deletePost(postId) Future<bool>` calls the existing `deletePost` GraphQL mutation and optimistically removes the post from local state via the existing `removePost` helper.
- **Screen** (`unassigned_posts_screen.dart`): each `_PostTile` gets an `IconButton(Icons.delete_outline)`. Tapping it opens an `AlertDialog` (existing i18n: `deletePostConfirm` / `cannotBeUndone` / `delete` / `cancel`); on confirm, the new `_deletePost` helper invokes the notifier and surfaces `failedDeletePost` via SnackBar on failure.

No backend changes — the existing `deletePost` mutation already enforces `ctx.authUser.userId === post.authorId` and cascades to `post_media`. No new i18n keys, no ARB regeneration.

## Defenses layered on top of the server-side authz

1. **Existence check**: `state.posts.any((p) => p.id == postId)` before mutating — prevents callers from deleting arbitrary IDs that were never rendered (defense-in-depth on top of `authorId` check)
2. **Tap-storm guard**: `_inFlightDeletes: Set<String>` blocks duplicate concurrent mutations for the same `postId`
3. **Async-gap guards**: `if (disposed) return false` after the await and in the catch; `if (!context.mounted) return` after the confirm dialog

## Reviewer multi-agent results

- **security-reviewer** (Sonnet): Critical 0 / Important 0
- **flutter-ui-reviewer** (Sonnet): Important 2 → both fixed (`context.mounted` after dialog, `disposed` in catch)
- **graphql-reviewer** (Sonnet): Critical 0 / Important 0
- **synthesis-reviewer** (Opus): 方針承認 / PR 作成可

## Manual QA checklist (please run before merging)

- [ ] Tap the trash icon on an unassigned post → AlertDialog appears in the current locale (EN/JA)
- [ ] Confirm delete → post disappears from the list, no SnackBar
- [ ] Cancel → dialog closes, post remains
- [ ] When list becomes empty → falls through to existing empty state (`noUnassignedPosts`)
- [ ] Tap-storm the trash icon (rapid taps) → only one mutation fires (network tab confirms)
- [ ] Force a failure (offline / kill backend) → `failedDeletePost` SnackBar shows, post remains in list
- [ ] Reassign and delete in quick succession → no UI breakage (the tile that was reassigned is already gone, so the delete button is moot)

## Related

- Issue #344 — separate cleanup item for the existing `deletePost` mutation's `console.error` exposing `mediaUrl` (surfaced by the security review of this PR; intentionally **not** in this PR's scope)

## Test results

- `dart format --set-exit-if-changed` — PASS (0 changed)
- `dart analyze lib/...` — No issues found
- `flutter test --platform chrome` — All 318 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)