### PR TITLE
feat(tune-in): sort avatar rail by recent post activity + lock down followers list

### DIFF
--- a/backend/drizzle/0014_fat_meteorite.sql
+++ b/backend/drizzle/0014_fat_meteorite.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "posts_author_visibility_updated_idx" ON "posts" USING btree ("author_id","visibility","updated_at");

--- a/backend/drizzle/0014_fat_meteorite.sql
+++ b/backend/drizzle/0014_fat_meteorite.sql
@@ -1,1 +1,11 @@
+-- Avatar rail / myTuneIns sort: aggregate MAX(posts.updated_at) per author
+-- after filtering by visibility = 'public'. (author_id, visibility,
+-- updated_at) is the matching index order.
+--
+-- ⚠ Production note: this `CREATE INDEX` is non-CONCURRENTLY, which takes
+-- a ShareLock on `posts` and blocks INSERT/UPDATE/DELETE while the index
+-- is built. Drizzle Kit runs migrations inside a transaction, so adding
+-- CONCURRENTLY here is not an option. See `docs/infrastructure.md` §6.2
+-- for the recommended production procedure (run CREATE INDEX CONCURRENTLY
+-- manually, then mark this migration as applied).
 CREATE INDEX "posts_author_visibility_updated_idx" ON "posts" USING btree ("author_id","visibility","updated_at");

--- a/backend/drizzle/0014_fat_meteorite.sql
+++ b/backend/drizzle/0014_fat_meteorite.sql
@@ -5,7 +5,10 @@
 -- ⚠ Production note: this `CREATE INDEX` is non-CONCURRENTLY, which takes
 -- a ShareLock on `posts` and blocks INSERT/UPDATE/DELETE while the index
 -- is built. Drizzle Kit runs migrations inside a transaction, so adding
--- CONCURRENTLY here is not an option. See `docs/infrastructure.md` §6.2
--- for the recommended production procedure (run CREATE INDEX CONCURRENTLY
--- manually, then mark this migration as applied).
-CREATE INDEX "posts_author_visibility_updated_idx" ON "posts" USING btree ("author_id","visibility","updated_at");
+-- CONCURRENTLY here is not an option. The `IF NOT EXISTS` clause makes the
+-- statement idempotent so the production workflow is:
+--   1. Run `CREATE INDEX CONCURRENTLY` manually (zero downtime).
+--   2. Run `pnpm db:migrate` — this statement becomes a no-op but drizzle
+--      still records the migration as applied.
+-- See `docs/infrastructure.md` §6.2.1.
+CREATE INDEX IF NOT EXISTS "posts_author_visibility_updated_idx" ON "posts" USING btree ("author_id","visibility","updated_at");

--- a/backend/drizzle/meta/0014_snapshot.json
+++ b/backend/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1949 @@
+{
+  "id": "9a82ae89-be15-4496-ad69-8f13b1f9899e",
+  "prevId": "4150d885-6639-45e8-abe6-00af74090a45",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analytics_events": {
+      "name": "analytics_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analytics_event_type_created_idx": {
+          "name": "analytics_event_type_created_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_event_user_id_idx": {
+          "name": "analytics_event_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_event_session_id_idx": {
+          "name": "analytics_event_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_genres": {
+      "name": "artist_genres",
+      "schema": "",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_genres_artist_id_artists_id_fk": {
+          "name": "artist_genres_artist_id_artists_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_genres_genre_id_genres_id_fk": {
+          "name": "artist_genres_genre_id_genres_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_genres_artist_id_genre_id_pk": {
+          "name": "artist_genres_artist_id_genre_id_pk",
+          "columns": [
+            "artist_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_links": {
+      "name": "artist_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_category": {
+          "name": "link_category",
+          "type": "link_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_links_artist_id_artists_id_fk": {
+          "name": "artist_links_artist_id_artists_id_fk",
+          "tableFrom": "artist_links",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_milestones": {
+      "name": "artist_milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "milestone_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artist_milestones_artist_id_idx": {
+          "name": "artist_milestones_artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_milestones_artist_id_artists_id_fk": {
+          "name": "artist_milestones_artist_id_artists_id_fk",
+          "tableFrom": "artist_milestones",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_username": {
+          "name": "artist_username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_since": {
+          "name": "active_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tuned_in_count": {
+          "name": "tuned_in_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artists_featured_visibility_idx": {
+          "name": "artists_featured_visibility_idx",
+          "columns": [
+            {
+              "expression": "is_featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artists_user_id_users_id_fk": {
+          "name": "artists_user_id_users_id_fk",
+          "tableFrom": "artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artists_user_id_unique": {
+          "name": "artists_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "artists_artist_username_unique": {
+          "name": "artists_artist_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_post_id_posts_id_fk": {
+          "name": "comments_post_id_posts_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "connection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_connection": {
+          "name": "unique_connection",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_source_id_posts_id_fk": {
+          "name": "connections_source_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_target_id_posts_id_fk": {
+          "name": "connections_target_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_neq_target": {
+          "name": "source_neq_target",
+          "value": "\"connections\".\"source_id\" != \"connections\".\"target_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.constellations": {
+      "name": "constellations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_post_id": {
+          "name": "anchor_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "constellations_artist_id_artists_id_fk": {
+          "name": "constellations_artist_id_artists_id_fk",
+          "tableFrom": "constellations",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "constellations_anchor_post_id_posts_id_fk": {
+          "name": "constellations_anchor_post_id_posts_id_fk",
+          "tableFrom": "constellations",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "anchor_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "constellations_anchor_post_id_unique": {
+          "name": "constellations_anchor_post_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anchor_post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "name": "follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "follower_neq_following": {
+          "name": "follower_neq_following",
+          "value": "\"follows\".\"follower_id\" != \"follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_promoted": {
+          "name": "is_promoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "genres_normalized_name_unique": {
+          "name": "genres_normalized_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "normalized_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_users_id_fk": {
+          "name": "invites_created_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_used_by_users_id_fk": {
+          "name": "invites_used_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_reactions": {
+      "name": "milestone_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestone_reactions_milestone_id_artist_milestones_id_fk": {
+          "name": "milestone_reactions_milestone_id_artist_milestones_id_fk",
+          "tableFrom": "milestone_reactions",
+          "tableTo": "artist_milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_reactions_user_id_users_id_fk": {
+          "name": "milestone_reactions_user_id_users_id_fk",
+          "tableFrom": "milestone_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_reactions_milestone_id_user_id_emoji_unique": {
+          "name": "milestone_reactions_milestone_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_media": {
+      "name": "post_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_media_post_id_position_idx": {
+          "name": "post_media_post_id_position_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_media_post_id_posts_id_fk": {
+          "name": "post_media_post_id_posts_id_fk",
+          "tableFrom": "post_media",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_format": {
+          "name": "body_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'plain'"
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importance": {
+          "name": "importance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_fetched_at": {
+          "name": "og_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_genre": {
+          "name": "article_genre",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_publish": {
+          "name": "external_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_x": {
+          "name": "layout_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "layout_y": {
+          "name": "layout_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_author_og_fetched_idx": {
+          "name": "posts_author_og_fetched_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "og_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_author_media_url_idx": {
+          "name": "posts_author_media_url_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_media_url_og_fetched_idx": {
+          "name": "posts_media_url_og_fetched_idx",
+          "columns": [
+            {
+              "expression": "media_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "og_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_author_visibility_updated_idx": {
+          "name": "posts_author_visibility_updated_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_track_id_tracks_id_fk": {
+          "name": "posts_track_id_tracks_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reactions_post_id_posts_id_fk": {
+          "name": "reactions_post_id_posts_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_user_id_users_id_fk": {
+          "name": "reactions_user_id_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_post_id_user_id_emoji_unique": {
+          "name": "reactions_post_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracks": {
+      "name": "tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_artist_track_name": {
+          "name": "unique_artist_track_name",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracks_artist_id_artists_id_fk": {
+          "name": "tracks_artist_id_artists_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tune_ins": {
+      "name": "tune_ins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tune_ins_user_id_users_id_fk": {
+          "name": "tune_ins_user_id_users_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tune_ins_artist_id_artists_id_fk": {
+          "name": "tune_ins_artist_id_artists_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tune_ins_user_id_artist_id_pk": {
+          "name": "tune_ins_user_id_artist_id_pk",
+          "columns": [
+            "user_id",
+            "artist_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "did": {
+          "name": "did",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_salt": {
+          "name": "password_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_private_key": {
+          "name": "encrypted_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_salt": {
+          "name": "encryption_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_year_month": {
+          "name": "birth_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_id": {
+          "name": "guardian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_guardian_id_users_id_fk": {
+          "name": "users_guardian_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "guardian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_did_unique": {
+          "name": "users_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_type": {
+      "name": "connection_type",
+      "schema": "public",
+      "values": [
+        "reply",
+        "remix",
+        "reference",
+        "evolution"
+      ]
+    },
+    "public.link_category": {
+      "name": "link_category",
+      "schema": "public",
+      "values": [
+        "social",
+        "music",
+        "video",
+        "website",
+        "store",
+        "other"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "thought",
+        "article",
+        "image",
+        "video",
+        "audio",
+        "link"
+      ]
+    },
+    "public.milestone_category": {
+      "name": "milestone_category",
+      "schema": "public",
+      "values": [
+        "award",
+        "release",
+        "event",
+        "affiliation",
+        "education",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1777211160563,
       "tag": "0013_chief_marvel_zombies",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1778158729271,
+      "tag": "0014_fat_meteorite",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/post.ts
+++ b/backend/src/db/schema/post.ts
@@ -82,5 +82,14 @@ export const posts = pgTable(
       table.mediaUrl,
       table.ogFetchedAt,
     ),
+    // Avatar rail / myTuneIns sort: filter by author + visibility, aggregate
+    // MAX(updated_at). The (author_id, visibility, updated_at) leading
+    // columns let the planner skip draft posts and stream rows in
+    // updated_at order per author.
+    index("posts_author_visibility_updated_idx").on(
+      table.authorId,
+      table.visibility,
+      table.updatedAt,
+    ),
   ],
 );

--- a/backend/src/graphql/__tests__/tune-in.test.ts
+++ b/backend/src/graphql/__tests__/tune-in.test.ts
@@ -82,6 +82,15 @@ const ARTIST_QUERY = `
   }
 `;
 
+const ARTIST_WITH_TUNE_INS_QUERY = `
+  query ArtistWithTuneIns($username: String!) {
+    artist(username: $username) {
+      id
+      tuneIns { user { id username } }
+    }
+  }
+`;
+
 const TOGGLE_TUNE_IN_MUTATION = `
   mutation ToggleTuneIn($artistId: String!) {
     toggleTuneIn(artistId: $artistId) {
@@ -96,6 +105,30 @@ const TUNE_INS_QUERY = `
   query TuneIns($artistId: String!) {
     tuneIns(artistId: $artistId) {
       user { id username }
+    }
+  }
+`;
+
+const MY_TUNE_INS_QUERY = `
+  query MyTuneIns {
+    myTuneIns {
+      createdAt
+      lastPostActivityAt
+      artist { id artistUsername }
+    }
+  }
+`;
+
+const CREATE_TRACK_MUTATION = `
+  mutation CreateTrack($name: String!, $color: String!) {
+    createTrack(name: $name, color: $color) { id }
+  }
+`;
+
+const CREATE_POST_MUTATION = `
+  mutation CreatePost($trackId: String!, $mediaType: MediaType!, $title: String, $visibility: String) {
+    createPost(trackId: $trackId, mediaType: $mediaType, title: $title, visibility: $visibility) {
+      id
     }
   }
 `;
@@ -129,6 +162,51 @@ async function signupAndRegisterArtist(
   );
   const artistId = (result.data!.registerArtist as { id: string }).id;
   return { token, artistId };
+}
+
+/**
+ * Create a post by the artist owner and (optionally) backdate its
+ * `updated_at` to a specific time so we can test the avatar rail sort
+ * deterministically.
+ */
+async function createPostWithUpdatedAt(
+  app: ReturnType<typeof createTestApp>,
+  ownerToken: string,
+  options: {
+    visibility?: "public" | "draft";
+    updatedAt?: Date;
+    title?: string;
+  } = {},
+) {
+  const trackResult = await gql(
+    app,
+    CREATE_TRACK_MUTATION,
+    { name: `track_${crypto.randomUUID().slice(0, 8)}`, color: "#FF0000" },
+    ownerToken,
+  );
+  const trackId = (trackResult.data!.createTrack as { id: string }).id;
+
+  const postResult = await gql(
+    app,
+    CREATE_POST_MUTATION,
+    {
+      trackId,
+      mediaType: "thought",
+      title: options.title ?? null,
+      visibility: options.visibility ?? "public",
+    },
+    ownerToken,
+  );
+  const postId = (postResult.data!.createPost as { id: string }).id;
+
+  if (options.updatedAt) {
+    // Direct UPDATE — createPost only sets updated_at to defaultNow().
+    // Tests need explicit timestamps to assert sort order without flakiness.
+    await db.execute(
+      sql`UPDATE posts SET updated_at = ${options.updatedAt.toISOString()}::timestamptz WHERE id = ${postId}`,
+    );
+  }
+  return postId;
 }
 
 describe("TuneIn GraphQL integration", () => {
@@ -175,7 +253,6 @@ describe("TuneIn GraphQL integration", () => {
       // Verify tunedInCount incremented
       const artistResult = await gql(app, ARTIST_QUERY, {
         username: "tartist1a",
-        birthYearMonth: "1990-01",
       });
       const artist = artistResult.data!.artist as Record<string, unknown>;
       expect(artist.tunedInCount).toBe(1);
@@ -208,7 +285,6 @@ describe("TuneIn GraphQL integration", () => {
       // Verify tunedInCount decremented back to 0
       const artistResult = await gql(app, ARTIST_QUERY, {
         username: "tartist2a",
-        birthYearMonth: "1990-01",
       });
       const artist = artistResult.data!.artist as Record<string, unknown>;
       expect(artist.tunedInCount).toBe(0);
@@ -224,41 +300,325 @@ describe("TuneIn GraphQL integration", () => {
     });
   });
 
-  describe("tuneIns query", () => {
-    it("returns tuned-in users for an artist", async () => {
-      const { artistId } = await signupAndRegisterArtist(
+  describe("tuneIns query (artist followers)", () => {
+    it("returns followers when called by the artist owner", async () => {
+      const { token: ownerToken, artistId } = await signupAndRegisterArtist(
         app,
         "q1a@example.com",
         "quser1a",
         "qartist1a",
       );
-      const userToken = await signupAndGetToken(
+      const followerToken = await signupAndGetToken(
         app,
         "q1b@example.com",
         "quser1b",
       );
 
-      await gql(app, TOGGLE_TUNE_IN_MUTATION, { artistId }, userToken);
+      await gql(app, TOGGLE_TUNE_IN_MUTATION, { artistId }, followerToken);
 
-      const result = await gql(app, TUNE_INS_QUERY, { artistId });
+      const result = await gql(app, TUNE_INS_QUERY, { artistId }, ownerToken);
 
       expect(result.errors).toBeUndefined();
       const tuneIns = result.data!.tuneIns as Array<Record<string, unknown>>;
       expect(tuneIns).toHaveLength(1);
+      expect((tuneIns[0].user as Record<string, unknown>).username).toBe(
+        "quser1b",
+      );
     });
 
-    it("returns empty array for artist with no tune-ins", async () => {
-      const { artistId } = await signupAndRegisterArtist(
+    it("returns empty array for artist with no tune-ins (owner)", async () => {
+      const { token: ownerToken, artistId } = await signupAndRegisterArtist(
         app,
         "q2@example.com",
         "quser2",
         "qartist2",
       );
 
-      const result = await gql(app, TUNE_INS_QUERY, { artistId });
+      const result = await gql(app, TUNE_INS_QUERY, { artistId }, ownerToken);
 
       expect(result.errors).toBeUndefined();
       expect(result.data!.tuneIns).toEqual([]);
+    });
+
+    it("rejects unauthenticated requests", async () => {
+      const { artistId } = await signupAndRegisterArtist(
+        app,
+        "q3@example.com",
+        "quser3",
+        "qartist3",
+      );
+
+      const result = await gql(app, TUNE_INS_QUERY, { artistId });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Authentication required");
+    });
+
+    it("rejects non-owner callers (Forbidden)", async () => {
+      const { artistId } = await signupAndRegisterArtist(
+        app,
+        "q4a@example.com",
+        "quser4a",
+        "qartist4a",
+      );
+      const otherToken = await signupAndGetToken(
+        app,
+        "q4b@example.com",
+        "quser4b",
+      );
+
+      const result = await gql(app, TUNE_INS_QUERY, { artistId }, otherToken);
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Forbidden");
+    });
+  });
+
+  describe("Artist.tuneIns field (artist followers via Artist query)", () => {
+    it("returns followers when called by the artist owner", async () => {
+      const { token: ownerToken, artistId } = await signupAndRegisterArtist(
+        app,
+        "a1a@example.com",
+        "auser1a",
+        "aartist1a",
+      );
+      const followerToken = await signupAndGetToken(
+        app,
+        "a1b@example.com",
+        "auser1b",
+      );
+      await gql(app, TOGGLE_TUNE_IN_MUTATION, { artistId }, followerToken);
+
+      const result = await gql(
+        app,
+        ARTIST_WITH_TUNE_INS_QUERY,
+        { username: "aartist1a" },
+        ownerToken,
+      );
+
+      expect(result.errors).toBeUndefined();
+      const artist = result.data!.artist as Record<string, unknown>;
+      const fieldTuneIns = artist.tuneIns as Array<Record<string, unknown>>;
+      expect(fieldTuneIns).toHaveLength(1);
+    });
+
+    it("rejects unauthenticated requests via Artist.tuneIns", async () => {
+      await signupAndRegisterArtist(
+        app,
+        "a2@example.com",
+        "auser2",
+        "aartist2",
+      );
+
+      const result = await gql(app, ARTIST_WITH_TUNE_INS_QUERY, {
+        username: "aartist2",
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Authentication required");
+    });
+
+    it("rejects non-owner callers via Artist.tuneIns (Forbidden)", async () => {
+      await signupAndRegisterArtist(
+        app,
+        "a3a@example.com",
+        "auser3a",
+        "aartist3a",
+      );
+      const otherToken = await signupAndGetToken(
+        app,
+        "a3b@example.com",
+        "auser3b",
+      );
+
+      const result = await gql(
+        app,
+        ARTIST_WITH_TUNE_INS_QUERY,
+        { username: "aartist3a" },
+        otherToken,
+      );
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Forbidden");
+    });
+  });
+
+  describe("myTuneIns sort order (avatar rail)", () => {
+    /**
+     * Setup: viewer tunes in to artists A, B, C in that order.
+     * Each test then arranges per-artist post activity and asserts the
+     * resolver's returned order.
+     */
+    async function setupThreeArtists() {
+      const a = await signupAndRegisterArtist(
+        app,
+        "ma1@example.com",
+        "musera1",
+        "mart_a",
+      );
+      const b = await signupAndRegisterArtist(
+        app,
+        "mb1@example.com",
+        "muserb1",
+        "mart_b",
+      );
+      const c = await signupAndRegisterArtist(
+        app,
+        "mc1@example.com",
+        "muserc1",
+        "mart_c",
+      );
+      const viewerToken = await signupAndGetToken(
+        app,
+        "viewer@example.com",
+        "viewerm",
+      );
+
+      await gql(
+        app,
+        TOGGLE_TUNE_IN_MUTATION,
+        { artistId: a.artistId },
+        viewerToken,
+      );
+      await gql(
+        app,
+        TOGGLE_TUNE_IN_MUTATION,
+        { artistId: b.artistId },
+        viewerToken,
+      );
+      await gql(
+        app,
+        TOGGLE_TUNE_IN_MUTATION,
+        { artistId: c.artistId },
+        viewerToken,
+      );
+
+      return { a, b, c, viewerToken };
+    }
+
+    it("orders artists by MAX(posts.updated_at) DESC", async () => {
+      const { a, b, c, viewerToken } = await setupThreeArtists();
+
+      // a: oldest activity, b: newest activity, c: middle
+      await createPostWithUpdatedAt(app, a.token, {
+        updatedAt: new Date("2024-01-01T00:00:00Z"),
+      });
+      await createPostWithUpdatedAt(app, b.token, {
+        updatedAt: new Date("2024-03-01T00:00:00Z"),
+      });
+      await createPostWithUpdatedAt(app, c.token, {
+        updatedAt: new Date("2024-02-01T00:00:00Z"),
+      });
+
+      const result = await gql(app, MY_TUNE_INS_QUERY, {}, viewerToken);
+
+      expect(result.errors).toBeUndefined();
+      const tuneIns = result.data!.myTuneIns as Array<Record<string, unknown>>;
+      const usernames = tuneIns.map(
+        (t) => (t.artist as Record<string, unknown>).artistUsername,
+      );
+      expect(usernames).toEqual(["mart_b", "mart_c", "mart_a"]);
+    });
+
+    it("places artists with no posts at the end, ordered by tunedInAt ASC", async () => {
+      // a and c are needed only for the tune-in side effect inside
+      // setupThreeArtists(); the assertion only inspects ordering.
+      const { b, viewerToken } = await setupThreeArtists();
+
+      // Only b has a post; a and c have nothing.
+      await createPostWithUpdatedAt(app, b.token, {
+        updatedAt: new Date("2024-05-01T00:00:00Z"),
+      });
+
+      const result = await gql(app, MY_TUNE_INS_QUERY, {}, viewerToken);
+
+      expect(result.errors).toBeUndefined();
+      const tuneIns = result.data!.myTuneIns as Array<Record<string, unknown>>;
+      const usernames = tuneIns.map(
+        (t) => (t.artist as Record<string, unknown>).artistUsername,
+      );
+      // b (has post) → a, c (no posts, in tune-in order)
+      expect(usernames).toEqual(["mart_b", "mart_a", "mart_c"]);
+    });
+
+    it("ignores draft posts when sorting (visibility filter)", async () => {
+      const { a, b, viewerToken } = await setupThreeArtists();
+
+      // a has a recent draft (must NOT count), b has an older public post
+      await createPostWithUpdatedAt(app, a.token, {
+        visibility: "draft",
+        updatedAt: new Date("2024-12-01T00:00:00Z"),
+      });
+      await createPostWithUpdatedAt(app, b.token, {
+        visibility: "public",
+        updatedAt: new Date("2024-01-01T00:00:00Z"),
+      });
+
+      const result = await gql(app, MY_TUNE_INS_QUERY, {}, viewerToken);
+
+      expect(result.errors).toBeUndefined();
+      const tuneIns = result.data!.myTuneIns as Array<Record<string, unknown>>;
+      const orderedActive = tuneIns
+        .filter((t) => t.lastPostActivityAt !== null)
+        .map((t) => (t.artist as Record<string, unknown>).artistUsername);
+      // Only b is "active" — a's draft is ignored, c has no posts.
+      expect(orderedActive).toEqual(["mart_b"]);
+      // a's lastPostActivityAt should be null (draft excluded)
+      const tuneInForA = tuneIns.find(
+        (t) =>
+          (t.artist as Record<string, unknown>).artistUsername === "mart_a",
+      );
+      expect(tuneInForA!.lastPostActivityAt).toBeNull();
+    });
+
+    it("orders artists with no posts by tunedInAt ASC (oldest tune-in first)", async () => {
+      const { viewerToken } = await setupThreeArtists();
+      // No posts created — all three artists have null lastPostActivityAt.
+
+      const result = await gql(app, MY_TUNE_INS_QUERY, {}, viewerToken);
+
+      expect(result.errors).toBeUndefined();
+      const tuneIns = result.data!.myTuneIns as Array<Record<string, unknown>>;
+      const usernames = tuneIns.map(
+        (t) => (t.artist as Record<string, unknown>).artistUsername,
+      );
+      // All null → tunedInAt ASC = order of toggleTuneIn calls (a, b, c)
+      expect(usernames).toEqual(["mart_a", "mart_b", "mart_c"]);
+      for (const t of tuneIns) {
+        expect(t.lastPostActivityAt).toBeNull();
+      }
+    });
+
+    it("uses MAX(updated_at) so a recent edit re-sorts the artist to the front", async () => {
+      const { a, b, viewerToken } = await setupThreeArtists();
+
+      // Both have a post, b's is newer initially.
+      await createPostWithUpdatedAt(app, a.token, {
+        updatedAt: new Date("2024-01-01T00:00:00Z"),
+      });
+      await createPostWithUpdatedAt(app, b.token, {
+        updatedAt: new Date("2024-02-01T00:00:00Z"),
+      });
+
+      // Bump a's old post's updated_at to "now-ish" — simulates an edit.
+      await createPostWithUpdatedAt(app, a.token, {
+        updatedAt: new Date("2024-12-01T00:00:00Z"),
+      });
+
+      const result = await gql(app, MY_TUNE_INS_QUERY, {}, viewerToken);
+
+      expect(result.errors).toBeUndefined();
+      const tuneIns = result.data!.myTuneIns as Array<Record<string, unknown>>;
+      const usernames = tuneIns
+        .filter((t) => t.lastPostActivityAt !== null)
+        .map((t) => (t.artist as Record<string, unknown>).artistUsername);
+      expect(usernames).toEqual(["mart_a", "mart_b"]);
+    });
+
+    it("rejects unauthenticated myTuneIns requests", async () => {
+      const result = await gql(app, MY_TUNE_INS_QUERY);
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Authentication required");
     });
   });
 });

--- a/backend/src/graphql/builder.ts
+++ b/backend/src/graphql/builder.ts
@@ -36,6 +36,25 @@ export interface GraphQLContext {
       updatedAt: Date;
     }
   >;
+  /**
+   * Per-request cache for tune-in follower lookups (avoids N+1 on
+   * `TuneInType.user` when resolving the followers list of an artist).
+   * Populated by the `tuneIns(artistId)` query and the `Artist.tuneIns`
+   * field — both prefetch the user via JOIN and store the
+   * `publicUserColumns` shape here.
+   */
+  tuneInUserCache?: Map<
+    string,
+    {
+      id: string;
+      did: string;
+      username: string;
+      displayName: string | null;
+      bio: string | null;
+      avatarUrl: string | null;
+      createdAt: Date;
+    }
+  >;
 }
 
 export const builder = new SchemaBuilder<{

--- a/backend/src/graphql/builder.ts
+++ b/backend/src/graphql/builder.ts
@@ -1,5 +1,17 @@
 import SchemaBuilder from "@pothos/core";
 import type { AuthUser } from "../auth/middleware.js";
+import type { artists } from "../db/schema/index.js";
+// `import type` erases at compile time, so this does not create a runtime
+// import cycle with `./types/user.ts` (which imports from this file).
+import type { PublicUserShape } from "./types/user.js";
+
+/**
+ * Drizzle-derived row shape for the `artists` table — kept in sync with
+ * the schema automatically. Used as the cache value type below so a column
+ * addition to `db/schema/artist.ts` does not silently drift from the
+ * cache.
+ */
+type ArtistRow = typeof artists.$inferSelect;
 
 export interface GraphQLContext {
   authUser?: AuthUser;
@@ -16,26 +28,13 @@ export interface GraphQLContext {
   >;
   /** Promise guard to prevent parallel cache initialization. */
   constellationCachePromise?: Promise<void>;
-  /** Per-request cache for tune-in artist lookups (avoids N+1 in myTuneIns). */
-  tuneInArtistCache?: Map<
-    string,
-    {
-      id: string;
-      userId: string;
-      artistUsername: string;
-      displayName: string | null;
-      bio: string | null;
-      tagline: string | null;
-      location: string | null;
-      activeSince: number | null;
-      avatarUrl: string | null;
-      coverImageUrl: string | null;
-      profileVisibility: string;
-      tunedInCount: number;
-      createdAt: Date;
-      updatedAt: Date;
-    }
-  >;
+  /**
+   * Per-request cache for tune-in artist lookups. Populated by the
+   * `myTuneIns` query (which JOINs `artists`) and read by the
+   * `TuneInType.artist` field resolver to avoid a per-row SELECT against
+   * the `artists` table.
+   */
+  tuneInArtistCache?: Map<string, ArtistRow>;
   /**
    * Per-request cache for tune-in follower lookups (avoids N+1 on
    * `TuneInType.user` when resolving the followers list of an artist).
@@ -43,18 +42,7 @@ export interface GraphQLContext {
    * field — both prefetch the user via JOIN and store the
    * `publicUserColumns` shape here.
    */
-  tuneInUserCache?: Map<
-    string,
-    {
-      id: string;
-      did: string;
-      username: string;
-      displayName: string | null;
-      bio: string | null;
-      avatarUrl: string | null;
-      createdAt: Date;
-    }
-  >;
+  tuneInUserCache?: Map<string, PublicUserShape>;
 }
 
 export const builder = new SchemaBuilder<{

--- a/backend/src/graphql/types/tune-in.ts
+++ b/backend/src/graphql/types/tune-in.ts
@@ -1,8 +1,8 @@
 import { GraphQLError } from "graphql";
 import { builder } from "../builder.js";
 import { db } from "../../db/index.js";
-import { artists, tuneIns, users } from "../../db/schema/index.js";
-import { and, eq, sql } from "drizzle-orm";
+import { artists, posts, tuneIns, users } from "../../db/schema/index.js";
+import { and, asc, eq, sql } from "drizzle-orm";
 import { ArtistType } from "./artist.js";
 import { PublicUserType, publicUserColumns } from "./user.js";
 
@@ -10,12 +10,20 @@ const TuneInType = builder.objectRef<{
   userId: string;
   artistId: string;
   createdAt: Date;
+  // Computed: MAX(posts.updated_at) for the followed artist's public posts.
+  // null when the artist has never posted (or only has draft posts). Used by
+  // the avatar rail to sort by recent activity. See ADR / Issue link in PR.
+  lastPostActivityAt: Date | null;
 }>("TuneIn");
 
 TuneInType.implement({
   fields: (t) => ({
     createdAt: t.string({
       resolve: (tuneIn) => tuneIn.createdAt.toISOString(),
+    }),
+    lastPostActivityAt: t.string({
+      nullable: true,
+      resolve: (tuneIn) => tuneIn.lastPostActivityAt?.toISOString() ?? null,
     }),
     user: t.field({
       type: PublicUserType,
@@ -102,7 +110,12 @@ builder.mutationFields((t) => ({
       // Tune in — use transaction for count consistency
       try {
         let result:
-          | { userId: string; artistId: string; createdAt: Date }
+          | {
+              userId: string;
+              artistId: string;
+              createdAt: Date;
+              lastPostActivityAt: Date | null;
+            }
           | undefined;
         await db.transaction(async (tx) => {
           const [tuneIn] = await tx
@@ -116,7 +129,9 @@ builder.mutationFields((t) => ({
             .update(artists)
             .set({ tunedInCount: sql`${artists.tunedInCount} + 1` })
             .where(eq(artists.id, args.artistId));
-          result = tuneIn;
+          // Newly created tune-in has no aggregated activity yet — clients
+          // should refetch myTuneIns to pick up the sorted state.
+          result = { ...tuneIn, lastPostActivityAt: null };
         });
         return result!;
       } catch {
@@ -126,17 +141,57 @@ builder.mutationFields((t) => ({
   }),
 }));
 
+/**
+ * Authorization helper for the artist-followers list. The followers of an
+ * artist are private to the artist owner (Phase 0 family lifelog policy):
+ * exposing this list publicly would leak who is connected to whom across
+ * unrelated households. Returns the artist row when the caller owns it,
+ * otherwise throws.
+ *
+ * Both "artist does not exist" and "you are not the owner" surface the same
+ * "Forbidden" error so that an authenticated attacker cannot enumerate
+ * artist IDs by probing for differentiated error messages.
+ */
+async function assertArtistOwnership(
+  artistId: string,
+  authUserId: string | undefined,
+): Promise<{ id: string; userId: string }> {
+  if (!authUserId) {
+    throw new GraphQLError("Authentication required");
+  }
+  const [artist] = await db
+    .select({ id: artists.id, userId: artists.userId })
+    .from(artists)
+    .where(and(eq(artists.id, artistId), eq(artists.userId, authUserId)))
+    .limit(1);
+  if (!artist) {
+    throw new GraphQLError("Forbidden");
+  }
+  return artist;
+}
+
 builder.queryFields((t) => ({
   tuneIns: t.field({
     type: [TuneInType],
     args: {
       artistId: t.arg.string({ required: true }),
     },
-    resolve: async (_parent, args) => {
-      return db
+    resolve: async (_parent, args, ctx) => {
+      // Followers list is private to the artist owner. See
+      // assertArtistOwnership() for rationale.
+      await assertArtistOwnership(args.artistId, ctx.authUser?.userId);
+      const rows = await db
         .select()
         .from(tuneIns)
         .where(eq(tuneIns.artistId, args.artistId));
+      // The followers list does not need lastPostActivityAt — that field is
+      // about the followed artist's activity, not about each follower.
+      return rows.map((r) => ({
+        userId: r.userId,
+        artistId: r.artistId,
+        createdAt: r.createdAt,
+        lastPostActivityAt: null,
+      }));
     },
   }),
 
@@ -146,17 +201,41 @@ builder.queryFields((t) => ({
       if (!ctx.authUser) {
         throw new GraphQLError("Authentication required");
       }
-      // JOIN to prefetch artist data — avoids N+1 on TuneInType.artist resolver
+      // JOIN to prefetch artist data — avoids N+1 on TuneInType.artist resolver.
+      // LEFT JOIN posts on the followed artist's public posts so we can sort
+      // the avatar rail by recent activity. visibility='public' is critical:
+      // without it, draft posts' updated_at would leak the artist's editing
+      // activity to their followers.
       const rows = await db
         .select({
           userId: tuneIns.userId,
           artistId: tuneIns.artistId,
           createdAt: tuneIns.createdAt,
           artist: artists,
+          // postgres.js does not auto-parse aggregate results to Date — keep
+          // it as the raw `string | null` here and normalize below.
+          lastPostActivityAt: sql<string | null>`MAX(${posts.updatedAt})`.as(
+            "last_post_activity_at",
+          ),
         })
         .from(tuneIns)
         .innerJoin(artists, eq(tuneIns.artistId, artists.id))
-        .where(eq(tuneIns.userId, ctx.authUser.userId));
+        .leftJoin(
+          posts,
+          and(
+            eq(posts.authorId, artists.userId),
+            eq(posts.visibility, "public"),
+          ),
+        )
+        .where(eq(tuneIns.userId, ctx.authUser.userId))
+        // GROUP BY tune-in PK + artist PK — PostgreSQL's functional
+        // dependency analysis lets us SELECT artists.* and ti.created_at
+        // without listing them here.
+        .groupBy(tuneIns.userId, tuneIns.artistId, artists.id)
+        .orderBy(
+          sql`MAX(${posts.updatedAt}) DESC NULLS LAST`,
+          asc(tuneIns.createdAt),
+        );
 
       // Attach prefetched artist to context cache so TuneInType.artist resolver
       // can use it instead of issuing another query
@@ -171,17 +250,33 @@ builder.queryFields((t) => ({
         userId: r.userId,
         artistId: r.artistId,
         createdAt: r.createdAt,
+        // Normalize the aggregate result back to Date (or null when the
+        // artist has no public posts).
+        lastPostActivityAt: r.lastPostActivityAt
+          ? new Date(r.lastPostActivityAt)
+          : null,
       }));
     },
   }),
 }));
 
-// Add tuneIns field to ArtistType
+// Add tuneIns field to ArtistType — same authorization as the top-level
+// tuneIns(artistId) query: only the artist owner can list their followers.
 builder.objectFields(ArtistType, (t) => ({
   tuneIns: t.field({
     type: [TuneInType],
-    resolve: async (artist) => {
-      return db.select().from(tuneIns).where(eq(tuneIns.artistId, artist.id));
+    resolve: async (artist, _args, ctx) => {
+      await assertArtistOwnership(artist.id, ctx.authUser?.userId);
+      const rows = await db
+        .select()
+        .from(tuneIns)
+        .where(eq(tuneIns.artistId, artist.id));
+      return rows.map((r) => ({
+        userId: r.userId,
+        artistId: r.artistId,
+        createdAt: r.createdAt,
+        lastPostActivityAt: null,
+      }));
     },
   }),
 }));

--- a/backend/src/graphql/types/tune-in.ts
+++ b/backend/src/graphql/types/tune-in.ts
@@ -27,7 +27,11 @@ TuneInType.implement({
     }),
     user: t.field({
       type: PublicUserType,
-      resolve: async (tuneIn) => {
+      resolve: async (tuneIn, _args, ctx) => {
+        // Use prefetched cache from the followers-list resolvers (tuneIns,
+        // Artist.tuneIns) when available — avoids N+1 SELECTs.
+        const cached = ctx.tuneInUserCache?.get(tuneIn.userId);
+        if (cached) return cached;
         const [user] = await db
           .select(publicUserColumns)
           .from(users)
@@ -170,6 +174,69 @@ async function assertArtistOwnership(
   return artist;
 }
 
+/**
+ * Variant of {@link assertArtistOwnership} for callers that already hold the
+ * artist row (e.g. the `Artist.tuneIns` field resolver receives `artist`
+ * from its parent). Avoids a redundant DB roundtrip while preserving the
+ * same uniform "Forbidden" semantics.
+ */
+function assertArtistOwnerByUserId(
+  artistUserId: string,
+  authUserId: string | undefined,
+): void {
+  if (!authUserId) {
+    throw new GraphQLError("Authentication required");
+  }
+  if (artistUserId !== authUserId) {
+    throw new GraphQLError("Forbidden");
+  }
+}
+
+/**
+ * Common shape returned by the followers-list resolvers (`tuneIns(artistId)`
+ * and `Artist.tuneIns`). They both fetch tune-in rows joined with the
+ * follower's public-user columns and populate the per-request cache so
+ * `TuneInType.user` does not re-issue SELECTs for each follower.
+ */
+async function fetchFollowersWithUsers(
+  artistId: string,
+  ctx: import("../builder.js").GraphQLContext,
+): Promise<
+  {
+    userId: string;
+    artistId: string;
+    createdAt: Date;
+    lastPostActivityAt: null;
+  }[]
+> {
+  const rows = await db
+    .select({
+      userId: tuneIns.userId,
+      artistId: tuneIns.artistId,
+      createdAt: tuneIns.createdAt,
+      user: publicUserColumns,
+    })
+    .from(tuneIns)
+    .innerJoin(users, eq(users.id, tuneIns.userId))
+    .where(eq(tuneIns.artistId, artistId));
+
+  if (!ctx.tuneInUserCache) {
+    ctx.tuneInUserCache = new Map();
+  }
+  for (const row of rows) {
+    ctx.tuneInUserCache.set(row.userId, row.user);
+  }
+
+  // The followers list does not need lastPostActivityAt — that field is
+  // about the followed artist's activity, not about each follower.
+  return rows.map((r) => ({
+    userId: r.userId,
+    artistId: r.artistId,
+    createdAt: r.createdAt,
+    lastPostActivityAt: null,
+  }));
+}
+
 builder.queryFields((t) => ({
   tuneIns: t.field({
     type: [TuneInType],
@@ -180,18 +247,7 @@ builder.queryFields((t) => ({
       // Followers list is private to the artist owner. See
       // assertArtistOwnership() for rationale.
       await assertArtistOwnership(args.artistId, ctx.authUser?.userId);
-      const rows = await db
-        .select()
-        .from(tuneIns)
-        .where(eq(tuneIns.artistId, args.artistId));
-      // The followers list does not need lastPostActivityAt — that field is
-      // about the followed artist's activity, not about each follower.
-      return rows.map((r) => ({
-        userId: r.userId,
-        artistId: r.artistId,
-        createdAt: r.createdAt,
-        lastPostActivityAt: null,
-      }));
+      return fetchFollowersWithUsers(args.artistId, ctx);
     },
   }),
 
@@ -232,8 +288,10 @@ builder.queryFields((t) => ({
         // dependency analysis lets us SELECT artists.* and ti.created_at
         // without listing them here.
         .groupBy(tuneIns.userId, tuneIns.artistId, artists.id)
+        // Reuse the SELECT alias rather than repeating the MAX(...)
+        // expression so the two stay in sync if the aggregate changes.
         .orderBy(
-          sql`MAX(${posts.updatedAt}) DESC NULLS LAST`,
+          sql`last_post_activity_at DESC NULLS LAST`,
           asc(tuneIns.createdAt),
         );
 
@@ -266,17 +324,10 @@ builder.objectFields(ArtistType, (t) => ({
   tuneIns: t.field({
     type: [TuneInType],
     resolve: async (artist, _args, ctx) => {
-      await assertArtistOwnership(artist.id, ctx.authUser?.userId);
-      const rows = await db
-        .select()
-        .from(tuneIns)
-        .where(eq(tuneIns.artistId, artist.id));
-      return rows.map((r) => ({
-        userId: r.userId,
-        artistId: r.artistId,
-        createdAt: r.createdAt,
-        lastPostActivityAt: null,
-      }));
+      // Parent already provides artist.userId, so we can authorize with a
+      // direct comparison instead of re-fetching the artist row.
+      assertArtistOwnerByUserId(artist.userId, ctx.authUser?.userId);
+      return fetchFollowersWithUsers(artist.id, ctx);
     },
   }),
 }));

--- a/backend/src/graphql/types/tune-in.ts
+++ b/backend/src/graphql/types/tune-in.ts
@@ -11,8 +11,19 @@ const TuneInType = builder.objectRef<{
   artistId: string;
   createdAt: Date;
   // Computed: MAX(posts.updated_at) for the followed artist's public posts.
-  // null when the artist has never posted (or only has draft posts). Used by
-  // the avatar rail to sort by recent activity. See ADR / Issue link in PR.
+  // Used by the avatar rail (`myTuneIns`) to sort by recent activity.
+  //
+  // Semantics of null:
+  //   - In `myTuneIns`: the followed artist has no public posts (yet, or
+  //     only has drafts). Sort places these last (NULLS LAST + tunedInAt).
+  //   - In `tuneIns(artistId)` and `Artist.tuneIns` (followers list): the
+  //     field is meaningless in this context — those resolvers return
+  //     followers of an artist, not artists being followed — so the value
+  //     is *always* null. Clients SHOULD omit the field from those
+  //     selections; it remains exposed only because GraphQL field shapes
+  //     are typed once per object type. A future split into `MyTuneIn`
+  //     vs `ArtistFollower` is tracked in a follow-up issue if/when this
+  //     becomes a real source of confusion.
   lastPostActivityAt: Date | null;
 }>("TuneIn");
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -203,26 +203,22 @@ Drizzle Kit は migration をトランザクション内で実行するため、
 
 該当する migration（例: `0014_fat_meteorite.sql` — `posts_author_visibility_updated_idx`）は、本番では以下の手順で適用する:
 
-1. **手動で CONCURRENTLY 実行**:
+1. **手動で CONCURRENTLY 実行**（書き込みをブロックしない）:
    ```bash
    railway run --service backend psql "$DATABASE_URL" -c \
      "CREATE INDEX CONCURRENTLY IF NOT EXISTS posts_author_visibility_updated_idx \
       ON posts USING btree (author_id, visibility, updated_at);"
    ```
-2. **migration を「適用済み」としてマーク**（drizzle が再度実行しないようにする）:
+2. **`pnpm db:migrate` を通常実行**:
    ```bash
-   railway run --service backend psql "$DATABASE_URL" -c \
-     "INSERT INTO drizzle.__drizzle_migrations (hash, created_at) \
-      SELECT hash, EXTRACT(EPOCH FROM NOW())::bigint * 1000 \
-      FROM (VALUES ('<migration hash from drizzle journal>')) AS t(hash) \
-      ON CONFLICT (hash) DO NOTHING;"
+   railway run --service backend pnpm db:migrate
    ```
-   migration hash は `backend/drizzle/meta/_journal.json` に記録されている。
-3. **以降のリリースで `pnpm db:migrate` を通常実行** — 上記でマーク済みの migration は skip される。
+   migration SQL 側に `CREATE INDEX IF NOT EXISTS` を付けてあるため、ステップ 1 で既に index が存在していれば SQL は no-op で完了する。drizzle はこの migration を「適用済み」として `__drizzle_migrations` に記録するので、以降のデプロイで再実行されない。
 
 判定基準:
 - **数百行以下のテーブル** → `pnpm db:migrate` で素直に実行（一瞬で終わる）
 - **`posts` / `comments` / `reactions` 等の書き込み多発テーブル** → 上記の手動 CONCURRENTLY 手順
+- **新規 index migration を追加するときは SQL 側に `IF NOT EXISTS` を必ず付ける** — drizzle-kit が自動付与しない場合は手動で追記すること
 
 ### 6.3 admin:setup（管理者 + 招待コード生成）
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -197,6 +197,33 @@ railway run --service backend pnpm db:migrate
 > ⚠ 本番では `db:push` を**使わない**。テーブル再作成でデータが消える可能性がある。Drizzle の migration ファイル経由で適用する。
 > （参照: `project_gleisner_migration_policy.md`）
 
+#### 6.2.1 大きなテーブルへの `CREATE INDEX` は手動で CONCURRENTLY 実行
+
+Drizzle Kit は migration をトランザクション内で実行するため、`CREATE INDEX CONCURRENTLY`（PostgreSQL でテーブルロックを避ける唯一の手段）を使えない。素の `CREATE INDEX` は `posts` のような書き込み多発テーブルに ShareLock を取り、index ビルドが完了するまで INSERT/UPDATE/DELETE をブロックする。
+
+該当する migration（例: `0014_fat_meteorite.sql` — `posts_author_visibility_updated_idx`）は、本番では以下の手順で適用する:
+
+1. **手動で CONCURRENTLY 実行**:
+   ```bash
+   railway run --service backend psql "$DATABASE_URL" -c \
+     "CREATE INDEX CONCURRENTLY IF NOT EXISTS posts_author_visibility_updated_idx \
+      ON posts USING btree (author_id, visibility, updated_at);"
+   ```
+2. **migration を「適用済み」としてマーク**（drizzle が再度実行しないようにする）:
+   ```bash
+   railway run --service backend psql "$DATABASE_URL" -c \
+     "INSERT INTO drizzle.__drizzle_migrations (hash, created_at) \
+      SELECT hash, EXTRACT(EPOCH FROM NOW())::bigint * 1000 \
+      FROM (VALUES ('<migration hash from drizzle journal>')) AS t(hash) \
+      ON CONFLICT (hash) DO NOTHING;"
+   ```
+   migration hash は `backend/drizzle/meta/_journal.json` に記録されている。
+3. **以降のリリースで `pnpm db:migrate` を通常実行** — 上記でマーク済みの migration は skip される。
+
+判定基準:
+- **数百行以下のテーブル** → `pnpm db:migrate` で素直に実行（一瞬で終わる）
+- **`posts` / `comments` / `reactions` 等の書き込み多発テーブル** → 上記の手動 CONCURRENTLY 手順
+
 ### 6.3 admin:setup（管理者 + 招待コード生成）
 
 ```bash

--- a/frontend/lib/graphql/mutations/tune_in.dart
+++ b/frontend/lib/graphql/mutations/tune_in.dart
@@ -2,6 +2,7 @@ const toggleTuneInMutation = r'''
   mutation ToggleTuneIn($artistId: String!) {
     toggleTuneIn(artistId: $artistId) {
       createdAt
+      lastPostActivityAt
       artist {
         id
         artistUsername

--- a/frontend/lib/graphql/queries/artist.dart
+++ b/frontend/lib/graphql/queries/artist.dart
@@ -129,6 +129,7 @@ const myTuneInsQuery = r'''
   query MyTuneIns {
     myTuneIns {
       createdAt
+      lastPostActivityAt
       artist {
         id
         artistUsername

--- a/frontend/lib/providers/tune_in_provider.dart
+++ b/frontend/lib/providers/tune_in_provider.dart
@@ -17,6 +17,13 @@ class TunedInArtist {
   final String profileVisibility;
   final DateTime tunedInAt;
 
+  /// MAX(posts.updated_at) of the followed artist's public posts. null when
+  /// the artist has never posted (or only has draft posts). The avatar rail
+  /// uses backend ordering (lastPostActivityAt DESC NULLS LAST, then
+  /// tunedInAt ASC) so the field is informational here, but kept on the
+  /// model in case future UX wants to render "last seen X minutes ago".
+  final DateTime? lastPostActivityAt;
+
   const TunedInArtist({
     required this.id,
     required this.artistUsername,
@@ -25,12 +32,14 @@ class TunedInArtist {
     required this.tunedInCount,
     this.profileVisibility = 'public',
     required this.tunedInAt,
+    this.lastPostActivityAt,
   });
 
   bool get isPrivate => profileVisibility == 'private';
 
   factory TunedInArtist.fromJson(Map<String, dynamic> json) {
     final artist = json['artist'] as Map<String, dynamic>;
+    final lastActivity = json['lastPostActivityAt'] as String?;
     return TunedInArtist(
       id: artist['id'] as String,
       artistUsername: artist['artistUsername'] as String,
@@ -39,6 +48,9 @@ class TunedInArtist {
       tunedInCount: artist['tunedInCount'] as int,
       profileVisibility: artist['profileVisibility'] as String? ?? 'public',
       tunedInAt: DateTime.parse(json['createdAt'] as String),
+      lastPostActivityAt: lastActivity != null
+          ? DateTime.parse(lastActivity)
+          : null,
     );
   }
 }
@@ -146,7 +158,15 @@ class TuneInNotifier extends Notifier<TuneInState> with DisposableNotifier {
         );
         return false;
       } else {
-        // Tuned in (got data back) — deduplicate to prevent race with loadMyTuneIns
+        // Tuned in (got data back) — deduplicate to prevent race with loadMyTuneIns.
+        //
+        // The optimistic position is the END of the rail. The backend returns
+        // `lastPostActivityAt: null` for newly created tune-ins, which under
+        // the avatar-rail sort (DESC NULLS LAST, then tunedInAt ASC) places
+        // them after every artist that has posted. The next loadMyTuneIns —
+        // typically triggered when navigating into the timeline — will move
+        // the artist to its correct sort position if they actually have
+        // public posts.
         final newTuneIn = TunedInArtist.fromJson(data as Map<String, dynamic>);
         final filtered = state.tunedInArtists
             .where((a) => a.id != newTuneIn.id)

--- a/frontend/test/providers/tune_in_provider_test.dart
+++ b/frontend/test/providers/tune_in_provider_test.dart
@@ -48,6 +48,9 @@ Map<String, dynamic> _tuneInResponse(
   return {
     'toggleTuneIn': {
       'createdAt': '2026-01-01T00:00:00Z',
+      // Newly tuned-in artists always start with null; the next loadMyTuneIns
+      // refresh fills it in if the artist has public posts.
+      'lastPostActivityAt': null,
       'artist': {
         'id': id,
         'artistUsername': username,
@@ -72,6 +75,10 @@ Map<String, dynamic> _myTuneInsResponse(List<Map<String, dynamic>> artists) {
           (a) => {
             '__typename': 'TuneIn',
             'createdAt': '2026-01-01T00:00:00Z',
+            // Field is part of the query — graphql_flutter raises a partial-
+            // data exception if the mock omits it. null = artist has not
+            // posted (or only has draft posts).
+            'lastPostActivityAt': null,
             'artist': a,
           },
         )
@@ -267,6 +274,138 @@ void main() {
         await notifier.toggleTuneIn('a1');
         expect(container.read(tuneInProvider).isTunedIn('a1'), isFalse);
       });
+    });
+
+    group('lastPostActivityAt and avatar rail order', () {
+      // Server-side ordering: `myTuneIns` returns artists sorted by
+      // MAX(posts.updated_at) DESC NULLS LAST, then tunedInAt ASC. The
+      // notifier preserves that order; no client-side re-sorting.
+
+      Map<String, dynamic> activityResponse(
+        List<
+          ({String id, String username, String? lastActivity, String tunedInAt})
+        >
+        entries,
+      ) {
+        return {
+          '__typename': 'Query',
+          'myTuneIns': entries
+              .map(
+                (e) => {
+                  '__typename': 'TuneIn',
+                  'createdAt': e.tunedInAt,
+                  'lastPostActivityAt': e.lastActivity,
+                  'artist': {
+                    '__typename': 'Artist',
+                    'id': e.id,
+                    'artistUsername': e.username,
+                    'displayName': e.username,
+                    'avatarUrl': null,
+                    'tunedInCount': 1,
+                    'profileVisibility': 'public',
+                  },
+                },
+              )
+              .toList(),
+        };
+      }
+
+      test('parses lastPostActivityAt as DateTime when present', () async {
+        final client = _clientWithResponses([
+          activityResponse([
+            (
+              id: 'a1',
+              username: 'artist1',
+              lastActivity: '2026-03-01T12:34:56Z',
+              tunedInAt: '2026-01-01T00:00:00Z',
+            ),
+          ]),
+        ]);
+        final container = _createContainer(client: client);
+        addTearDown(container.dispose);
+
+        await container.read(tuneInProvider.notifier).loadMyTuneIns();
+        final artist = container.read(tuneInProvider).tunedInArtists.single;
+        expect(artist.lastPostActivityAt, isNotNull);
+        expect(
+          artist.lastPostActivityAt!.toUtc().toIso8601String(),
+          '2026-03-01T12:34:56.000Z',
+        );
+      });
+
+      test(
+        'parses lastPostActivityAt as null when artist has no posts',
+        () async {
+          final client = _clientWithResponses([
+            activityResponse([
+              (
+                id: 'a1',
+                username: 'artist1',
+                lastActivity: null,
+                tunedInAt: '2026-01-01T00:00:00Z',
+              ),
+            ]),
+          ]);
+          final container = _createContainer(client: client);
+          addTearDown(container.dispose);
+
+          await container.read(tuneInProvider.notifier).loadMyTuneIns();
+          expect(
+            container
+                .read(tuneInProvider)
+                .tunedInArtists
+                .single
+                .lastPostActivityAt,
+            isNull,
+          );
+        },
+      );
+
+      test(
+        'preserves server-provided order (active first, no-activity last)',
+        () async {
+          // Server has already sorted: b (recent) > c (older) > a, d (no activity,
+          // tunedInAt ASC). The notifier must not re-sort.
+          final client = _clientWithResponses([
+            activityResponse([
+              (
+                id: 'b',
+                username: 'mart_b',
+                lastActivity: '2026-03-01T00:00:00Z',
+                tunedInAt: '2026-01-02T00:00:00Z',
+              ),
+              (
+                id: 'c',
+                username: 'mart_c',
+                lastActivity: '2026-02-01T00:00:00Z',
+                tunedInAt: '2026-01-03T00:00:00Z',
+              ),
+              (
+                id: 'a',
+                username: 'mart_a',
+                lastActivity: null,
+                tunedInAt: '2026-01-01T00:00:00Z',
+              ),
+              (
+                id: 'd',
+                username: 'mart_d',
+                lastActivity: null,
+                tunedInAt: '2026-01-04T00:00:00Z',
+              ),
+            ]),
+          ]);
+          final container = _createContainer(client: client);
+          addTearDown(container.dispose);
+
+          await container.read(tuneInProvider.notifier).loadMyTuneIns();
+          final usernames = container
+              .read(tuneInProvider)
+              .tunedInArtists
+              .map((a) => a.artistUsername)
+              .toList();
+          expect(usernames, ['mart_b', 'mart_c', 'mart_a', 'mart_d']);
+        },
+      );
     });
 
     group('Tune Out sequence (simulating Timeline behavior)', () {


### PR DESCRIPTION
## 概要

タイムライン上部のアバターレイルを **最終投稿時刻順** に並べる。自分のアバターは最左固定（既存ロジック維持）、他人のアバターは `MAX(posts.updated_at) DESC` 順。投稿0件のアーティストは末尾に `tunedInAt ASC` で配置。

**🔴 Critical security fix を同梱**: 既存の `tuneIns(artistId)` / `Artist.tuneIns` の認可漏れ（誰でも他人のフォロワー一覧を取得可能だった）を本人のみ閲覧可に修正。詳細は下記。

## 確定仕様

| 項目 | 内容 |
|---|---|
| 並び順 | 自分=最左固定、他人=`MAX(posts.updated_at) DESC NULLS LAST`、投稿0件は末尾に `tunedInAt ASC` |
| 「活動」の定義 | 投稿の作成・編集のみ（reaction / comment は含めない） |
| 更新タイミング | pull-to-refresh / 画面再オープン時のみ（自動 invalidate なし） |
| 認可（同梱修正） | `tuneIns(artistId)` / `Artist.tuneIns` は **アーティスト本人のみ** 閲覧可 |

## 主な変更

### Backend (GraphQL + Hono + Drizzle)

- **`TuneInType` GraphQL 型に `lastPostActivityAt: DateTime` (nullable) を追加** — `PublicUserType` / `ArtistType` には追加せず露出スコープを TuneIn に限定
- **`myTuneIns` resolver 改修**:
  - `LEFT JOIN posts ON (posts.author_id = artists.user_id AND posts.visibility = 'public')`
  - `GROUP BY tune_ins.user_id, tune_ins.artist_id, artists.id`（PG functional dependency analysis 利用）
  - `MAX(posts.updated_at)` を集計、postgres.js の string 戻り値を `new Date()` で normalize
  - `ORDER BY MAX(updated_at) DESC NULLS LAST, tune_ins.created_at ASC`
- **🔴 Critical security fix**: `tuneIns(artistId)` / `Artist.tuneIns` に `assertArtistOwnership()` を適用
  - 認証済み + アーティスト本人 (=`artists.user_id == authUser.userId`) のみフォロワー一覧を返す
  - 「存在しない artistId」と「他人の artistId」を区別せず一律 `Forbidden` 返却（列挙オラクル防止）
- **`posts_author_visibility_updated_idx` 複合 index 追加** — `(author_id, visibility, updated_at)` の順序で myTuneIns の JOIN + GROUP BY + MAX 計算を最適化

### Frontend (Flutter)

- `TunedInArtist` モデルに `lastPostActivityAt: DateTime?` 追加
- `myTuneInsQuery` / `toggleTuneInMutation` に `lastPostActivityAt` フィールドを追加
- 並び順は **backend に完全委譲** — クライアント側で再ソートなし
- `toggleTuneIn` の楽観的更新（末尾追加）の意図をコメントで明記

## テスト

### Backend (16 件、全て新規 or 更新)
- `myTuneIns` ソート順 5 ケース（最新順 / 0件は末尾 / draft 除外 / 0件同士は tunedInAt ASC / updated_at による再ソート）
- `tuneIns(artistId)` 認可 4 ケース（本人成功 / 本人 0件 / 未認証拒否 / 非本人 Forbidden）
- `Artist.tuneIns` field 認可 3 ケース（本人成功 / 未認証拒否 / 非本人 Forbidden）
- `myTuneIns` 未認証拒否
- 既存 `toggleTuneIn` テスト 3 件（不変）

### Frontend (3 件追加、既存 11 件は helper の `lastPostActivityAt: null` 追加で互換維持)
- `lastPostActivityAt` を DateTime としてパース
- null をパースしてもクラッシュしない
- backend のソート順を保持（クライアント再ソートなし）

## マルチエージェントレビュー結果

| レビュアー | 結果 |
|---|---|
| security-reviewer (Sonnet) | 指摘 1 件（列挙オラクル）→ 修正済み。残り 4 件は信頼度 ≤ 68 で除外 or Phase 1 案件 |
| GraphQL/data review (Sonnet) | 8 観点 Critical なし、整合性 OK |
| Flutter UI review (Sonnet) | 7 観点 Critical なし、Nice 1 件（コメント追加）→ 対応済み |
| synthesis-reviewer (Opus) | **マージ承認**、Critical / Important なし |

## Follow-up Issues

| # | 内容 | Phase |
|---|---|---|
| #357 | tune-in 件数の上限なし → DoS リスク | Phase 1 |
| #358 | `toggleTuneIn` が `profileVisibility` をチェックしない | Phase 1 |
| #359 | `logout` 時の連鎖 `ref.invalidate` を `auth_provider` に集約 | Phase 0 (副次バグ) |

## PR 前チェック結果

| チェック | 結果 |
|---|---|
| `cd backend && pnpm build` | ✅ |
| `cd backend && pnpm lint` | ✅ |
| `cd backend && pnpm format:check` | ✅ |
| `cd backend && pnpm test` | ✅ 553 passed / 1 skipped |
| `cd frontend && dart analyze lib/` | ✅ No issues |
| `cd frontend && dart format --set-exit-if-changed <変更ファイル>` | ✅ |
| `cd frontend && flutter test --platform chrome` | ✅ 346 passed |

## マイグレーション運用

新環境向けに `0014_fat_meteorite.sql` を生成済み（`CREATE INDEX` のみ、安全）。既存 dev DB は `pnpm db:push` で同等のスキーマ反映を実施済み（`project_gleisner_migration_policy.md` 準拠）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)