### PR TITLE
fix(timeline): restore delete UI in iPad side panel and align horizontal scroll with side nav

### DIFF
--- a/frontend/lib/screens/timeline/public_timeline_screen.dart
+++ b/frontend/lib/screens/timeline/public_timeline_screen.dart
@@ -191,7 +191,12 @@ class _PublicTimelineScreenState extends ConsumerState<PublicTimelineScreen>
                       builder: (context, constraints) {
                         final width = constraints.maxWidth;
                         final height = constraints.maxHeight;
-                        final useHorizontal = isDesktop(width);
+                        // Tie horizontal scroll to the same breakpoint as the
+                        // NavigationRail (Idea 030), and use the screen width
+                        // so the decision is consistent with the authenticated
+                        // timeline.
+                        final screenWidth = MediaQuery.of(context).size.width;
+                        final useHorizontal = isTabletOrWider(screenWidth);
                         if (_lastWidth != width || _lastHeight != height) {
                           _lastWidth = width;
                           _lastHeight = height;

--- a/frontend/lib/screens/timeline/public_timeline_screen.dart
+++ b/frontend/lib/screens/timeline/public_timeline_screen.dart
@@ -37,6 +37,7 @@ class _PublicTimelineScreenState extends ConsumerState<PublicTimelineScreen>
     with SingleTickerProviderStateMixin {
   double? _lastWidth;
   double? _lastHeight;
+  bool? _lastUseHorizontal;
   final ScrollController _scrollController = ScrollController();
   final ValueNotifier<double> _scrollOffset = ValueNotifier(0);
   String? _focusedPostId;
@@ -82,6 +83,10 @@ class _PublicTimelineScreenState extends ConsumerState<PublicTimelineScreen>
         isAuthenticated &&
         timeline.artist != null &&
         timeline.artist!.artistUsername == widget.username;
+    // Compute outside LayoutBuilder so the orientation decision is taken
+    // from the screen width (size-only MediaQuery dependency) rather than
+    // the inner constraint, which the NavigationRail / side panel shrink.
+    final useHorizontal = useHorizontalTimeline(context);
 
     return Scaffold(
       backgroundColor: colorSurface0,
@@ -191,15 +196,16 @@ class _PublicTimelineScreenState extends ConsumerState<PublicTimelineScreen>
                       builder: (context, constraints) {
                         final width = constraints.maxWidth;
                         final height = constraints.maxHeight;
-                        // Tie horizontal scroll to the same breakpoint as the
-                        // NavigationRail (Idea 030), and use the screen width
-                        // so the decision is consistent with the authenticated
-                        // timeline.
-                        final screenWidth = MediaQuery.of(context).size.width;
-                        final useHorizontal = isTabletOrWider(screenWidth);
-                        if (_lastWidth != width || _lastHeight != height) {
+                        // Re-dispatch when orientation flips at the same
+                        // viewport size (e.g. screen-level resize that crosses
+                        // the tablet breakpoint without the inner constraint
+                        // changing).
+                        if (_lastWidth != width ||
+                            _lastHeight != height ||
+                            _lastUseHorizontal != useHorizontal) {
                           _lastWidth = width;
                           _lastHeight = height;
+                          _lastUseHorizontal = useHorizontal;
                           WidgetsBinding.instance.addPostFrameCallback((_) {
                             if (!context.mounted) return;
                             ref

--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -38,6 +38,7 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
     with SingleTickerProviderStateMixin {
   double? _lastWidth;
   double? _lastHeight;
+  bool? _lastUseHorizontal;
   // Issue #160 recovery path: when layout is null but items exist (Notifier
   // rebuild zeroed _lastWidth), schedule a single computeLayout dispatch.
   // The flag prevents addPostFrameCallback from being re-registered every
@@ -178,6 +179,11 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
 
     final theme = Theme.of(context);
     final isOwn = _isOwnTimeline;
+    // Decide orientation outside LayoutBuilder so it depends on the screen
+    // width (size-only MediaQuery dependency) rather than the inner
+    // constraint, which the NavigationRail / side panel shrink. Idea 030
+    // ties horizontal scroll to the same breakpoint as the side nav.
+    final useHorizontal = useHorizontalTimeline(context);
 
     // Show first-post tutorial when: artist mode + no posts + not seen + loaded
     final tutorialState = ref.watch(tutorialProvider);
@@ -491,19 +497,6 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                                 builder: (context, constraints) {
                                   final width = constraints.maxWidth;
                                   final height = constraints.maxHeight;
-                                  // Tie horizontal scroll to the same
-                                  // breakpoint as the NavigationRail so the
-                                  // timeline orientation flips together with
-                                  // the side nav (Idea 030). Use the screen
-                                  // width — not constraints.maxWidth — so the
-                                  // decision stays stable when the side detail
-                                  // panel opens and shrinks the inner column.
-                                  final screenWidth = MediaQuery.of(
-                                    context,
-                                  ).size.width;
-                                  final useHorizontal = isTabletOrWider(
-                                    screenWidth,
-                                  );
                                   // Re-dispatch when layout is missing despite
                                   // having items: TimelineNotifier loses its
                                   // viewport (_lastWidth=0) on Riverpod rebuild
@@ -512,6 +505,11 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                                   // chains to timelineProvider. The widget-side
                                   // width/height haven't changed so the prior
                                   // guard skipped re-dispatch (Issue #160).
+                                  // Also re-dispatch when useHorizontal flips
+                                  // at the same constraint size (rare, but a
+                                  // screen-level resize crossing the tablet
+                                  // breakpoint can leave constraints stable
+                                  // when the rail toggles in/out).
                                   final hasItems =
                                       timeline.posts.isNotEmpty ||
                                       (timeline.artist?.milestones.isNotEmpty ??
@@ -520,7 +518,8 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                                       timeline.layout == null && hasItems;
                                   final viewportChanged =
                                       _lastWidth != width ||
-                                      _lastHeight != height;
+                                      _lastHeight != height ||
+                                      _lastUseHorizontal != useHorizontal;
                                   if (viewportChanged) {
                                     // Viewport actually changed — always
                                     // redispatch and reset the recovery flag
@@ -528,6 +527,7 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                                     // dispatch again.
                                     _lastWidth = width;
                                     _lastHeight = height;
+                                    _lastUseHorizontal = useHorizontal;
                                     _layoutDispatchInFlight = false;
                                     _scheduleComputeLayout(
                                       width,
@@ -974,6 +974,9 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
               onNameConstellation: isOwn
                   ? (postId, name) => notifier.nameConstellation(postId, name)
                   : null,
+              // Constellation removal updates the post locally (the post
+              // stays in the timeline), so the side panel can stay open and
+              // PostDetailContent updates its own UI via _removedConstellationIds.
               onDeleteConstellation: isOwn
                   ? (id) => notifier.deleteConstellation(id)
                   : null,
@@ -983,12 +986,12 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                       _openEditPost(post);
                     }
                   : null,
+              // Unlike the bottom-sheet path, PostDetailContent in embedded
+              // mode skips Navigator.pop, so we must close the side panel
+              // ourselves once the post is gone from the timeline.
               onDeletePost: isOwn
                   ? () async {
                       final success = await notifier.deletePost(post.id);
-                      // PostDetailContent skips Navigator.pop in embedded
-                      // mode, so the side panel must close itself when
-                      // the post is gone from the timeline.
                       if (success && mounted) {
                         setState(() => _sidePanelPostId = null);
                       }
@@ -1048,6 +1051,10 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
               _openEditPost(post);
             }
           : null,
+      // Bottom-sheet path: PostDetailContent's _confirmDeletePost calls
+      // Navigator.pop after a successful delete (since embedded == false),
+      // so we don't need to close the modal ourselves here. The embedded
+      // counterpart in _buildSidePanel handles its own close.
       onDeletePost: isOwn ? () => notifier.deletePost(post.id) : null,
       allPosts: ref.read(timelineProvider).posts,
     );

--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -491,7 +491,19 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                                 builder: (context, constraints) {
                                   final width = constraints.maxWidth;
                                   final height = constraints.maxHeight;
-                                  final useHorizontal = isDesktop(width);
+                                  // Tie horizontal scroll to the same
+                                  // breakpoint as the NavigationRail so the
+                                  // timeline orientation flips together with
+                                  // the side nav (Idea 030). Use the screen
+                                  // width — not constraints.maxWidth — so the
+                                  // decision stays stable when the side detail
+                                  // panel opens and shrinks the inner column.
+                                  final screenWidth = MediaQuery.of(
+                                    context,
+                                  ).size.width;
+                                  final useHorizontal = isTabletOrWider(
+                                    screenWidth,
+                                  );
                                   // Re-dispatch when layout is missing despite
                                   // having items: TimelineNotifier loses its
                                   // viewport (_lastWidth=0) on Riverpod rebuild
@@ -962,10 +974,25 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
               onNameConstellation: isOwn
                   ? (postId, name) => notifier.nameConstellation(postId, name)
                   : null,
+              onDeleteConstellation: isOwn
+                  ? (id) => notifier.deleteConstellation(id)
+                  : null,
               onEdit: isOwn
                   ? () {
                       setState(() => _sidePanelPostId = null);
                       _openEditPost(post);
+                    }
+                  : null,
+              onDeletePost: isOwn
+                  ? () async {
+                      final success = await notifier.deletePost(post.id);
+                      // PostDetailContent skips Navigator.pop in embedded
+                      // mode, so the side panel must close itself when
+                      // the post is gone from the timeline.
+                      if (success && mounted) {
+                        setState(() => _sidePanelPostId = null);
+                      }
+                      return success;
                     }
                   : null,
               allPosts: timeline.posts,

--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -166,6 +166,13 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
     setState(() {
       _focusedPostId = null;
       _lastWidth = null; // Force layout recalculation
+      // Setting _lastWidth = null already forces viewportChanged on the next
+      // build (null != width), so the redispatch always runs. Reset
+      // _lastUseHorizontal in lockstep so the cached state never lies — if
+      // a future refactor narrows the viewportChanged predicate, this
+      // assignment keeps the orientation cache from going stale.
+      _lastHeight = null;
+      _lastUseHorizontal = null;
     });
   }
 
@@ -317,6 +324,8 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                           setState(() {
                             _focusedPostId = null;
                             _lastWidth = null;
+                            _lastHeight = null;
+                            _lastUseHorizontal = null;
                           });
                         }
                       },
@@ -974,9 +983,12 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
               onNameConstellation: isOwn
                   ? (postId, name) => notifier.nameConstellation(postId, name)
                   : null,
-              // Constellation removal updates the post locally (the post
-              // stays in the timeline), so the side panel can stay open and
-              // PostDetailContent updates its own UI via _removedConstellationIds.
+              // Constellation deletion only dissolves the grouping — the
+              // post itself stays in the timeline, so unlike onDeletePost we
+              // intentionally do NOT clear _sidePanelPostId here.
+              // PostDetailContent updates its own UI by tracking removed
+              // ids in _removedConstellationIds, which is why we don't need
+              // to react to the future at this layer either.
               onDeleteConstellation: isOwn
                   ? (id) => notifier.deleteConstellation(id)
                   : null,

--- a/frontend/lib/theme/gleisner_tokens.dart
+++ b/frontend/lib/theme/gleisner_tokens.dart
@@ -125,6 +125,13 @@ bool isDesktop(double width) => width >= breakpointDesktop;
 /// called outside `LayoutBuilder` — `LayoutBuilder` builders should never
 /// touch `MediaQuery.of` directly because non-size changes (textScale,
 /// viewInsets) would trigger redundant constraint rebuilds.
+///
+/// At the lower edge of the breakpoint (≥600 px screen) the NavigationRail
+/// consumes [navRailWidth] (72 px) plus a 1 px divider, so the effective
+/// horizontal canvas can be as narrow as ~527 px. [ConstellationLayout]
+/// must keep nodes legible at that width — verify when changing layout
+/// constants. The desktop side panel ([sidePanelWidth]) opens only at
+/// ≥1024 px, where there is enough room left for the canvas.
 bool useHorizontalTimeline(BuildContext context) =>
     isTabletOrWider(MediaQuery.sizeOf(context).width);
 

--- a/frontend/lib/theme/gleisner_tokens.dart
+++ b/frontend/lib/theme/gleisner_tokens.dart
@@ -117,6 +117,17 @@ bool isTabletOrWider(double width) => width >= breakpointTablet;
 /// True if the width is desktop (>= 1024px).
 bool isDesktop(double width) => width >= breakpointDesktop;
 
+/// True when the timeline should use horizontal (DAW-style) scrolling.
+///
+/// Tied to the same breakpoint as the NavigationRail (Idea 030): the
+/// timeline orientation flips together with the side nav. Reads the screen
+/// width via [MediaQuery.sizeOf] (size-only dependency) so it can be safely
+/// called outside `LayoutBuilder` — `LayoutBuilder` builders should never
+/// touch `MediaQuery.of` directly because non-size changes (textScale,
+/// viewInsets) would trigger redundant constraint rebuilds.
+bool useHorizontalTimeline(BuildContext context) =>
+    isTabletOrWider(MediaQuery.sizeOf(context).width);
+
 /// Responsive grid column count for card grids (Discover, etc.).
 int responsiveGridColumns(double width) {
   if (width >= breakpointDesktop) return 4;


### PR DESCRIPTION
## Summary

iPad Safari の FB から発見された 2 件をまとめて修正します。両方とも PR #197 (Idea 030) で導入したレスポンシブレイアウトの取りこぼしです。

### 1. サイドパネルで自分の投稿の削除UIが出ない（FB の主訴）

`_buildSidePanel` が `PostDetailContent` を呼び出す際、ボトムシート版（`_showDetailBottomSheet`）と比較して 2 つのコールバックが抜けていました：

| コールバック | ボトムシート | サイドパネル | 影響 |
|-----------|------------|-----------|------|
| `onDeletePost` | ✅ | ❌ | 削除アイコンが表示されない（FB の症状） |
| `onDeleteConstellation` | ✅ | ❌ | 星座の解除UIが表示されない |

`PostDetailContent` 側は `widget.onDeletePost != null` で出し分けるため、null 渡しでボタンごと消えていました。

サイドパネル版の `onDeletePost` は **embedded mode で `Navigator.pop` がスキップされる** ため、削除成功時にサイドパネルを自分で閉じる必要があります（成功時のみ `_sidePanelPostId = null`）。

### 2. ナビが横なのにタイムラインが縦スクロール

ブレークポイントの不一致が原因でした：

| 切り替え | 判定対象 | 閾値 |
|---------|---------|------|
| ナビレール化 | `MediaQuery` 全画面幅 | **600px** `isTabletOrWider` |
| 詳細サイドパネル化 | `MediaQuery` 全画面幅 | **1024px** `isDesktop` |
| **タイムライン横スクロール** | **`LayoutBuilder.maxWidth`** | **1024px** `isDesktop` |

iPad Pro 12.9" 縦 (1024px) のケース：
- `MediaQuery = 1024` → 詳細はサイドパネル化 ✅
- `LayoutBuilder = 1024 - navRail(72) - divider(1) = 951` → `isDesktop(951) = false` → 縦スクロールのまま ❌

iPad Pro 11" 横 (1194px) など >1024 のケースでも、サイドパネルを開いた瞬間に `LayoutBuilder` が `1194 - 72 - 1 - sidePanel(420) = 701` に縮み、横→縦に切り替わってしまう挙動でした。

`docs/ideas/030-responsive-layout-desktop-tablet.md:13-19` には「Desktop/Tablet で horizontal scroll」と明記されており、ナビレールの閾値（>=600）と揃えるのが Idea 030 の意図でした。

修正:
- `useHorizontal` の判定を `isDesktop(constraints.maxWidth)` → `isTabletOrWider(MediaQuery.of(context).size.width)` に変更
- 画面幅ベースになったので、サイドパネルの開閉で orientation が flip しなくなる（containerWidth/Height は引き続き LayoutBuilder constraint をそのまま使うのでレイアウト計算自体はサイドパネル分の収縮を反映）
- 同じ `useHorizontal = isDesktop(width)` を持つ `public_timeline_screen.dart` も同時に修正（FB は認証済みタイムラインだが、未認証 `/@username` ページとも揃えた方が自然）

## Test Plan

- [x] `flutter analyze lib/` — "No issues found!"
- [x] `flutter test --platform chrome` — 343 / 343 passed
- [x] `dart format --set-exit-if-changed lib/screens/timeline/timeline_screen.dart lib/screens/timeline/public_timeline_screen.dart`
- [ ] 実機確認（PR の reviewer で実施）：
  - iPad Pro 12.9" 縦 (1024px) → サイドパネル化 + 横スクロール
  - iPad Pro 11" 横 (1194px) → サイドパネル化 + 横スクロール（サイドパネル開閉で flip しない）
  - iPad mini 縦 (744px) → ボトムシート + 横スクロール（ナビはレール）
  - iPhone 横 (≥600px) → 横スクロール（ナビレール）
  - iPhone 縦 (<600px) → 縦スクロール（ボトムナビ）
  - 自分の投稿のサイドパネル → 削除アイコン表示 → タップ → 確認ダイアログ → 削除成功でサイドパネル自動クローズ
  - 自分の星座が紐づいた投稿のサイドパネル → 解除UI 表示

## Related

- Closes user FB: iPad Safari の投稿詳細サイドパネルで削除UI が見えない / ナビが横なのにタイムラインが縦
- Idea 030 `docs/ideas/030-responsive-layout-desktop-tablet.md`
- 元の実装: PR #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up Issues

- #355 — extract `isOwn` branching to a pure function and add unit tests
- #356 — narrow `useHorizontalTimeline` rebuild scope with `context.select` / consider relocating to `utils/responsive_utils.dart`