### PR TITLE
feat(frontend): track color picker (preset grid + HEX + edit dialog)

### DIFF
--- a/frontend/lib/graphql/mutations/track.dart
+++ b/frontend/lib/graphql/mutations/track.dart
@@ -17,3 +17,21 @@ const deleteTrackMutation = r'''
     }
   }
 ''';
+
+/// Both `$name` and `$color` are optional on the server side
+/// (`backend/src/graphql/types/track.ts:101-102`). Omitting a variable
+/// from the client request leaves the corresponding column unchanged;
+/// sending it overwrites the column. Track.color is `varchar(7) NOT NULL`
+/// and Track.name is `varchar(30) NOT NULL`, so neither value should be
+/// sent as `null` (the server validates `name.length` / `HEX_COLOR_RE`
+/// when the field is provided).
+const updateTrackMutation = r'''
+  mutation UpdateTrack($id: String!, $name: String, $color: String) {
+    updateTrack(id: $id, name: $name, color: $color) {
+      id
+      name
+      color
+      createdAt
+    }
+  }
+''';

--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -592,5 +592,39 @@
   "publicLinkCopied": "Public link copied",
   "@publicLinkCopied": {
     "description": "SnackBar message confirming that the artist's public-timeline URL was placed on the clipboard."
+  },
+
+  "selectColor": "Select a color",
+  "@selectColor": {
+    "description": "Section heading inside the track color picker. Reused by the new-track dialog, the artist registration wizard, and the edit-track dialog."
+  },
+  "moreColors": "More colors",
+  "@moreColors": {
+    "description": "Button label that expands the inline preset color grid into the full HSV color picker for entering an arbitrary HEX value."
+  },
+  "customColorHex": "Custom color (HEX)",
+  "@customColorHex": {
+    "description": "Label of the text field where users can type or paste an arbitrary #RRGGBB HEX color when the preset grid does not have what they want."
+  },
+  "invalidHexFormat": "Invalid HEX format (e.g. #ff0000)",
+  "@invalidHexFormat": {
+    "description": "Validation error shown when the HEX color text field contains anything other than a #RRGGBB 6-digit value. Mirrors the backend validation regex in track.ts."
+  },
+  "editTrack": "Edit track",
+  "@editTrack": {
+    "description": "Title of the track edit dialog (rename + recolor) opened by tapping the edit icon on a track row in the Edit Artist tracks sheet."
+  },
+  "failedUpdateTrack": "Failed to update track",
+  "@failedUpdateTrack": {
+    "description": "Generic fallback shown when the updateTrack mutation fails. Server error details are logged via debugPrint only and never surfaced to the UI per .claude/rules/frontend-implementation.md."
+  },
+  "failedUpdateTrackRetry": "Failed to update track. Please try again.",
+  "@failedUpdateTrackRetry": {
+    "description": "Same as failedUpdateTrack with an explicit retry hint, mirroring failedCreateTrackRetry."
+  },
+  "colorPresetLabel": "Color {hex}",
+  "@colorPresetLabel": {
+    "description": "Semantics label for each tappable color swatch in the track color picker preset grid. Read by screen readers as e.g. 'Color #f97316'.",
+    "placeholders": { "hex": { "type": "String" } }
   }
 }

--- a/frontend/lib/l10n/app_ja.arb
+++ b/frontend/lib/l10n/app_ja.arb
@@ -423,5 +423,14 @@
   "monthDecember": "12月",
 
   "copyPublicLink": "公開リンクをコピー",
-  "publicLinkCopied": "公開リンクをコピーしました"
+  "publicLinkCopied": "公開リンクをコピーしました",
+
+  "selectColor": "色を選択",
+  "moreColors": "もっと色",
+  "customColorHex": "カスタムカラー（HEX）",
+  "invalidHexFormat": "HEX形式が正しくありません（例: #ff0000）",
+  "editTrack": "トラックを編集",
+  "failedUpdateTrack": "トラックの更新に失敗しました",
+  "failedUpdateTrackRetry": "トラックの更新に失敗しました。再試行してください。",
+  "colorPresetLabel": "色 {hex}"
 }

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -2377,6 +2377,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Public link copied'**
   String get publicLinkCopied;
+
+  /// Section heading inside the track color picker. Reused by the new-track dialog, the artist registration wizard, and the edit-track dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a color'**
+  String get selectColor;
+
+  /// Button label that expands the inline preset color grid into the full HSV color picker for entering an arbitrary HEX value.
+  ///
+  /// In en, this message translates to:
+  /// **'More colors'**
+  String get moreColors;
+
+  /// Label of the text field where users can type or paste an arbitrary #RRGGBB HEX color when the preset grid does not have what they want.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom color (HEX)'**
+  String get customColorHex;
+
+  /// Validation error shown when the HEX color text field contains anything other than a #RRGGBB 6-digit value. Mirrors the backend validation regex in track.ts.
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid HEX format (e.g. #ff0000)'**
+  String get invalidHexFormat;
+
+  /// Title of the track edit dialog (rename + recolor) opened by tapping the edit icon on a track row in the Edit Artist tracks sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit track'**
+  String get editTrack;
+
+  /// Generic fallback shown when the updateTrack mutation fails. Server error details are logged via debugPrint only and never surfaced to the UI per .claude/rules/frontend-implementation.md.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to update track'**
+  String get failedUpdateTrack;
+
+  /// Same as failedUpdateTrack with an explicit retry hint, mirroring failedCreateTrackRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to update track. Please try again.'**
+  String get failedUpdateTrackRetry;
+
+  /// Semantics label for each tappable color swatch in the track color picker preset grid. Read by screen readers as e.g. 'Color #f97316'.
+  ///
+  /// In en, this message translates to:
+  /// **'Color {hex}'**
+  String colorPresetLabel(String hex);
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -1281,4 +1281,31 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get publicLinkCopied => 'Public link copied';
+
+  @override
+  String get selectColor => 'Select a color';
+
+  @override
+  String get moreColors => 'More colors';
+
+  @override
+  String get customColorHex => 'Custom color (HEX)';
+
+  @override
+  String get invalidHexFormat => 'Invalid HEX format (e.g. #ff0000)';
+
+  @override
+  String get editTrack => 'Edit track';
+
+  @override
+  String get failedUpdateTrack => 'Failed to update track';
+
+  @override
+  String get failedUpdateTrackRetry =>
+      'Failed to update track. Please try again.';
+
+  @override
+  String colorPresetLabel(String hex) {
+    return 'Color $hex';
+  }
 }

--- a/frontend/lib/l10n/app_localizations_ja.dart
+++ b/frontend/lib/l10n/app_localizations_ja.dart
@@ -1240,4 +1240,30 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get publicLinkCopied => '公開リンクをコピーしました';
+
+  @override
+  String get selectColor => '色を選択';
+
+  @override
+  String get moreColors => 'もっと色';
+
+  @override
+  String get customColorHex => 'カスタムカラー（HEX）';
+
+  @override
+  String get invalidHexFormat => 'HEX形式が正しくありません（例: #ff0000）';
+
+  @override
+  String get editTrack => 'トラックを編集';
+
+  @override
+  String get failedUpdateTrack => 'トラックの更新に失敗しました';
+
+  @override
+  String get failedUpdateTrackRetry => 'トラックの更新に失敗しました。再試行してください。';
+
+  @override
+  String colorPresetLabel(String hex) {
+    return '色 $hex';
+  }
 }

--- a/frontend/lib/providers/edit_artist_provider.dart
+++ b/frontend/lib/providers/edit_artist_provider.dart
@@ -291,6 +291,52 @@ class EditArtistNotifier extends Notifier<AsyncValue<void>> {
     }
   }
 
+  /// Update a track's name and/or color.
+  ///
+  /// Either or both of [name] and [color] may be provided. Omitted
+  /// arguments are not sent to the server, leaving that column
+  /// unchanged. Returns the updated [Track] on success, or `null` on
+  /// failure. Server-side error details are logged via `debugPrint`
+  /// only — see PR #346 and `.claude/rules/frontend-implementation.md`
+  /// "サーバーエラーメッセージを UI に露出しない".
+  Future<Track?> updateTrack({
+    required String id,
+    String? name,
+    String? color,
+  }) async {
+    try {
+      final result = await _client.mutate(
+        MutationOptions(
+          document: gql(updateTrackMutation),
+          variables: {'id': id, 'name': ?name, 'color': ?color},
+        ),
+      );
+
+      if (result.hasException) {
+        debugPrint(
+          '[EditArtistNotifier] updateTrack error: ${result.exception}',
+        );
+        return null;
+      }
+
+      final data = result.data?['updateTrack'] as Map<String, dynamic>?;
+      if (data == null) {
+        debugPrint('[EditArtistNotifier] updateTrack: no data returned');
+        return null;
+      }
+
+      // Refresh myArtistProvider only on confirmed success — same
+      // ordering as createTrack to avoid a wasted full-artist refetch
+      // on the (!hasException && data == null) edge case.
+      await ref.read(myArtistProvider.notifier).load();
+
+      return Track.fromJson(data);
+    } catch (e) {
+      debugPrint('[EditArtistNotifier] updateTrack error: $e');
+      return null;
+    }
+  }
+
   Future<bool> deleteTrack(String id) async {
     try {
       final result = await _client.mutate(

--- a/frontend/lib/screens/artist/artist_page_screen.dart
+++ b/frontend/lib/screens/artist/artist_page_screen.dart
@@ -1097,11 +1097,16 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
   }
 
   void _showEditTracksSheet(BuildContext context, Artist artist) {
+    // The sheet is only triggered from the `isSelf` branches in this
+    // screen (lines 206/258/272 etc), but pass `isOwner: true`
+    // explicitly so EditArtistTracksSheet's internal mutation gating
+    // does not silently fall back to its conservative default.
+    // See PR #346 review S2.
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (_) => EditArtistTracksSheet(artist: artist),
+      builder: (_) => EditArtistTracksSheet(artist: artist, isOwner: true),
     );
   }
 }

--- a/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
@@ -8,6 +8,7 @@ import '../../providers/edit_artist_provider.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/unassigned_posts_provider.dart';
 import '../../theme/gleisner_tokens.dart';
+import '../../widgets/common/track_color_picker.dart';
 
 class EditArtistTracksSheet extends ConsumerStatefulWidget {
   final Artist artist;
@@ -24,6 +25,7 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
   bool _showAddForm = false;
   bool _isSubmitting = false;
   String? _error;
+  String _selectedColor = trackColorPresets[0];
   final _nameController = TextEditingController();
   final _addFormKey = GlobalKey<FormState>();
   late final FocusNode _nameFocusNode;
@@ -107,7 +109,7 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
     });
 
     final name = _nameController.text.trim();
-    final color = trackColorPresets[_tracks.length % trackColorPresets.length];
+    final color = _selectedColor;
 
     final track = await ref
         .read(editArtistProvider.notifier)
@@ -220,7 +222,15 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
                     IconButton(
                       icon: const Icon(Icons.add, color: colorAccentGold),
                       onPressed: () {
-                        setState(() => _showAddForm = true);
+                        setState(() {
+                          _showAddForm = true;
+                          // Seed the picker with the next auto-color so users
+                          // who don't care about color get the same rotation
+                          // they had before, while still being able to override.
+                          _selectedColor =
+                              trackColorPresets[_tracks.length %
+                                  trackColorPresets.length];
+                        });
                         // Scroll to bottom after the form is rendered
                         WidgetsBinding.instance.addPostFrameCallback((_) {
                           _scrollController?.animateTo(
@@ -335,6 +345,12 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
                           }
                           return null;
                         },
+                      ),
+                      const SizedBox(height: spaceLg),
+                      TrackColorPicker(
+                        selectedHex: _selectedColor,
+                        onChanged: (hex) =>
+                            setState(() => _selectedColor = hex),
                       ),
                       const SizedBox(height: spaceLg),
                       Row(

--- a/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
@@ -13,7 +13,20 @@ import '../../widgets/common/track_color_picker.dart';
 class EditArtistTracksSheet extends ConsumerStatefulWidget {
   final Artist artist;
 
-  const EditArtistTracksSheet({super.key, required this.artist});
+  /// Defense-in-depth flag: even though the sheet is only opened from
+  /// `artist_page_screen` when `isSelf == true`, mutation UI (Add,
+  /// edit, delete) is also gated on this so future call sites that
+  /// forget the outer check cannot accidentally surface the buttons.
+  /// The backend ownership check in `updateTrack` / `deleteTrack` is
+  /// the final defense, but rendering disabled buttons would still
+  /// expose a confusing UX. See PR #346 review S2.
+  final bool isOwner;
+
+  const EditArtistTracksSheet({
+    super.key,
+    required this.artist,
+    this.isOwner = false,
+  });
 
   @override
   ConsumerState<EditArtistTracksSheet> createState() =>
@@ -139,6 +152,140 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
     }
   }
 
+  Future<void> _editTrack(Track track) async {
+    final updated = await showDialog<Track>(
+      context: context,
+      builder: (dialogContext) {
+        final nameController = TextEditingController(text: track.name);
+        // All dialog-local state lives inside the StatefulBuilder scope so
+        // setDialogState rebuilds reach every value (PR #346 review F3).
+        var selectedColor = track.color;
+        var isSubmitting = false;
+        String? errorText;
+
+        return StatefulBuilder(
+          builder: (ctx, setDialogState) {
+            Future<void> save() async {
+              final newName = nameController.text.trim();
+              if (newName.isEmpty) {
+                setDialogState(() => errorText = ctx.l10n.trackNameRequired);
+                return;
+              }
+              // Reject duplicate names against the current local list,
+              // skipping the row being edited (otherwise renaming to the
+              // same name would always fail).
+              if (_tracks.any(
+                (t) =>
+                    t.id != track.id &&
+                    t.name.toLowerCase() == newName.toLowerCase(),
+              )) {
+                setDialogState(
+                  () => errorText = ctx.l10n.trackNameAlreadyExists,
+                );
+                return;
+              }
+
+              final nameChanged = newName != track.name;
+              final colorChanged = selectedColor != track.color;
+              if (!nameChanged && !colorChanged) {
+                Navigator.pop(dialogContext);
+                return;
+              }
+
+              setDialogState(() {
+                isSubmitting = true;
+                errorText = null;
+              });
+
+              final result = await ref
+                  .read(editArtistProvider.notifier)
+                  .updateTrack(
+                    id: track.id,
+                    name: nameChanged ? newName : null,
+                    color: colorChanged ? selectedColor : null,
+                  );
+
+              if (!dialogContext.mounted) return;
+              if (result != null) {
+                Navigator.pop(dialogContext, result);
+              } else {
+                setDialogState(() {
+                  isSubmitting = false;
+                  errorText = ctx.l10n.failedUpdateTrackRetry;
+                });
+              }
+            }
+
+            return AlertDialog(
+              backgroundColor: colorSurface1,
+              scrollable: true,
+              insetPadding: const EdgeInsets.all(spaceLg),
+              title: Text(
+                ctx.l10n.editTrack,
+                style: const TextStyle(color: colorTextPrimary),
+              ),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TextField(
+                    controller: nameController,
+                    autofocus: true,
+                    maxLength: 30,
+                    style: const TextStyle(color: colorTextPrimary),
+                    decoration: InputDecoration(
+                      labelText: ctx.l10n.trackName,
+                      labelStyle: const TextStyle(color: colorTextMuted),
+                      border: const OutlineInputBorder(),
+                      errorText: errorText,
+                    ),
+                    enabled: !isSubmitting,
+                    onSubmitted: isSubmitting ? null : (_) => save(),
+                  ),
+                  const SizedBox(height: spaceMd),
+                  TrackColorPicker(
+                    selectedHex: selectedColor,
+                    onChanged: (hex) =>
+                        setDialogState(() => selectedColor = hex),
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: isSubmitting
+                      ? null
+                      : () => Navigator.pop(dialogContext),
+                  child: Text(ctx.l10n.cancel),
+                ),
+                FilledButton(
+                  onPressed: isSubmitting ? null : save,
+                  child: isSubmitting
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Text(ctx.l10n.save),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    if (updated == null || !mounted) return;
+    setState(() {
+      final idx = _tracks.indexWhere((t) => t.id == updated.id);
+      if (idx != -1) _tracks = [..._tracks]..[idx] = updated;
+    });
+    // Refresh the artist page so the updated color/name shows up in the
+    // timeline + node renderings, mirroring _deleteTrack's reload step.
+    await ref
+        .read(artistPageProvider.notifier)
+        .loadArtist(widget.artist.artistUsername);
+  }
+
   Future<void> _deleteTrack(Track track) async {
     final confirmed = await showDialog<bool>(
       context: context,
@@ -218,7 +365,7 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
                   Expanded(
                     child: Text(context.l10n.manageTracks, style: textTitle),
                   ),
-                  if (!_showAddForm && _tracks.length < 10)
+                  if (widget.isOwner && !_showAddForm && _tracks.length < 10)
                     IconButton(
                       icon: const Icon(Icons.add, color: colorAccentGold),
                       onPressed: () {
@@ -273,7 +420,8 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
               ..._tracks.map(
                 (track) => _TrackRow(
                   track: track,
-                  onDelete: () => _deleteTrack(track),
+                  onDelete: widget.isOwner ? () => _deleteTrack(track) : null,
+                  onEdit: widget.isOwner ? () => _editTrack(track) : null,
                 ),
               ),
 
@@ -402,9 +550,15 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
 
 class _TrackRow extends StatelessWidget {
   final Track track;
-  final VoidCallback onDelete;
+  // Both callbacks are nullable so the row can render in read-only
+  // contexts (PR #346 review F2 — keep StatelessWidget + delegate
+  // dialog management to the parent State, mirroring _TrackChip in
+  // register_artist_wizard.dart). The parent already gates these on
+  // EditArtistTracksSheet.isOwner; null hides the corresponding icon.
+  final VoidCallback? onDelete;
+  final VoidCallback? onEdit;
 
-  const _TrackRow({required this.track, required this.onDelete});
+  const _TrackRow({required this.track, this.onDelete, this.onEdit});
 
   @override
   Widget build(BuildContext context) {
@@ -441,14 +595,25 @@ class _TrackRow extends StatelessWidget {
                 ),
               ),
             ),
-            IconButton(
-              icon: const Icon(
-                Icons.delete_outline,
-                size: 18,
-                color: colorError,
+            if (onEdit != null)
+              IconButton(
+                icon: const Icon(
+                  Icons.edit_outlined,
+                  size: 18,
+                  color: colorAccentGold,
+                ),
+                tooltip: context.l10n.editTrack,
+                onPressed: onEdit,
               ),
-              onPressed: onDelete,
-            ),
+            if (onDelete != null)
+              IconButton(
+                icon: const Icon(
+                  Icons.delete_outline,
+                  size: 18,
+                  color: colorError,
+                ),
+                onPressed: onDelete,
+              ),
           ],
         ),
       ),

--- a/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
+++ b/frontend/lib/screens/artist/edit_artist_tracks_sheet.dart
@@ -153,137 +153,147 @@ class _EditArtistTracksSheetState extends ConsumerState<EditArtistTracksSheet> {
   }
 
   Future<void> _editTrack(Track track) async {
-    final updated = await showDialog<Track>(
-      context: context,
-      builder: (dialogContext) {
-        final nameController = TextEditingController(text: track.name);
-        // All dialog-local state lives inside the StatefulBuilder scope so
-        // setDialogState rebuilds reach every value (PR #346 review F3).
-        var selectedColor = track.color;
-        var isSubmitting = false;
-        String? errorText;
+    // The controller lives outside `showDialog` so it can be disposed in
+    // `finally`. `StatefulBuilder` does not provide a `State.dispose()`
+    // hook, and creating the controller inside `builder` would leak it
+    // every time the user opens the edit dialog (PR #349 review C-1).
+    // Mirrors the try/finally pattern in register_artist_wizard.dart's
+    // rename dialog.
+    final nameController = TextEditingController(text: track.name);
+    try {
+      final updated = await showDialog<Track>(
+        context: context,
+        builder: (dialogContext) {
+          // All dialog-local state lives inside the StatefulBuilder scope so
+          // setDialogState rebuilds reach every value (PR #346 review F3).
+          var selectedColor = track.color;
+          var isSubmitting = false;
+          String? errorText;
 
-        return StatefulBuilder(
-          builder: (ctx, setDialogState) {
-            Future<void> save() async {
-              final newName = nameController.text.trim();
-              if (newName.isEmpty) {
-                setDialogState(() => errorText = ctx.l10n.trackNameRequired);
-                return;
-              }
-              // Reject duplicate names against the current local list,
-              // skipping the row being edited (otherwise renaming to the
-              // same name would always fail).
-              if (_tracks.any(
-                (t) =>
-                    t.id != track.id &&
-                    t.name.toLowerCase() == newName.toLowerCase(),
-              )) {
-                setDialogState(
-                  () => errorText = ctx.l10n.trackNameAlreadyExists,
-                );
-                return;
-              }
-
-              final nameChanged = newName != track.name;
-              final colorChanged = selectedColor != track.color;
-              if (!nameChanged && !colorChanged) {
-                Navigator.pop(dialogContext);
-                return;
-              }
-
-              setDialogState(() {
-                isSubmitting = true;
-                errorText = null;
-              });
-
-              final result = await ref
-                  .read(editArtistProvider.notifier)
-                  .updateTrack(
-                    id: track.id,
-                    name: nameChanged ? newName : null,
-                    color: colorChanged ? selectedColor : null,
+          return StatefulBuilder(
+            builder: (ctx, setDialogState) {
+              Future<void> save() async {
+                final newName = nameController.text.trim();
+                if (newName.isEmpty) {
+                  setDialogState(() => errorText = ctx.l10n.trackNameRequired);
+                  return;
+                }
+                // Reject duplicate names against the current local list,
+                // skipping the row being edited (otherwise renaming to the
+                // same name would always fail).
+                if (_tracks.any(
+                  (t) =>
+                      t.id != track.id &&
+                      t.name.toLowerCase() == newName.toLowerCase(),
+                )) {
+                  setDialogState(
+                    () => errorText = ctx.l10n.trackNameAlreadyExists,
                   );
+                  return;
+                }
 
-              if (!dialogContext.mounted) return;
-              if (result != null) {
-                Navigator.pop(dialogContext, result);
-              } else {
+                final nameChanged = newName != track.name;
+                final colorChanged = selectedColor != track.color;
+                if (!nameChanged && !colorChanged) {
+                  Navigator.pop(dialogContext);
+                  return;
+                }
+
                 setDialogState(() {
-                  isSubmitting = false;
-                  errorText = ctx.l10n.failedUpdateTrackRetry;
+                  isSubmitting = true;
+                  errorText = null;
                 });
-              }
-            }
 
-            return AlertDialog(
-              backgroundColor: colorSurface1,
-              scrollable: true,
-              insetPadding: const EdgeInsets.all(spaceLg),
-              title: Text(
-                ctx.l10n.editTrack,
-                style: const TextStyle(color: colorTextPrimary),
-              ),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  TextField(
-                    controller: nameController,
-                    autofocus: true,
-                    maxLength: 30,
-                    style: const TextStyle(color: colorTextPrimary),
-                    decoration: InputDecoration(
-                      labelText: ctx.l10n.trackName,
-                      labelStyle: const TextStyle(color: colorTextMuted),
-                      border: const OutlineInputBorder(),
-                      errorText: errorText,
+                final result = await ref
+                    .read(editArtistProvider.notifier)
+                    .updateTrack(
+                      id: track.id,
+                      name: nameChanged ? newName : null,
+                      color: colorChanged ? selectedColor : null,
+                    );
+
+                if (!dialogContext.mounted) return;
+                if (result != null) {
+                  Navigator.pop(dialogContext, result);
+                } else {
+                  setDialogState(() {
+                    isSubmitting = false;
+                    errorText = ctx.l10n.failedUpdateTrackRetry;
+                  });
+                }
+              }
+
+              return AlertDialog(
+                backgroundColor: colorSurface1,
+                scrollable: true,
+                insetPadding: const EdgeInsets.all(spaceLg),
+                title: Text(
+                  ctx.l10n.editTrack,
+                  style: const TextStyle(color: colorTextPrimary),
+                ),
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TextField(
+                      controller: nameController,
+                      autofocus: true,
+                      maxLength: 30,
+                      style: const TextStyle(color: colorTextPrimary),
+                      decoration: InputDecoration(
+                        labelText: ctx.l10n.trackName,
+                        labelStyle: const TextStyle(color: colorTextMuted),
+                        border: const OutlineInputBorder(),
+                        errorText: errorText,
+                      ),
+                      enabled: !isSubmitting,
+                      onSubmitted: isSubmitting ? null : (_) => save(),
                     ),
-                    enabled: !isSubmitting,
-                    onSubmitted: isSubmitting ? null : (_) => save(),
+                    const SizedBox(height: spaceMd),
+                    TrackColorPicker(
+                      selectedHex: selectedColor,
+                      onChanged: (hex) =>
+                          setDialogState(() => selectedColor = hex),
+                    ),
+                  ],
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: isSubmitting
+                        ? null
+                        : () => Navigator.pop(dialogContext),
+                    child: Text(ctx.l10n.cancel),
                   ),
-                  const SizedBox(height: spaceMd),
-                  TrackColorPicker(
-                    selectedHex: selectedColor,
-                    onChanged: (hex) =>
-                        setDialogState(() => selectedColor = hex),
+                  FilledButton(
+                    onPressed: isSubmitting ? null : save,
+                    child: isSubmitting
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : Text(ctx.l10n.save),
                   ),
                 ],
-              ),
-              actions: [
-                TextButton(
-                  onPressed: isSubmitting
-                      ? null
-                      : () => Navigator.pop(dialogContext),
-                  child: Text(ctx.l10n.cancel),
-                ),
-                FilledButton(
-                  onPressed: isSubmitting ? null : save,
-                  child: isSubmitting
-                      ? const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : Text(ctx.l10n.save),
-                ),
-              ],
-            );
-          },
-        );
-      },
-    );
+              );
+            },
+          );
+        },
+      );
 
-    if (updated == null || !mounted) return;
-    setState(() {
-      final idx = _tracks.indexWhere((t) => t.id == updated.id);
-      if (idx != -1) _tracks = [..._tracks]..[idx] = updated;
-    });
-    // Refresh the artist page so the updated color/name shows up in the
-    // timeline + node renderings, mirroring _deleteTrack's reload step.
-    await ref
-        .read(artistPageProvider.notifier)
-        .loadArtist(widget.artist.artistUsername);
+      if (updated == null || !mounted) return;
+      setState(() {
+        final idx = _tracks.indexWhere((t) => t.id == updated.id);
+        if (idx != -1) _tracks = [..._tracks]..[idx] = updated;
+      });
+      // Refresh the artist page so the updated color/name shows up in the
+      // timeline + node renderings, mirroring _deleteTrack's reload step.
+      await ref
+          .read(artistPageProvider.notifier)
+          .loadArtist(widget.artist.artistUsername);
+    } finally {
+      nameController.dispose();
+    }
   }
 
   Future<void> _deleteTrack(Track track) async {

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -16,6 +16,7 @@ import '../../widgets/common/connection_type_picker.dart';
 import '../../widgets/common/error_banner.dart';
 import '../../widgets/common/event_at_picker.dart';
 import '../../widgets/common/related_post_picker.dart';
+import '../../widgets/common/track_color_picker.dart';
 import '../../widgets/editor/rich_text_editor.dart';
 import '../../widgets/editor/text_body_counter.dart';
 import '../../theme/gleisner_tokens.dart';
@@ -384,48 +385,55 @@ class _TrackStep extends ConsumerWidget {
     showDialog<void>(
       context: context,
       builder: (dialogContext) {
+        // All dialog-local state lives inside the builder scope so the
+        // StatefulBuilder's setDialogState rebuilds reach every value
+        // (per PR #346 review F3 — variables outside StatefulBuilder
+        // are never observed by the inner setState).
         var isCreating = false;
         String? errorText;
-
-        Future<void> submit(StateSetter setDialogState) async {
-          final name = controller.text.trim();
-          if (name.isEmpty) {
-            setDialogState(
-              () => errorText = l10n.fieldRequired(l10n.trackName),
-            );
-            return;
-          }
-          if (tracks.any((t) => t.name.toLowerCase() == name.toLowerCase())) {
-            setDialogState(() => errorText = l10n.trackAlreadyExists(name));
-            return;
-          }
-
-          setDialogState(() {
-            isCreating = true;
-            errorText = null;
-          });
-
-          final track = await notifier.createTrack(name, autoColor);
-          if (track != null) {
-            if (dialogContext.mounted) Navigator.pop(dialogContext);
-          } else {
-            if (dialogContext.mounted) {
-              setDialogState(() {
-                isCreating = false;
-                errorText = l10n.failedCreateTrack;
-              });
-            }
-          }
-        }
+        var selectedColor = autoColor;
 
         return StatefulBuilder(
           builder: (ctx, setDialogState) {
+            Future<void> submit() async {
+              final name = controller.text.trim();
+              if (name.isEmpty) {
+                setDialogState(
+                  () => errorText = l10n.fieldRequired(l10n.trackName),
+                );
+                return;
+              }
+              if (tracks.any(
+                (t) => t.name.toLowerCase() == name.toLowerCase(),
+              )) {
+                setDialogState(() => errorText = l10n.trackAlreadyExists(name));
+                return;
+              }
+
+              setDialogState(() {
+                isCreating = true;
+                errorText = null;
+              });
+
+              final track = await notifier.createTrack(name, selectedColor);
+              if (track != null) {
+                if (dialogContext.mounted) Navigator.pop(dialogContext);
+              } else {
+                if (dialogContext.mounted) {
+                  setDialogState(() {
+                    isCreating = false;
+                    errorText = l10n.failedCreateTrack;
+                  });
+                }
+              }
+            }
+
             return AlertDialog(
               // PR #342 made Flutter's automatic insetPadding addition work
               // on iPhone Safari (by injecting visualViewport into MediaQuery),
               // so the dialog no longer flies off the top. But on small visible
               // areas (iPhone Safari with the keyboard up leaves ~358px of
-              // viewport height), the title + TextField + color preview row +
+              // viewport height), the title + TextField + color picker +
               // Cancel/Create buttons collectively exceed the available
               // vertical space, and the top edge of the dialog gets clipped.
               // `scrollable: true` makes Flutter wrap the title+content+actions
@@ -452,27 +460,13 @@ class _TrackStep extends ConsumerWidget {
                       border: const OutlineInputBorder(),
                       errorText: errorText,
                     ),
-                    onSubmitted: isCreating
-                        ? null
-                        : (_) => submit(setDialogState),
+                    onSubmitted: isCreating ? null : (_) => submit(),
                   ),
                   const SizedBox(height: spaceSm),
-                  Row(
-                    children: [
-                      Container(
-                        width: 16,
-                        height: 16,
-                        decoration: BoxDecoration(
-                          color: parseHexColor(autoColor),
-                          shape: BoxShape.circle,
-                        ),
-                      ),
-                      const SizedBox(width: spaceSm),
-                      Text(
-                        l10n.colorAutoAssigned,
-                        style: Theme.of(ctx).textTheme.labelSmall,
-                      ),
-                    ],
+                  TrackColorPicker(
+                    selectedHex: selectedColor,
+                    onChanged: (hex) =>
+                        setDialogState(() => selectedColor = hex),
                   ),
                 ],
               ),
@@ -482,7 +476,7 @@ class _TrackStep extends ConsumerWidget {
                   child: Text(l10n.cancel),
                 ),
                 FilledButton(
-                  onPressed: isCreating ? null : () => submit(setDialogState),
+                  onPressed: isCreating ? null : submit,
                   child: isCreating
                       ? const SizedBox(
                           width: 16,

--- a/frontend/lib/screens/profile/register_artist_wizard.dart
+++ b/frontend/lib/screens/profile/register_artist_wizard.dart
@@ -11,6 +11,7 @@ import '../../models/genre.dart';
 import '../../l10n/l10n.dart';
 import '../../providers/my_artist_provider.dart';
 import '../../theme/gleisner_tokens.dart';
+import '../../widgets/common/track_color_picker.dart';
 
 /// ADR 013: 4-step artist registration wizard.
 /// Step 1: Intro — feature overview
@@ -910,6 +911,14 @@ class _StepTracks extends StatelessWidget {
                   );
                   onTracksChanged(updated);
                 },
+                onColorChange: (newColor) {
+                  final updated = List<_TrackDraft>.from(tracks);
+                  updated[i] = _TrackDraft(
+                    name: tracks[i].name,
+                    color: newColor,
+                  );
+                  onTracksChanged(updated);
+                },
               ),
             const SizedBox(height: spaceMd),
           ],
@@ -1008,12 +1017,49 @@ class _TrackChip extends StatelessWidget {
   final _TrackDraft track;
   final VoidCallback onRemove;
   final ValueChanged<String> onRename;
+  final ValueChanged<String> onColorChange;
 
   const _TrackChip({
     required this.track,
     required this.onRemove,
     required this.onRename,
+    required this.onColorChange,
   });
+
+  Future<void> _editColor(BuildContext context) async {
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) {
+        var selectedHex = track.color;
+        return StatefulBuilder(
+          builder: (ctx, setDialogState) => AlertDialog(
+            backgroundColor: colorSurface1,
+            scrollable: true,
+            insetPadding: const EdgeInsets.all(spaceLg),
+            title: Text(
+              context.l10n.selectColor,
+              style: const TextStyle(color: colorTextPrimary),
+            ),
+            content: TrackColorPicker(
+              selectedHex: selectedHex,
+              onChanged: (hex) => setDialogState(() => selectedHex = hex),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: Text(context.l10n.cancel),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, selectedHex),
+                child: Text(context.l10n.save),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+    if (result != null && result != track.color) onColorChange(result);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1032,10 +1078,31 @@ class _TrackChip extends StatelessWidget {
         ),
         child: Row(
           children: [
-            Container(
-              width: 12,
-              height: 12,
-              decoration: BoxDecoration(shape: BoxShape.circle, color: color),
+            Semantics(
+              button: true,
+              label: context.l10n.selectColor,
+              child: InkWell(
+                onTap: () => _editColor(context),
+                borderRadius: BorderRadius.circular(22),
+                child: SizedBox(
+                  width: 32,
+                  height: 32,
+                  child: Center(
+                    child: Container(
+                      width: 16,
+                      height: 16,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: color,
+                        border: Border.all(
+                          color: color.withValues(alpha: 0.4),
+                          width: 1,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
             ),
             const SizedBox(width: spaceMd),
             Expanded(

--- a/frontend/lib/theme/gleisner_tokens.dart
+++ b/frontend/lib/theme/gleisner_tokens.dart
@@ -83,6 +83,19 @@ const radiusSheet = 20.0;
 const radiusFull = 999.0;
 
 // ---------------------------------------------------------------------------
+// Tap target / swatch sizes
+// ---------------------------------------------------------------------------
+
+/// Minimum interactive tap target per Material guidelines (matches
+/// Flutter's `kMinInteractiveDimension`).
+const tapTargetMin = 44.0;
+
+/// Visible diameter of a color swatch dot inside a tappable cell. The
+/// outer cell is `tapTargetMin` so the dot floats inside a generous
+/// touch zone for color-vision-deficient users.
+const swatchVisibleSize = 32.0;
+
+// ---------------------------------------------------------------------------
 // Responsive breakpoints (Idea 030)
 // ---------------------------------------------------------------------------
 
@@ -112,7 +125,14 @@ int responsiveGridColumns(double width) {
 }
 
 // ---------------------------------------------------------------------------
-// Track color presets (for auto-assignment)
+// Track color presets
+//
+// Used for both
+//   (1) auto-assigning a color when a track is created without an explicit
+//       picker selection (e.g. the artist registration wizard's default
+//       drafts), and
+//   (2) the preset swatch grid in `TrackColorPicker` so the quick-pick
+//       chips share the same palette as the auto-assignment rotation.
 // ---------------------------------------------------------------------------
 
 const trackColorPresets = [

--- a/frontend/lib/utils/color_hex.dart
+++ b/frontend/lib/utils/color_hex.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+/// Validates a `#RRGGBB` HEX string. Mirrors the backend regex in
+/// `backend/src/graphql/types/track.ts` so the client rejects bad input
+/// before sending the mutation.
+final hexColor6Regex = RegExp(r'^#[0-9A-Fa-f]{6}$');
+
+/// Whether [value] is a valid `#RRGGBB` HEX color (6 hex digits, leading `#`).
+/// Alpha-prefixed `#AARRGGBB` is intentionally rejected — Track.color is
+/// stored as `varchar(7)` in the DB and the regex enforces the same shape
+/// on both ends.
+bool isValidHex6(String? value) =>
+    value != null && hexColor6Regex.hasMatch(value);
+
+/// Converts a [Color] to a 6-digit `#RRGGBB` string, dropping the alpha
+/// channel.
+///
+/// `flutter_colorpicker` returns ARGB-encoded `Color` values
+/// (`0xAARRGGBB`). Track.color is RGB-only, so masking off the alpha
+/// byte is required to match the backend regex `/^#[0-9A-Fa-f]{6}$/`
+/// and the `varchar(7)` column shape.
+String colorToHex6(Color color) {
+  // `toARGB32()` returns the 32-bit ARGB representation. Masking with
+  // 0xFFFFFF drops the alpha byte so a fully opaque color does not
+  // become `#FF...` and an inadvertently semi-transparent picker
+  // output does not truncate into a different RGB value.
+  final rgb = color.toARGB32() & 0xFFFFFF;
+  return '#${rgb.toRadixString(16).toUpperCase().padLeft(6, '0')}';
+}
+
+/// Parses a `#RRGGBB` string into an opaque [Color]. Returns `null` for
+/// invalid input rather than throwing — callers typically want to fall
+/// back to a default presentation color (e.g. [colorTrackFallback]).
+Color? hex6ToColor(String? value) {
+  if (!isValidHex6(value)) return null;
+  final rgb = int.parse(value!.substring(1), radix: 16);
+  return Color(0xFF000000 | rgb);
+}

--- a/frontend/lib/utils/validators_l10n.dart
+++ b/frontend/lib/utils/validators_l10n.dart
@@ -1,4 +1,5 @@
 import '../l10n/l10n.dart';
+import 'color_hex.dart';
 
 /// Validator function type alias.
 typedef Validator = String? Function(String?);
@@ -41,5 +42,13 @@ Validator validateInviteCodeL10n(AppLocalizations l10n) => (value) {
   if (!_inviteCodeRegex.hasMatch(value.trim())) {
     return l10n.invalidInviteCode;
   }
+  return null;
+};
+
+/// Returns a localized HEX color (`#RRGGBB`) validator. Empty / null
+/// values are treated as required and rejected.
+Validator validateHexColorL10n(AppLocalizations l10n) => (value) {
+  if (value == null || value.isEmpty) return l10n.invalidHexFormat;
+  if (!isValidHex6(value)) return l10n.invalidHexFormat;
   return null;
 };

--- a/frontend/lib/utils/validators_l10n.dart
+++ b/frontend/lib/utils/validators_l10n.dart
@@ -1,5 +1,4 @@
 import '../l10n/l10n.dart';
-import 'color_hex.dart';
 
 /// Validator function type alias.
 typedef Validator = String? Function(String?);
@@ -42,13 +41,5 @@ Validator validateInviteCodeL10n(AppLocalizations l10n) => (value) {
   if (!_inviteCodeRegex.hasMatch(value.trim())) {
     return l10n.invalidInviteCode;
   }
-  return null;
-};
-
-/// Returns a localized HEX color (`#RRGGBB`) validator. Empty / null
-/// values are treated as required and rejected.
-Validator validateHexColorL10n(AppLocalizations l10n) => (value) {
-  if (value == null || value.isEmpty) return l10n.invalidHexFormat;
-  if (!isValidHex6(value)) return l10n.invalidHexFormat;
   return null;
 };

--- a/frontend/lib/widgets/common/track_color_picker.dart
+++ b/frontend/lib/widgets/common/track_color_picker.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
+
+import '../../l10n/l10n.dart';
+import '../../theme/gleisner_tokens.dart';
+import '../../utils/color_hex.dart';
+import '../../utils/ime_safe_focus.dart';
+
+/// Color picker that combines a 10-swatch preset grid with an optional
+/// "More colors" expansion that surfaces an HSV wheel + a HEX text input.
+///
+/// All color exchange happens via `#RRGGBB` 6-digit HEX strings to match
+/// the backend Track.color contract (`varchar(7)`,
+/// `/^#[0-9A-Fa-f]{6}$/`). Alpha is intentionally stripped — see
+/// `lib/utils/color_hex.dart`.
+///
+/// State (TextEditingController / FocusNode) is owned by the picker
+/// itself in `initState` / `dispose`, per
+/// `.claude/rules/frontend-implementation.md`
+/// "build() 内でリソースオブジェクトを生成しない".
+class TrackColorPicker extends StatefulWidget {
+  /// Currently selected color as a `#RRGGBB` HEX string. The picker
+  /// highlights this in the preset grid and uses it as the initial
+  /// position of the HSV wheel and the HEX text field.
+  final String selectedHex;
+
+  /// Called whenever the user picks a different color. Always invoked
+  /// with a valid `#RRGGBB` value (uppercase, alpha stripped). The
+  /// parent is responsible for storing this and re-rendering the
+  /// picker with the new [selectedHex].
+  final ValueChanged<String> onChanged;
+
+  const TrackColorPicker({
+    super.key,
+    required this.selectedHex,
+    required this.onChanged,
+  });
+
+  @override
+  State<TrackColorPicker> createState() => _TrackColorPickerState();
+}
+
+class _TrackColorPickerState extends State<TrackColorPicker> {
+  bool _showCustom = false;
+  late Color _customColor;
+  late final TextEditingController _hexController;
+  late final FocusNode _hexFocusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _customColor = hex6ToColor(widget.selectedHex) ?? colorTrackFallback;
+    _hexController = TextEditingController(
+      text: widget.selectedHex.toUpperCase(),
+    );
+    _hexFocusNode = createImeSafeFocusNode(_hexController);
+  }
+
+  @override
+  void didUpdateWidget(TrackColorPicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // When the parent forces a new selection (e.g. user tapped a preset),
+    // sync the wheel + text field so re-opening "More colors" starts
+    // from the latest pick.
+    if (widget.selectedHex != oldWidget.selectedHex) {
+      final parsed = hex6ToColor(widget.selectedHex);
+      if (parsed != null) _customColor = parsed;
+      final upper = widget.selectedHex.toUpperCase();
+      if (_hexController.text != upper) {
+        _hexController.text = upper;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    // FocusNode must be disposed before the controller (the IME-safe
+    // focus node holds a reference to the controller — see
+    // `lib/utils/ime_safe_focus.dart`).
+    _hexFocusNode.dispose();
+    _hexController.dispose();
+    super.dispose();
+  }
+
+  void _onPresetTap(String hex) {
+    final upper = hex.toUpperCase();
+    setState(() {
+      final parsed = hex6ToColor(upper);
+      if (parsed != null) _customColor = parsed;
+      if (_hexController.text != upper) _hexController.text = upper;
+    });
+    widget.onChanged(upper);
+  }
+
+  void _onWheelColorChanged(Color color) {
+    final hex = colorToHex6(color);
+    setState(() {
+      _customColor = color;
+      if (_hexController.text != hex) _hexController.text = hex;
+    });
+    widget.onChanged(hex);
+  }
+
+  void _onHexFieldChanged(String raw) {
+    var value = raw.trim().toUpperCase();
+    if (value.isNotEmpty && !value.startsWith('#')) {
+      value = '#$value';
+    }
+    if (!isValidHex6(value)) {
+      // Don't propagate invalid input upstream; the validator decoration
+      // surfaces the error via the field's helperText/errorText below.
+      setState(() {});
+      return;
+    }
+    final parsed = hex6ToColor(value);
+    if (parsed == null) return;
+    setState(() => _customColor = parsed);
+    widget.onChanged(value);
+  }
+
+  String? _hexFieldError(AppLocalizations l10n) {
+    final raw = _hexController.text.trim();
+    if (raw.isEmpty) return null;
+    var value = raw.toUpperCase();
+    if (!value.startsWith('#')) value = '#$value';
+    return isValidHex6(value) ? null : l10n.invalidHexFormat;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final selected = widget.selectedHex.toLowerCase();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(l10n.selectColor, style: Theme.of(context).textTheme.labelMedium),
+        const SizedBox(height: spaceSm),
+        Wrap(
+          spacing: spaceXs,
+          runSpacing: spaceXs,
+          children: [
+            for (final preset in trackColorPresets)
+              _PresetSwatch(
+                hex: preset,
+                isSelected: preset.toLowerCase() == selected,
+                onTap: () => _onPresetTap(preset),
+                semanticsLabel: l10n.colorPresetLabel(preset),
+              ),
+          ],
+        ),
+        const SizedBox(height: spaceSm),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton.icon(
+            onPressed: () => setState(() => _showCustom = !_showCustom),
+            icon: Icon(_showCustom ? Icons.expand_less : Icons.expand_more),
+            label: Text(l10n.moreColors),
+          ),
+        ),
+        if (_showCustom) ...[
+          ColorPicker(
+            pickerColor: _customColor,
+            onColorChanged: _onWheelColorChanged,
+            enableAlpha: false,
+            displayThumbColor: true,
+            paletteType: PaletteType.hueWheel,
+            labelTypes: const [],
+            pickerAreaBorderRadius: BorderRadius.circular(radiusMd),
+          ),
+          const SizedBox(height: spaceSm),
+          TextField(
+            controller: _hexController,
+            focusNode: _hexFocusNode,
+            decoration: InputDecoration(
+              labelText: l10n.customColorHex,
+              hintText: '#RRGGBB',
+              border: const OutlineInputBorder(),
+              errorText: _hexFieldError(l10n),
+            ),
+            maxLength: 7,
+            textCapitalization: TextCapitalization.characters,
+            onChanged: _onHexFieldChanged,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _PresetSwatch extends StatelessWidget {
+  final String hex;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final String semanticsLabel;
+
+  const _PresetSwatch({
+    required this.hex,
+    required this.isSelected,
+    required this.onTap,
+    required this.semanticsLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = hex6ToColor(hex) ?? colorTrackFallback;
+    return Semantics(
+      label: semanticsLabel,
+      button: true,
+      selected: isSelected,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(22),
+        // 44x44 logical px meets the Material minimum tap target while
+        // keeping the visible swatch a calmer 32x32 dot. The check icon
+        // doubles as a non-color cue for color-vision-deficient users
+        // (PR #346 review F5).
+        child: SizedBox(
+          width: 44,
+          height: 44,
+          child: Center(
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: color,
+                    shape: BoxShape.circle,
+                    border: isSelected
+                        ? Border.all(color: colorAccentGold, width: 2)
+                        : null,
+                  ),
+                ),
+                if (isSelected)
+                  const Icon(Icons.check, size: 16, color: Colors.white),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/widgets/common/track_color_picker.dart
+++ b/frontend/lib/widgets/common/track_color_picker.dart
@@ -67,7 +67,17 @@ class _TrackColorPickerState extends State<TrackColorPicker> {
       if (parsed != null) _customColor = parsed;
       final upper = widget.selectedHex.toUpperCase();
       if (_hexController.text != upper) {
+        // Preserve the cursor position when possible: assigning to
+        // `.text` resets `selection` to the end, which yanks the caret
+        // away if the user is mid-edit while the wheel changes the
+        // controller text (PR #349 review I-1). Restoring the previous
+        // selection only when it still fits the new text avoids out-of-
+        // bounds errors when shrinking.
+        final prevSelection = _hexController.selection;
         _hexController.text = upper;
+        if (prevSelection.isValid && prevSelection.end <= upper.length) {
+          _hexController.selection = prevSelection;
+        }
       }
     }
   }
@@ -109,6 +119,9 @@ class _TrackColorPickerState extends State<TrackColorPicker> {
     if (!isValidHex6(value)) {
       // Don't propagate invalid input upstream; the validator decoration
       // surfaces the error via the field's helperText/errorText below.
+      // The empty `setState` is intentional — it re-runs `_hexFieldError`
+      // in `build()` so the InputDecoration.errorText reflects the new
+      // controller value (PR #349 review N-3).
       setState(() {});
       return;
     }
@@ -211,21 +224,23 @@ class _PresetSwatch extends StatelessWidget {
       selected: isSelected,
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(22),
-        // 44x44 logical px meets the Material minimum tap target while
-        // keeping the visible swatch a calmer 32x32 dot. The check icon
-        // doubles as a non-color cue for color-vision-deficient users
-        // (PR #346 review F5).
+        // Pill-shaped ripple sized to the cell so the visual feedback
+        // stays inside the tap zone (radius = tapTargetMin / 2).
+        borderRadius: BorderRadius.circular(tapTargetMin / 2),
+        // `tapTargetMin` meets the Material minimum tap target while
+        // keeping the visible swatch a calmer `swatchVisibleSize` dot.
+        // The check icon doubles as a non-color cue for color-vision-
+        // deficient users (PR #346 review F5).
         child: SizedBox(
-          width: 44,
-          height: 44,
+          width: tapTargetMin,
+          height: tapTargetMin,
           child: Center(
             child: Stack(
               alignment: Alignment.center,
               children: [
                 Container(
-                  width: 32,
-                  height: 32,
+                  width: swatchVisibleSize,
+                  height: swatchVisibleSize,
                   decoration: BoxDecoration(
                     color: color,
                     shape: BoxShape.circle,
@@ -235,7 +250,13 @@ class _PresetSwatch extends StatelessWidget {
                   ),
                 ),
                 if (isSelected)
-                  const Icon(Icons.check, size: 16, color: Colors.white),
+                  // Sized to read clearly on the dot without dominating it
+                  // (≈ swatchVisibleSize / 2).
+                  Icon(
+                    Icons.check,
+                    size: swatchVisibleSize / 2,
+                    color: Colors.white,
+                  ),
               ],
             ),
           ),

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -247,7 +247,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_colorpicker:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_colorpicker
       sha256: "969de5f6f9e2a570ac660fb7b501551451ea2a1ab9e2097e89475f60e07816ea"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -54,6 +54,11 @@ dependencies:
   # graphql_flutter; declared explicitly to satisfy `depend_on_referenced_packages`.
   web: ^1.1.1
 
+  # Used directly by lib/widgets/common/track_color_picker.dart for the
+  # "More colors" HSV picker fallback. Already a transitive dep via
+  # flutter_quill; declared explicitly to satisfy `depend_on_referenced_packages`.
+  flutter_colorpicker: ^1.1.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/frontend/test/utils/color_hex_test.dart
+++ b/frontend/test/utils/color_hex_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gleisner_web/utils/color_hex.dart';
+
+void main() {
+  group('isValidHex6', () {
+    test('accepts canonical lowercase 6-digit HEX', () {
+      expect(isValidHex6('#f97316'), isTrue);
+    });
+
+    test('accepts uppercase 6-digit HEX', () {
+      expect(isValidHex6('#F97316'), isTrue);
+    });
+
+    test('accepts mixed-case 6-digit HEX', () {
+      expect(isValidHex6('#aB12Cd'), isTrue);
+    });
+
+    test('rejects null', () {
+      expect(isValidHex6(null), isFalse);
+    });
+
+    test('rejects empty string', () {
+      expect(isValidHex6(''), isFalse);
+    });
+
+    test('rejects HEX without leading #', () {
+      expect(isValidHex6('f97316'), isFalse);
+    });
+
+    test('rejects 3-digit short HEX', () {
+      expect(isValidHex6('#fff'), isFalse);
+    });
+
+    test('rejects 8-digit ARGB HEX', () {
+      // Backend column is varchar(7) RGB-only; ARGB must not pass.
+      expect(isValidHex6('#FFf97316'), isFalse);
+    });
+
+    test('rejects non-hex characters', () {
+      expect(isValidHex6('#zzzzzz'), isFalse);
+    });
+
+    test('rejects extra trailing whitespace', () {
+      // Callers are expected to trim before calling — the regex itself
+      // is anchored, so any surrounding noise must be rejected.
+      expect(isValidHex6('#f97316 '), isFalse);
+    });
+  });
+
+  group('colorToHex6', () {
+    test('serializes a fully-opaque color without the alpha byte', () {
+      final result = colorToHex6(const Color(0xFFF97316));
+      expect(result, '#F97316');
+    });
+
+    test('strips alpha from a semi-transparent color', () {
+      // flutter_colorpicker can return ARGB values where alpha != FF if
+      // a downstream caller flips enableAlpha to true. We must never
+      // forward those as 8-digit HEX into a varchar(7) column.
+      final result = colorToHex6(const Color(0x80F97316));
+      expect(result, '#F97316');
+    });
+
+    test('zero-pads short RGB values to 6 digits', () {
+      // 0x000001 would otherwise serialize as '#1'.
+      final result = colorToHex6(const Color(0xFF000001));
+      expect(result, '#000001');
+    });
+
+    test('always emits uppercase output', () {
+      final result = colorToHex6(const Color(0xFFabcdef));
+      expect(result, '#ABCDEF');
+    });
+  });
+
+  group('hex6ToColor', () {
+    test('parses canonical lowercase HEX into an opaque color', () {
+      final result = hex6ToColor('#f97316');
+      expect(result, isNotNull);
+      // Reconstructed color is always alpha=FF, RGB matches input.
+      expect(colorToHex6(result!), '#F97316');
+    });
+
+    test('parses uppercase HEX', () {
+      final result = hex6ToColor('#F97316');
+      expect(result, isNotNull);
+      expect(colorToHex6(result!), '#F97316');
+    });
+
+    test('returns null for invalid input', () {
+      expect(hex6ToColor('not a color'), isNull);
+      expect(hex6ToColor(''), isNull);
+      expect(hex6ToColor(null), isNull);
+      expect(hex6ToColor('#fff'), isNull);
+    });
+
+    test('round-trips colorToHex6 ↔ hex6ToColor for all preset values', () {
+      const presets = [
+        '#f97316',
+        '#a78bfa',
+        '#22d3ee',
+        '#84cc16',
+        '#ef4444',
+        '#fbbf24',
+        '#ec4899',
+        '#14b8a6',
+        '#8b5cf6',
+        '#f43f5e',
+      ];
+      for (final hex in presets) {
+        final color = hex6ToColor(hex);
+        expect(color, isNotNull, reason: 'failed to parse $hex');
+        expect(
+          colorToHex6(color!).toLowerCase(),
+          hex.toLowerCase(),
+          reason: '$hex did not round-trip',
+        );
+      }
+    });
+  });
+}

--- a/frontend/test/widgets/track_color_picker_test.dart
+++ b/frontend/test/widgets/track_color_picker_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gleisner_web/l10n/app_localizations.dart';
+import 'package:gleisner_web/theme/gleisner_tokens.dart';
+import 'package:gleisner_web/widgets/common/track_color_picker.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+  locale: const Locale('en'),
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(body: SingleChildScrollView(child: child)),
+);
+
+void main() {
+  group('TrackColorPicker', () {
+    testWidgets('renders the section heading and the More colors toggle', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          TrackColorPicker(
+            selectedHex: trackColorPresets[0],
+            onChanged: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Select a color'), findsOneWidget);
+      expect(find.text('More colors'), findsOneWidget);
+      // The HEX text field is collapsed until the user expands "More colors".
+      expect(find.text('Custom color (HEX)'), findsNothing);
+    });
+
+    testWidgets(
+      'tapping a preset swatch fires onChanged with that uppercase HEX',
+      (tester) async {
+        String? lastEmitted;
+        await tester.pumpWidget(
+          _wrap(
+            TrackColorPicker(
+              selectedHex: trackColorPresets[0],
+              onChanged: (hex) => lastEmitted = hex,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Each preset is wrapped in Semantics(button: true, label: 'Color #...')
+        // so the screen-reader path is also the canonical lookup path here.
+        await tester.tap(
+          find.bySemanticsLabel('Color ${trackColorPresets[1]}'),
+        );
+        await tester.pumpAndSettle();
+
+        expect(lastEmitted, trackColorPresets[1].toUpperCase());
+      },
+    );
+
+    testWidgets('expanding More colors reveals the HEX text field', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          TrackColorPicker(
+            selectedHex: trackColorPresets[0],
+            onChanged: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('More colors'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Custom color (HEX)'), findsOneWidget);
+    });
+
+    testWidgets('typing a valid HEX into the text field fires onChanged', (
+      tester,
+    ) async {
+      String? lastEmitted;
+      await tester.pumpWidget(
+        _wrap(
+          TrackColorPicker(
+            selectedHex: trackColorPresets[0],
+            onChanged: (hex) => lastEmitted = hex,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Expand the custom-input section first.
+      await tester.tap(find.text('More colors'));
+      await tester.pumpAndSettle();
+
+      // Find the HEX TextField via its decoration label (the only TextField
+      // inside this widget when the section is expanded).
+      final hexField = find.widgetWithText(TextField, 'Custom color (HEX)');
+      expect(hexField, findsOneWidget);
+
+      await tester.enterText(hexField, '#abcdef');
+      await tester.pump();
+
+      // The picker normalizes the value to uppercase before propagating.
+      expect(lastEmitted, '#ABCDEF');
+    });
+
+    testWidgets(
+      'typing an invalid HEX shows the error and suppresses onChanged',
+      (tester) async {
+        var emitCount = 0;
+        await tester.pumpWidget(
+          _wrap(
+            TrackColorPicker(
+              selectedHex: trackColorPresets[0],
+              onChanged: (_) => emitCount++,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('More colors'));
+        await tester.pumpAndSettle();
+
+        final hexField = find.widgetWithText(TextField, 'Custom color (HEX)');
+        await tester.enterText(hexField, 'nope');
+        await tester.pump();
+
+        expect(find.text('Invalid HEX format (e.g. #ff0000)'), findsOneWidget);
+        expect(emitCount, 0);
+      },
+    );
+  });
+}

--- a/frontend/test/widgets/track_color_picker_test.dart
+++ b/frontend/test/widgets/track_color_picker_test.dart
@@ -131,5 +131,50 @@ void main() {
         expect(emitCount, 0);
       },
     );
+
+    testWidgets(
+      'didUpdateWidget syncs the highlighted preset when selectedHex changes externally',
+      (tester) async {
+        // The selected swatch is the only one that overlays Icons.check on
+        // its dot, so we use that as a stable visual signal that the
+        // highlight has propagated. This sidesteps the SemanticsFlag API
+        // (which has shifted between Flutter versions) while still proving
+        // didUpdateWidget reaches build().
+        Finder checkIconInside(String hex) => find.descendant(
+          of: find.bySemanticsLabel('Color $hex'),
+          matching: find.byIcon(Icons.check),
+        );
+
+        // Phase 1: parent says preset[0] is selected.
+        await tester.pumpWidget(
+          _wrap(
+            TrackColorPicker(
+              selectedHex: trackColorPresets[0],
+              onChanged: (_) {},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(checkIconInside(trackColorPresets[0]), findsOneWidget);
+        expect(checkIconInside(trackColorPresets[3]), findsNothing);
+
+        // Phase 2: parent forces a different selection (e.g. the user
+        // tapped preset[3] from a sibling control); didUpdateWidget should
+        // propagate the highlight without any local taps.
+        await tester.pumpWidget(
+          _wrap(
+            TrackColorPicker(
+              selectedHex: trackColorPresets[3],
+              onChanged: (_) {},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(checkIconInside(trackColorPresets[3]), findsOneWidget);
+        expect(checkIconInside(trackColorPresets[0]), findsNothing);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Adds the **track color picker** feature so users can pick the color of every track they create *and* edit existing track colors. Implements the yatima `feedback_track_color_user_picker` memory item and aligns with ADR 012 (track color is a client-specified `#RRGGBB`).

The picker rolls out to every track-creation flow today (3 places) and unlocks the edit half by adding the missing `updateTrack` mutation/provider/UI. Backend work was already done — this PR is frontend-only, save for a docstring on the new mutation that points to the backend regex.

PR-A (#346) landed first to establish the leak-prevention pattern (`Future<T?>` + `debugPrint`); this PR follows that pattern verbatim for the new `updateTrack` provider.

## Egan thread

> Aligns with the yatima Egan thread "Self-determination" — artists pick the color of their own constellation stars rather than having one auto-assigned. Auto-color is still the default seed so users who don't care get the same rotation they had before.

## Commits

| SHA | Subject |
|---|---|
| `23c4c47` | `feat(frontend): add TrackColorPicker widget + color_hex utils + l10n strings (PR-B base)` |
| `96b1cfc` | `feat(frontend): wire TrackColorPicker into the three track-creation flows (PR-B create-side)` |
| `e1ed5c3` | `feat(frontend): add updateTrack mutation + edit dialog with name/color (PR-B edit-side)` |
| `8bb90d0` | `test(frontend): add color_hex unit tests + TrackColorPicker widget tests` |

## What changed

### New widget — `lib/widgets/common/track_color_picker.dart`

`StatefulWidget` that owns its own `TextEditingController` + IME-safe `FocusNode`. Renders 10 preset swatches in a `Wrap` grid (44×44 logical px tap target, 32×32 visible dot, `Icons.check` overlay on the selected one — the check doubles as a non-color cue for color-vision-deficient users). The "More colors" toggle reveals an HSV wheel (`flutter_colorpicker`) plus a normalized HEX text field. All values are exchanged as `#RRGGBB` uppercase strings; alpha is stripped via `color.toARGB32() & 0xFFFFFF`.

### New utils — `lib/utils/color_hex.dart`

`isValidHex6` / `colorToHex6` / `hex6ToColor`. Mirrors the backend regex in `backend/src/graphql/types/track.ts` so the client rejects bad input before sending the mutation.

### Validator — `validateHexColorL10n` in `lib/utils/validators_l10n.dart`

Returns `l10n.invalidHexFormat` for empty or malformed values. Same shape as `validateEmail` etc. in the same file.

### l10n — 8 new keys (en / ja)

`selectColor`, `moreColors`, `customColorHex`, `invalidHexFormat`, `editTrack`, `failedUpdateTrack`, `failedUpdateTrackRetry`, `colorPresetLabel({hex})`. Regenerated via `flutter gen-l10n`.

### Create-side — picker wired into 3 flows

| Flow | File | Change |
|---|---|---|
| Edit Artist tracks bottom sheet | `lib/screens/artist/edit_artist_tracks_sheet.dart` | Adds `_selectedColor` State seeded with the next auto-color; renders `TrackColorPicker` between the name field and the buttons |
| New track dialog (create_post) | `lib/screens/create_post/create_post_screen.dart` | Hoists `selectedColor` into the `StatefulBuilder.builder` scope (per PR #346 review F3); replaces the auto-color preview row with a full `TrackColorPicker` |
| Artist registration wizard | `lib/screens/profile/register_artist_wizard.dart` | `_TrackChip` gains `onColorChange`; the swatch is now a 32×32 tap target that opens an `AlertDialog` with `TrackColorPicker` and a Save/Cancel pair |

### Edit-side — new `updateTrack` mutation + dialog

- **`lib/graphql/mutations/track.dart`**: `updateTrackMutation` with optional `$name`/`$color` per backend signature.
- **`lib/providers/edit_artist_provider.dart`**: `EditArtistNotifier.updateTrack({ id, name?, color? })`. Same shape as `createTrack` after PR #346 — `Future<Track?>` on success / `null` on failure, `debugPrint` on every error branch, never surfaces GraphQL error text. Uses Dart 3.10 null-aware map elements (`?name` / `?color`) to elide null variables, matching `updateLink` in the same file.
- **`EditArtistTracksSheet`**: gains an `isOwner` flag (default `false`, the safe default). Add / edit / delete buttons all gate on it (defense-in-depth per PR #346 review S2). `_TrackRow` now takes nullable `onDelete` + `onEdit` callbacks (kept as `StatelessWidget` per PR #346 review F2). The new `_editTrack()` opens an `AlertDialog` with `TextField` + `TrackColorPicker`, validates name (required + duplicate against the local list, skipping the row being edited), only sends fields that actually changed, and disables buttons while submitting.
- **`artist_page_screen.dart`**: passes `isOwner: true` explicitly with a comment pointing at the existing `isSelf` gates.

### Tests — 23 new tests

| File | Tests | Notes |
|---|---|---|
| `test/utils/color_hex_test.dart` | 18 | `isValidHex6` / `colorToHex6` / `hex6ToColor`, including alpha stripping, ARGB rejection, round-trip across all 10 presets |
| `test/widgets/track_color_picker_test.dart` | 5 | Renders heading + toggle, preset tap fires `onChanged`, expansion reveals HEX field, valid HEX propagates uppercase, invalid HEX shows error and suppresses `onChanged` |

## Out of scope (filed as Issues)

- **#347** — `EditArtistNotifier.createTrack ↔ _addTrack` double-fetch (filed from PR #346 round-2 review). Resolving requires picking between in-notifier local-state update vs. caller-driven refetch; affects `updateTrack` too but the new path inherits the same shape so no new debt is introduced.
- **#348** — `EditArtistNotifier.createTrack` success-path test (filed from PR #346 round-2 review). Scope should be widened to include `EditArtistTracksSheet` widget tests for the edit dialog (open / `isOwner=false` hides icons / `updateTrack` mock verification) once the test scaffolding lands.
- **Phase 1 Issues to file once this PR merges** (deferred from PR #346 round-1 synthesis review):
  - `track` single-entity query has no auth check (information leak via existence enumeration when SNS opens).
  - `createTrack` 10-track cap is checked client-side only — backend needs `SELECT FOR UPDATE` to be TOCTOU-safe under concurrent requests.

## Local checks

```
dart analyze lib/                                    → No issues
dart format --set-exit-if-changed (full PR scope)    → 0 changed
flutter test --platform chrome                       → All tests passed!
                                                       (incl. 23 new tests)
```

## Manual verification checklist (for reviewer)

- [ ] Edit Artist sheet → Add track: picker renders, preset selection updates the dot, "More colors" reveals HEX + wheel, Save persists the chosen color
- [ ] Create-post → New track dialog: picker renders, color survives to the created track
- [ ] Artist registration wizard: tapping the swatch on a draft track opens the picker dialog, Save updates that draft
- [ ] Edit Artist sheet → row edit icon: opens dialog with current name/color pre-populated, Save updates both, Cancel discards
- [ ] Read-only context (someone else's artist page → can't open the sheet) — still verify the sheet renders without edit/delete if `isOwner: false` is forced via inspector
- [ ] dark mode: preset swatches remain visible against the "アーティストの宇宙" background

🤖 Generated with [Claude Code](https://claude.com/claude-code)
