### PR TITLE
fix(ui): remove duplicate edit icon and title in desktop side panel

### DIFF
--- a/frontend/lib/screens/artist/artist_page_screen.dart
+++ b/frontend/lib/screens/artist/artist_page_screen.dart
@@ -83,37 +83,23 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
       color: colorSurface1,
       child: Column(
         children: [
+          // Minimal close-only header strip. Title is owned by
+          // PostDetailContent's _buildContentSection, so the side panel
+          // header omits it to avoid duplicate rendering. Matches
+          // timeline_screen's side panel.
           Container(
             padding: const EdgeInsets.symmetric(
-              horizontal: spaceLg,
-              vertical: spaceSm,
+              horizontal: spaceSm,
+              vertical: spaceXxs,
             ),
+            alignment: Alignment.centerRight,
             decoration: const BoxDecoration(
               border: Border(bottom: BorderSide(color: colorBorder)),
             ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    post.title ?? context.l10n.untitled,
-                    style: const TextStyle(
-                      color: colorTextPrimary,
-                      fontSize: fontSizeLg,
-                      fontWeight: weightSemibold,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(
-                    Icons.close,
-                    size: 18,
-                    color: colorInteractive,
-                  ),
-                  onPressed: () => setState(() => _sidePanelPostId = null),
-                  tooltip: context.l10n.close,
-                ),
-              ],
+            child: IconButton(
+              icon: const Icon(Icons.close, size: 18, color: colorInteractive),
+              onPressed: () => setState(() => _sidePanelPostId = null),
+              tooltip: context.l10n.close,
             ),
           ),
           Expanded(

--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -908,51 +908,25 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
       color: colorSurface1,
       child: Column(
         children: [
-          // Header with close + edit buttons
+          // Minimal close-only header strip. Title / edit / delete are all
+          // owned by PostDetailContent (title in _buildContentSection, edit +
+          // delete inline in _buildDateRow), so the side panel header
+          // intentionally omits them to avoid duplicate rendering. The thin
+          // bar with a single close button mirrors the bottom-sheet "drag
+          // handle to dismiss" affordance for desktop.
           Container(
             padding: const EdgeInsets.symmetric(
-              horizontal: spaceLg,
-              vertical: spaceSm,
+              horizontal: spaceSm,
+              vertical: spaceXxs,
             ),
+            alignment: Alignment.centerRight,
             decoration: const BoxDecoration(
               border: Border(bottom: BorderSide(color: colorBorder)),
             ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    post.title ?? context.l10n.untitled,
-                    style: const TextStyle(
-                      color: colorTextPrimary,
-                      fontSize: fontSizeLg,
-                      fontWeight: weightSemibold,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-                if (isOwn)
-                  IconButton(
-                    icon: const Icon(
-                      Icons.edit_outlined,
-                      size: 18,
-                      color: colorInteractive,
-                    ),
-                    onPressed: () {
-                      setState(() => _sidePanelPostId = null);
-                      _openEditPost(post);
-                    },
-                    tooltip: context.l10n.edit,
-                  ),
-                IconButton(
-                  icon: const Icon(
-                    Icons.close,
-                    size: 18,
-                    color: colorInteractive,
-                  ),
-                  onPressed: () => setState(() => _sidePanelPostId = null),
-                  tooltip: context.l10n.close,
-                ),
-              ],
+            child: IconButton(
+              icon: const Icon(Icons.close, size: 18, color: colorInteractive),
+              onPressed: () => setState(() => _sidePanelPostId = null),
+              tooltip: context.l10n.close,
             ),
           ),
           // Shared content


### PR DESCRIPTION
## Summary

デスクトップサイドパネル（投稿詳細）で、自分の投稿を開いた時に **編集アイコンとタイトルが2箇所に表示**されていた問題を修正。

### 重複の発生源

`PostDetailContent` は body 内で:
- `_buildContentSection` でタイトル（`titleWidget`）を表示
- `_buildDateRow` で edit + delete アイコンを inline 表示

この上で `_buildSidePanel`（`timeline_screen.dart` / `artist_page_screen.dart`）のヘッダーが、タイトルと（timeline のみ）edit アイコンを **追加で** 出していた。

## 修正方針

両 `_buildSidePanel` のヘッダーを **close ボタンのみのミニマルストリップ**に置き換え、title / edit / delete は完全に `PostDetailContent` に集約。

- ✅ タイトルの二重表示を解消
- ✅ 編集アイコンの二重表示を解消（`timeline_screen` のみ該当）
- ✅ Close affordance はデスクトップで明示（bottom sheet のドラッグハンドル相当）
- ✅ `timeline_screen` と `artist_page_screen` のサイドパネルが同一構造になり一貫
- ✅ `onEdit` / `onDeletePost` callback は維持 → `_buildDateRow` の inline 操作は引き続き機能

## Before / After

```
[Before — timeline side panel header]
┌──────────────────────────────────────┐
│ My Post Title         [✏️] [✕]       │  ← edit + close
├──────────────────────────────────────┤
│ My Post Title                        │  ← duplicated title
│ Apr 28 · ✏️ ️🗑️                        │  ← duplicated edit
│ ...                                  │

[After]
┌──────────────────────────────────────┐
│                              [✕]     │  ← close only
├──────────────────────────────────────┤
│ My Post Title                        │
│ Apr 28 · ✏️ 🗑️                        │  ← single edit + delete
│ ...                                  │
```

## Scope

- `frontend/lib/screens/timeline/timeline_screen.dart` — header 簡素化（edit + title 削除）
- `frontend/lib/screens/artist/artist_page_screen.dart` — header 簡素化（title 削除、edit はそもそも無い）

差分: +24 / -64（ほぼ削除）。ロジック変更なし、UI 構造のみ。

## 検証

- `dart analyze lib/screens/timeline/timeline_screen.dart lib/screens/artist/artist_page_screen.dart` — clean
- `dart format` — 0 changes
- `flutter test --platform chrome` — 349 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)