### PR TITLE
fix(ui): add drop shadows to artist header icons over cover images

### DIFF
--- a/frontend/lib/screens/artist/artist_page_screen.dart
+++ b/frontend/lib/screens/artist/artist_page_screen.dart
@@ -159,10 +159,17 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
                           expandedHeight: 200,
                           pinned: true,
                           backgroundColor: colorSurface0,
+                          // The leading + action icons sit on top of an
+                          // arbitrary cover image. Near-white icons get washed
+                          // out on light photos (sky, snow, paper). Apply the
+                          // same two-layer dark shadow used for cover-image
+                          // text overlays (see post_detail_sheet.dart) so the
+                          // icons stay legible regardless of the cover.
                           leading: IconButton(
-                            icon: const Icon(
+                            icon: Icon(
                               Icons.arrow_back,
                               color: colorTextPrimary,
+                              shadows: coverIconShadows,
                             ),
                             onPressed: () => context.pop(),
                           ),
@@ -172,9 +179,10 @@ class _ArtistPageScreenState extends ConsumerState<ArtistPageScreen> {
                           actions: [
                             IconButton(
                               tooltip: context.l10n.copyPublicLink,
-                              icon: const Icon(
+                              icon: Icon(
                                 Icons.link,
                                 color: colorTextPrimary,
+                                shadows: coverIconShadows,
                               ),
                               onPressed: () => _copyPublicLink(
                                 context,

--- a/frontend/lib/theme/gleisner_tokens.dart
+++ b/frontend/lib/theme/gleisner_tokens.dart
@@ -220,3 +220,22 @@ final textLabel = GoogleFonts.plusJakartaSans(
 
 /// Monospace font family for URLs and code.
 final monoFontFamily = GoogleFonts.jetBrainsMono().fontFamily;
+
+// ---------------------------------------------------------------------------
+// Shadows — Stacked drop shadows for foreground content over cover images
+// ---------------------------------------------------------------------------
+
+/// Two-layer black shadow for icons / text rendered on top of an arbitrary
+/// cover image or hero photo. The tight inner shadow defines a sharp dark
+/// silhouette around the glyph; the wider outer shadow adds a soft halo
+/// that keeps near-white foreground content legible even on light photos
+/// (sky, snow, paper). Use this in preference to wrapping icons in a
+/// semi-transparent backdrop chip, which adds visual weight.
+///
+/// Color literals are const-friendly forms of `Colors.black.withValues(...)`:
+///   0xB3000000 ≈ alpha 0.70  (179/255)
+///   0x66000000 ≈ alpha 0.40  (102/255)
+const coverIconShadows = <Shadow>[
+  Shadow(color: Color(0xB3000000), blurRadius: 8),
+  Shadow(color: Color(0x66000000), blurRadius: 16),
+];


### PR DESCRIPTION
## Problem

アーティストプロフィール画面（`/@:username`）の上部にある **戻るアイコン**と**公開リンクコピーアイコン**は近白（`colorTextPrimary = 0xFFf0f0f5`）。背景のカバー画像が白っぽい色（空、雪、紙、淡いパステル）の場合、色被りでアイコンが見えにくくなる。

## Fix

`post_detail_sheet.dart` でカバー画像上のタイトルに使われているのと同じ **二重ドロップシャドウ**を両アイコンに適用:

- **内側 (tight)**: `Color(0xB3000000)`（α=0.7）/ `blurRadius: 8` — グリフのシャープな暗いシルエット
- **外側 (wide)**: `Color(0x66000000)`（α=0.4）/ `blurRadius: 16` — ソフトなハロー

これで明るい背景でも視認性を確保。半透明 backdrop chip で囲うアプローチではなく、シャドウ単体で済ませることでヘッダーの視覚的重さを増やさない。

## Token 化

シャドウ対は `gleisner_tokens.dart` に `coverIconShadows` として promote。将来カバー上の他の foreground 要素（カバー編集ピル、ヒーローテキスト等）を同じ treatment で揃えやすくする。alpha/blurRadius を call site で再定義する重複を防ぐ。

## Scope

- `frontend/lib/screens/artist/artist_page_screen.dart` — `Icons.arrow_back` と `Icons.link` に `shadows: coverIconShadows` を追加
- `frontend/lib/theme/gleisner_tokens.dart` — `coverIconShadows` const list を追加

差分: +29 / -2。ロジック変更なし、純粋なビジュアル改善。

## 検証

- `dart analyze` clean
- `dart format` 0 changes
- `flutter test --platform chrome` 349 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)