### PR TITLE
feat(reactions): expand reaction emoji set with full Unicode picker

### DIFF
--- a/backend/drizzle/0016_true_forgotten_one.sql
+++ b/backend/drizzle/0016_true_forgotten_one.sql
@@ -1,0 +1,19 @@
+-- Reaction emoji column expansion: varchar(10) -> varchar(64).
+--
+-- Supports ZWJ family / profession sequences (👨‍👩‍👧‍👦 = 11 code units),
+-- skin-tone modifiers, regional indicators, and variation selectors.
+-- See `validators.ts > MAX_EMOJI_LENGTH` for the application-layer limit.
+--
+-- Online safety: PostgreSQL 11+ widens varchar(N) without rewriting the
+-- table or rebuilding the row (existing values, all <= 10 chars, fit
+-- trivially into the new bound). No USING clause is required because the
+-- conversion is purely a metadata change. The unique index
+-- (post_id, user_id, emoji) keeps its existing rows; the additional
+-- single-column indexes below are CREATE INDEX (not CONCURRENTLY) but
+-- their tables are small enough at Phase 0 launch (~10² rows) that the
+-- short ACCESS EXCLUSIVE lock is acceptable. Re-evaluate with
+-- CREATE INDEX CONCURRENTLY before Phase 1 SNS expansion.
+ALTER TABLE "milestone_reactions" ALTER COLUMN "emoji" SET DATA TYPE varchar(64);--> statement-breakpoint
+ALTER TABLE "reactions" ALTER COLUMN "emoji" SET DATA TYPE varchar(64);--> statement-breakpoint
+CREATE INDEX "milestone_reactions_milestone_id_idx" ON "milestone_reactions" USING btree ("milestone_id");--> statement-breakpoint
+CREATE INDEX "reactions_post_id_idx" ON "reactions" USING btree ("post_id");

--- a/backend/drizzle/meta/0016_snapshot.json
+++ b/backend/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1997 @@
+{
+  "id": "54ffa868-0826-42e0-a5bf-0af706057822",
+  "prevId": "1569356f-98c0-4ae6-af6e-c128756efd10",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analytics_events": {
+      "name": "analytics_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analytics_event_type_created_idx": {
+          "name": "analytics_event_type_created_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_event_user_id_idx": {
+          "name": "analytics_event_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_event_session_id_idx": {
+          "name": "analytics_event_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_genres": {
+      "name": "artist_genres",
+      "schema": "",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_genres_artist_id_artists_id_fk": {
+          "name": "artist_genres_artist_id_artists_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_genres_genre_id_genres_id_fk": {
+          "name": "artist_genres_genre_id_genres_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_genres_artist_id_genre_id_pk": {
+          "name": "artist_genres_artist_id_genre_id_pk",
+          "columns": [
+            "artist_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_links": {
+      "name": "artist_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_category": {
+          "name": "link_category",
+          "type": "link_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_links_artist_id_artists_id_fk": {
+          "name": "artist_links_artist_id_artists_id_fk",
+          "tableFrom": "artist_links",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_milestones": {
+      "name": "artist_milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "milestone_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artist_milestones_artist_id_idx": {
+          "name": "artist_milestones_artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_milestones_artist_id_artists_id_fk": {
+          "name": "artist_milestones_artist_id_artists_id_fk",
+          "tableFrom": "artist_milestones",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_username": {
+          "name": "artist_username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_since": {
+          "name": "active_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tuned_in_count": {
+          "name": "tuned_in_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artists_featured_visibility_idx": {
+          "name": "artists_featured_visibility_idx",
+          "columns": [
+            {
+              "expression": "is_featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artists_user_id_users_id_fk": {
+          "name": "artists_user_id_users_id_fk",
+          "tableFrom": "artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artists_user_id_unique": {
+          "name": "artists_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "artists_artist_username_unique": {
+          "name": "artists_artist_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_post_id_posts_id_fk": {
+          "name": "comments_post_id_posts_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "connection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_connection": {
+          "name": "unique_connection",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_source_id_posts_id_fk": {
+          "name": "connections_source_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_target_id_posts_id_fk": {
+          "name": "connections_target_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_neq_target": {
+          "name": "source_neq_target",
+          "value": "\"connections\".\"source_id\" != \"connections\".\"target_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.constellations": {
+      "name": "constellations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_post_id": {
+          "name": "anchor_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "constellations_artist_id_artists_id_fk": {
+          "name": "constellations_artist_id_artists_id_fk",
+          "tableFrom": "constellations",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "constellations_anchor_post_id_posts_id_fk": {
+          "name": "constellations_anchor_post_id_posts_id_fk",
+          "tableFrom": "constellations",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "anchor_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "constellations_anchor_post_id_unique": {
+          "name": "constellations_anchor_post_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anchor_post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "name": "follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "follower_neq_following": {
+          "name": "follower_neq_following",
+          "value": "\"follows\".\"follower_id\" != \"follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_promoted": {
+          "name": "is_promoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "genres_normalized_name_unique": {
+          "name": "genres_normalized_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "normalized_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_users_id_fk": {
+          "name": "invites_created_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_used_by_users_id_fk": {
+          "name": "invites_used_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_reactions": {
+      "name": "milestone_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "milestone_reactions_milestone_id_idx": {
+          "name": "milestone_reactions_milestone_id_idx",
+          "columns": [
+            {
+              "expression": "milestone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "milestone_reactions_milestone_id_artist_milestones_id_fk": {
+          "name": "milestone_reactions_milestone_id_artist_milestones_id_fk",
+          "tableFrom": "milestone_reactions",
+          "tableTo": "artist_milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_reactions_user_id_users_id_fk": {
+          "name": "milestone_reactions_user_id_users_id_fk",
+          "tableFrom": "milestone_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_reactions_milestone_id_user_id_emoji_unique": {
+          "name": "milestone_reactions_milestone_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_media": {
+      "name": "post_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_media_post_id_position_idx": {
+          "name": "post_media_post_id_position_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_media_post_id_posts_id_fk": {
+          "name": "post_media_post_id_posts_id_fk",
+          "tableFrom": "post_media",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_format": {
+          "name": "body_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'plain'"
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importance": {
+          "name": "importance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_fetched_at": {
+          "name": "og_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_genre": {
+          "name": "article_genre",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_publish": {
+          "name": "external_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_x": {
+          "name": "layout_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "layout_y": {
+          "name": "layout_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_author_og_fetched_idx": {
+          "name": "posts_author_og_fetched_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "og_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_author_media_url_idx": {
+          "name": "posts_author_media_url_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_media_url_og_fetched_idx": {
+          "name": "posts_media_url_og_fetched_idx",
+          "columns": [
+            {
+              "expression": "media_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "og_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_author_visibility_updated_idx": {
+          "name": "posts_author_visibility_updated_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_track_id_tracks_id_fk": {
+          "name": "posts_track_id_tracks_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_post_id_idx": {
+          "name": "reactions_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_post_id_posts_id_fk": {
+          "name": "reactions_post_id_posts_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_user_id_users_id_fk": {
+          "name": "reactions_user_id_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_post_id_user_id_emoji_unique": {
+          "name": "reactions_post_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracks": {
+      "name": "tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_artist_track_name": {
+          "name": "unique_artist_track_name",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracks_artist_id_artists_id_fk": {
+          "name": "tracks_artist_id_artists_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tune_ins": {
+      "name": "tune_ins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tune_ins_user_id_users_id_fk": {
+          "name": "tune_ins_user_id_users_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tune_ins_artist_id_artists_id_fk": {
+          "name": "tune_ins_artist_id_artists_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tune_ins_user_id_artist_id_pk": {
+          "name": "tune_ins_user_id_artist_id_pk",
+          "columns": [
+            "user_id",
+            "artist_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "did": {
+          "name": "did",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_salt": {
+          "name": "password_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_private_key": {
+          "name": "encrypted_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_salt": {
+          "name": "encryption_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_year_month": {
+          "name": "birth_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_id": {
+          "name": "guardian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_guardian_id_idx": {
+          "name": "users_guardian_id_idx",
+          "columns": [
+            {
+              "expression": "guardian_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_guardian_id_users_id_fk": {
+          "name": "users_guardian_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "guardian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_did_unique": {
+          "name": "users_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_type": {
+      "name": "connection_type",
+      "schema": "public",
+      "values": [
+        "reply",
+        "remix",
+        "reference",
+        "evolution"
+      ]
+    },
+    "public.link_category": {
+      "name": "link_category",
+      "schema": "public",
+      "values": [
+        "social",
+        "music",
+        "video",
+        "website",
+        "store",
+        "other"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "thought",
+        "article",
+        "image",
+        "video",
+        "audio",
+        "link"
+      ]
+    },
+    "public.milestone_category": {
+      "name": "milestone_category",
+      "schema": "public",
+      "values": [
+        "award",
+        "release",
+        "event",
+        "affiliation",
+        "education",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1778207988308,
       "tag": "0015_wise_nehzno",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1778256543005,
+      "tag": "0016_true_forgotten_one",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/milestone-reaction.ts
+++ b/backend/src/db/schema/milestone-reaction.ts
@@ -1,4 +1,11 @@
-import { pgTable, uuid, varchar, timestamp, unique } from "drizzle-orm/pg-core";
+import {
+  pgTable,
+  uuid,
+  varchar,
+  timestamp,
+  unique,
+  index,
+} from "drizzle-orm/pg-core";
 import { artistMilestones } from "./artist-milestone.js";
 import { users } from "./user.js";
 
@@ -12,10 +19,17 @@ export const milestoneReactions = pgTable(
     userId: uuid("user_id")
       .references(() => users.id, { onDelete: "cascade" })
       .notNull(),
-    emoji: varchar("emoji", { length: 10 }).notNull(),
+    // Mirror `reactions.emoji` (varchar(64)) so the validator (`validateEmoji`)
+    // and the two reaction tables stay in lockstep. See `reaction.ts`.
+    emoji: varchar("emoji", { length: 64 }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
   },
-  (t) => [unique().on(t.milestoneId, t.userId, t.emoji)],
+  (t) => [
+    unique().on(t.milestoneId, t.userId, t.emoji),
+    // Dedicated milestone_id index for aggregate queries on a single
+    // milestone (mirrors `reactions_post_id_idx`).
+    index("milestone_reactions_milestone_id_idx").on(t.milestoneId),
+  ],
 );

--- a/backend/src/db/schema/reaction.ts
+++ b/backend/src/db/schema/reaction.ts
@@ -1,4 +1,11 @@
-import { pgTable, uuid, varchar, timestamp, unique } from "drizzle-orm/pg-core";
+import {
+  pgTable,
+  uuid,
+  varchar,
+  timestamp,
+  unique,
+  index,
+} from "drizzle-orm/pg-core";
 import { posts } from "./post.js";
 import { users } from "./user.js";
 
@@ -12,10 +19,25 @@ export const reactions = pgTable(
     userId: uuid("user_id")
       .references(() => users.id, { onDelete: "cascade" })
       .notNull(),
-    emoji: varchar("emoji", { length: 10 }).notNull(),
+    // varchar(64) accommodates ZWJ sequences (family / profession glyphs),
+    // skin-tone modifiers, regional indicators, and variation selectors
+    // while still capping the unique-keyed row's emoji column. The
+    // application-layer limit lives in `validators.ts > MAX_EMOJI_LENGTH`
+    // — keep both in sync.
+    emoji: varchar("emoji", { length: 64 }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
   },
-  (t) => [unique().on(t.postId, t.userId, t.emoji)],
+  (t) => [
+    unique().on(t.postId, t.userId, t.emoji),
+    // The unique constraint above creates an index ordered by
+    // (post_id, user_id, emoji), but the aggregate query
+    // `Post.reactionCounts` (`WHERE post_id = ? GROUP BY emoji ORDER BY
+    // count(*) DESC LIMIT 5`) filters on post_id alone. A dedicated
+    // single-column index keeps that path cheap as the table grows and
+    // as `varchar(64)` makes the unique-index entries up to 6.4× wider
+    // than under the previous `varchar(10)`.
+    index("reactions_post_id_idx").on(t.postId),
+  ],
 );

--- a/backend/src/graphql/__tests__/artist-milestone.test.ts
+++ b/backend/src/graphql/__tests__/artist-milestone.test.ts
@@ -44,6 +44,24 @@ const ARTIST_WITH_MILESTONES = `
   }
 `;
 
+const TOGGLE_MILESTONE_REACTION = `
+  mutation ToggleMilestoneReaction($milestoneId: String!, $emoji: String!) {
+    toggleMilestoneReaction(milestoneId: $milestoneId, emoji: $emoji) {
+      id emoji createdAt
+    }
+  }
+`;
+
+const ARTIST_MILESTONE_REACTIONS = `
+  query Artist($username: String!) {
+    artist(username: $username) {
+      milestones {
+        id reactionCounts { emoji count }
+      }
+    }
+  }
+`;
+
 describe("Artist Milestones", () => {
   let app: Awaited<ReturnType<typeof getTestApp>>;
 
@@ -242,6 +260,230 @@ describe("Artist Milestones", () => {
 
       const result = await gql(app, DELETE_MILESTONE, { id }, token);
       expect(result.errors).toBeUndefined();
+    });
+  });
+
+  // Milestone reactions exercise the same `validateEmoji` + ON CONFLICT
+  // refactor as `toggleReaction` (see `reaction.test.ts`). Until this PR
+  // there were NO integration tests for `toggleMilestoneReaction` at all,
+  // so this block also serves as basic-behavior coverage.
+  describe("toggleMilestoneReaction", () => {
+    async function createMilestone(
+      app: Awaited<ReturnType<typeof getTestApp>>,
+      token: string,
+    ): Promise<string> {
+      const result = await gql(
+        app,
+        CREATE_MILESTONE,
+        {
+          category: "release",
+          title: "Debut Single",
+          date: "2024-04-01",
+        },
+        token,
+      );
+      return (result.data!.createArtistMilestone as { id: string }).id;
+    }
+
+    it("toggles a reaction on, then off", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "mr1@test.com",
+        "mruser1",
+        "mrartist1",
+      );
+      const milestoneId = await createMilestone(app, token);
+
+      const onResult = await gql(
+        app,
+        TOGGLE_MILESTONE_REACTION,
+        { milestoneId, emoji: "🔥" },
+        token,
+      );
+      expect(onResult.errors).toBeUndefined();
+      const reaction = onResult.data!.toggleMilestoneReaction as Record<
+        string,
+        unknown
+      >;
+      expect(reaction.emoji).toBe("🔥");
+
+      const offResult = await gql(
+        app,
+        TOGGLE_MILESTONE_REACTION,
+        { milestoneId, emoji: "🔥" },
+        token,
+      );
+      expect(offResult.errors).toBeUndefined();
+      expect(offResult.data!.toggleMilestoneReaction).toBeNull();
+    });
+
+    it("accepts a 64-character emoji string (maxlen boundary)", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "mr2@test.com",
+        "mruser2",
+        "mrartist2",
+      );
+      const milestoneId = await createMilestone(app, token);
+      const value = "a".repeat(64);
+
+      const result = await gql(
+        app,
+        TOGGLE_MILESTONE_REACTION,
+        { milestoneId, emoji: value },
+        token,
+      );
+      expect(result.errors).toBeUndefined();
+      const reaction = result.data!.toggleMilestoneReaction as Record<
+        string,
+        unknown
+      >;
+      expect(reaction.emoji).toBe(value);
+    });
+
+    it("rejects an emoji string longer than 64 characters", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "mr3@test.com",
+        "mruser3",
+        "mrartist3",
+      );
+      const milestoneId = await createMilestone(app, token);
+
+      const result = await gql(
+        app,
+        TOGGLE_MILESTONE_REACTION,
+        { milestoneId, emoji: "a".repeat(65) },
+        token,
+      );
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("64 characters or less");
+    });
+
+    it("accepts a ZWJ family emoji (👨‍👩‍👧‍👦)", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "mr4@test.com",
+        "mruser4",
+        "mrartist4",
+      );
+      const milestoneId = await createMilestone(app, token);
+      const family = "👨‍👩‍👧‍👦";
+
+      const result = await gql(
+        app,
+        TOGGLE_MILESTONE_REACTION,
+        { milestoneId, emoji: family },
+        token,
+      );
+      expect(result.errors).toBeUndefined();
+      const reaction = result.data!.toggleMilestoneReaction as Record<
+        string,
+        unknown
+      >;
+      expect(reaction.emoji).toBe(family);
+    });
+
+    it("rejects emoji containing control or bidi characters", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "mr5@test.com",
+        "mruser5",
+        "mrartist5",
+      );
+      const milestoneId = await createMilestone(app, token);
+
+      const result = await gql(
+        app,
+        TOGGLE_MILESTONE_REACTION,
+        { milestoneId, emoji: "​🔥" }, // ZWSP
+        token,
+      );
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe(
+        "Emoji contains disallowed characters",
+      );
+    });
+
+    it("rejects unauthenticated request", async () => {
+      const result = await gql(app, TOGGLE_MILESTONE_REACTION, {
+        milestoneId: "00000000-0000-0000-0000-000000000000",
+        emoji: "🔥",
+      });
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Authentication required");
+    });
+
+    it("rejects malformed milestone id (validateUUID guard)", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "mr6@test.com",
+        "mruser6",
+        "mrartist6",
+      );
+
+      const result = await gql(
+        app,
+        TOGGLE_MILESTONE_REACTION,
+        { milestoneId: "not-a-uuid", emoji: "🔥" },
+        token,
+      );
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toBe("Invalid milestone id");
+    });
+
+    it("is idempotent under concurrent toggle requests for the same emoji", async () => {
+      // ON CONFLICT DO NOTHING regression guard. Without it the second
+      // INSERT in a parallel pair would surface the unique-constraint
+      // violation as a generic 500.
+      const token = await signupAndRegisterArtist(
+        app,
+        "mr7@test.com",
+        "mruser7",
+        "mrartist7",
+      );
+      const milestoneId = await createMilestone(app, token);
+
+      const results = await Promise.all([
+        gql(
+          app,
+          TOGGLE_MILESTONE_REACTION,
+          { milestoneId, emoji: "🚀" },
+          token,
+        ),
+        gql(
+          app,
+          TOGGLE_MILESTONE_REACTION,
+          { milestoneId, emoji: "🚀" },
+          token,
+        ),
+      ]);
+      for (const r of results) {
+        expect(r.errors).toBeUndefined();
+      }
+
+      // Final state must be either 0 (both toggled — net cancel) or 1
+      // (one INSERT survived; the other is a no-op via ON CONFLICT) —
+      // never an error.
+      const finalQuery = await gql(
+        app,
+        ARTIST_MILESTONE_REACTIONS,
+        { username: "mrartist7" },
+        token,
+      );
+      const milestones = (
+        finalQuery.data!.artist as {
+          milestones: Array<{
+            id: string;
+            reactionCounts: Array<{ emoji: string; count: number }>;
+          }>;
+        }
+      ).milestones;
+      const target = milestones.find((m) => m.id === milestoneId)!;
+      const rocket = target.reactionCounts.find((c) => c.emoji === "🚀");
+      expect([undefined, { emoji: "🚀", count: 1 }]).toContainEqual(
+        rocket ?? undefined,
+      );
     });
   });
 

--- a/backend/src/graphql/__tests__/reaction.test.ts
+++ b/backend/src/graphql/__tests__/reaction.test.ts
@@ -343,6 +343,140 @@ describe("Reaction GraphQL integration", () => {
       const reaction = result.data!.toggleReaction as Record<string, unknown>;
       expect(reaction.emoji).toBe("🎉");
     });
+
+    // Emoji column expansion (varchar(10) -> varchar(64)) and validateEmoji
+    // helper rollout. Each case exercises one branch of `validateEmoji` in
+    // GraphQL context; the helper itself is unit-tested in
+    // `validators.test.ts` so these only assert the integration path.
+
+    it("accepts a 64-character emoji string (maxlen boundary)", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "r7@example.com",
+        "ruser7",
+        "rartist7",
+      );
+      const postId = await createPostForTest(app, token);
+      const value = "a".repeat(64);
+
+      const result = await gql(
+        app,
+        TOGGLE_REACTION_MUTATION,
+        { postId, emoji: value },
+        token,
+      );
+      expect(result.errors).toBeUndefined();
+      const reaction = result.data!.toggleReaction as Record<string, unknown>;
+      expect(reaction.emoji).toBe(value);
+    });
+
+    it("rejects an emoji string longer than 64 characters", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "r8@example.com",
+        "ruser8",
+        "rartist8",
+      );
+      const postId = await createPostForTest(app, token);
+
+      const result = await gql(
+        app,
+        TOGGLE_REACTION_MUTATION,
+        { postId, emoji: "a".repeat(65) },
+        token,
+      );
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0].message).toContain("64 characters or less");
+    });
+
+    it("accepts a ZWJ family emoji (👨‍👩‍👧‍👦 = 11 code units)", async () => {
+      // The whole motivation for the column expansion: this emoji is 11
+      // UTF-16 code units (4 surrogate pairs joined by 3 ZWJ chars), so
+      // the previous `varchar(10)` silently truncated it to a different
+      // glyph at the DB layer.
+      const token = await signupAndRegisterArtist(
+        app,
+        "r9@example.com",
+        "ruser9",
+        "rartist9",
+      );
+      const postId = await createPostForTest(app, token);
+      const family = "👨‍👩‍👧‍👦";
+
+      const result = await gql(
+        app,
+        TOGGLE_REACTION_MUTATION,
+        { postId, emoji: family },
+        token,
+      );
+      expect(result.errors).toBeUndefined();
+      const reaction = result.data!.toggleReaction as Record<string, unknown>;
+      expect(reaction.emoji).toBe(family);
+    });
+
+    it("rejects emoji containing control or bidi characters", async () => {
+      const token = await signupAndRegisterArtist(
+        app,
+        "r10@example.com",
+        "ruser10",
+        "rartist10",
+      );
+      const postId = await createPostForTest(app, token);
+
+      // Trojan Source / invisible-payload class. Picker UI cannot produce
+      // these, so any client sending them is already off-path.
+      const cases = [
+        "\u200B\uD83C\uDF89", // ZWSP + party-popper
+        "\uD83C\uDF89\u202E\uD83C\uDF89", // RLO bidi override sandwich
+        "\uD83C\uDF89\u0000\uD83C\uDF89", // NUL embedded
+        "\uD83C\uDF89\uFEFF\uD83C\uDF89", // ZWNBSP / BOM (mid-string; trim() would otherwise strip a leading/trailing BOM)
+      ];
+      for (const value of cases) {
+        const result = await gql(
+          app,
+          TOGGLE_REACTION_MUTATION,
+          { postId, emoji: value },
+          token,
+        );
+        expect(result.errors).toBeDefined();
+        expect(result.errors![0].message).toBe(
+          "Emoji contains disallowed characters",
+        );
+      }
+    });
+
+    it("is idempotent under concurrent toggle requests for the same emoji", async () => {
+      // Regression guard for the ON CONFLICT DO NOTHING refactor. The
+      // previous SELECT → DELETE/INSERT path could race past `existing`
+      // and surface a unique-constraint 500 ("Failed to create reaction")
+      // when two requests arrived in the same tick. Either ordering of
+      // INSERT-INSERT (one wins / one toggles off) is fine — what we
+      // assert here is "no GraphQL errors and the table converges to a
+      // deterministic state".
+      const token = await signupAndRegisterArtist(
+        app,
+        "r11@example.com",
+        "ruser11",
+        "rartist11",
+      );
+      const postId = await createPostForTest(app, token);
+
+      const results = await Promise.all([
+        gql(app, TOGGLE_REACTION_MUTATION, { postId, emoji: "🚀" }, token),
+        gql(app, TOGGLE_REACTION_MUTATION, { postId, emoji: "🚀" }, token),
+      ]);
+      for (const r of results) {
+        expect(r.errors).toBeUndefined();
+      }
+
+      // After two toggles by the same user, the row count must be 0 OR 1
+      // (depending on which call's INSERT succeeded first), but never 2 —
+      // the unique constraint prevents 2, and the helper must not
+      // surface that as an error.
+      const queryResult = await gql(app, REACTIONS_QUERY, { postId }, token);
+      const reactions = queryResult.data!.reactions as Array<unknown>;
+      expect([0, 1]).toContain(reactions.length);
+    });
   });
 
   describe("deleteReaction", () => {

--- a/backend/src/graphql/__tests__/validators.test.ts
+++ b/backend/src/graphql/__tests__/validators.test.ts
@@ -20,6 +20,8 @@ import {
   assertUploadedR2ObjectsMatch,
   assertUploadedR2ObjectMatches,
   validateUUID,
+  validateEmoji,
+  MAX_EMOJI_LENGTH,
 } from "../validators.js";
 import { GraphQLError } from "graphql";
 import {
@@ -343,5 +345,109 @@ describe("validateUUID", () => {
       expect(err).toBeInstanceOf(GraphQLError);
       expect((err as GraphQLError).extensions?.code).toBe("BAD_USER_INPUT");
     }
+  });
+});
+
+// Reaction emoji input gating. Phase 0 keeps the picker as the only client
+// path, so the server check exists for non-picker clients and abuse cases:
+// over-length payloads, control / bidi characters that hide payload, and
+// the empty / whitespace-only edge.
+describe("validateEmoji", () => {
+  it("accepts a single-codepoint emoji", () => {
+    expect(validateEmoji("🔥")).toBe("🔥");
+  });
+
+  it("accepts an emoji with a Variation Selector (heart + VS-16)", () => {
+    // ❤ + U+FE0F renders as the red-heart glyph; VS chars must NOT be
+    // rejected or the entire heart family becomes invalid.
+    expect(validateEmoji("❤️")).toBe("❤️");
+  });
+
+  it("accepts a ZWJ family emoji (man + ZWJ + woman + ZWJ + girl + ZWJ + boy)", () => {
+    // The whole point of expanding from varchar(10) to varchar(64): the
+    // family glyph is 4 surrogate-pair codepoints joined by 3 ZWJ chars =
+    // 11 UTF-16 code units, which the previous varchar(10) silently
+    // truncated. Without ZWJ exemption (U+200D), the
+    // emoji_picker_flutter "people" category would also be unusable.
+    const family = "👨‍👩‍👧‍👦";
+    expect(family.length).toBe(11);
+    expect(family.length).toBeGreaterThan(10); // Regression guard for the previous limit.
+    expect(validateEmoji(family)).toBe(family);
+  });
+
+  it("accepts a kiss-with-skin-tone ZWJ sequence (well above the old 10-char limit)", () => {
+    // Documents that the helper handles deeper ZWJ sequences than the
+    // family case. The exact code-unit count varies by source-string
+    // representation (with/without VS-16 on the heart, etc.); the
+    // important contract is "the old varchar(10) cut this off, the new
+    // limit accepts it".
+    const kiss = "👨🏻‍❤️‍💋‍👨🏿";
+    expect(kiss.length).toBeGreaterThan(10);
+    expect(validateEmoji(kiss)).toBe(kiss);
+  });
+
+  it("trims surrounding whitespace and returns the trimmed value", () => {
+    expect(validateEmoji("  🎉  ")).toBe("🎉");
+  });
+
+  it("accepts exactly MAX_EMOJI_LENGTH code units", () => {
+    const value = "a".repeat(MAX_EMOJI_LENGTH);
+    expect(validateEmoji(value)).toBe(value);
+  });
+
+  it("rejects values longer than MAX_EMOJI_LENGTH after trimming", () => {
+    const value = "a".repeat(MAX_EMOJI_LENGTH + 1);
+    expect(() => validateEmoji(value)).toThrow(GraphQLError);
+    expect(() => validateEmoji(value)).toThrow(
+      `Emoji must be ${MAX_EMOJI_LENGTH} characters or less`,
+    );
+  });
+
+  it("rejects empty string", () => {
+    expect(() => validateEmoji("")).toThrow("Emoji is required");
+  });
+
+  it("rejects whitespace-only string", () => {
+    expect(() => validateEmoji("   \t\n  ")).toThrow("Emoji is required");
+  });
+
+  it("rejects non-string values (defensive)", () => {
+    expect(() => validateEmoji(undefined)).toThrow(GraphQLError);
+    expect(() => validateEmoji(null)).toThrow(GraphQLError);
+    expect(() => validateEmoji(42 as unknown)).toThrow(GraphQLError);
+    expect(() => validateEmoji({} as unknown)).toThrow(GraphQLError);
+  });
+
+  // Trojan Source / invisible-payload defense. Each char would be
+  // rendered invisibly inside an otherwise normal-looking emoji string and
+  // could either hide payload or flip the visual direction of adjacent
+  // labels (e.g. usernames rendered next to the reaction count).
+  it.each([
+    ["NUL (U+0000)", " "],
+    ["LF (U+000A)", "\n"],
+    ["DEL (U+007F)", ""],
+    ["C1 control (U+0085 next-line)", ""],
+    ["ZWSP (U+200B)", "​"],
+    ["ZWNJ (U+200C)", "‌"],
+    ["LRM (U+200E)", "‎"],
+    ["RLM (U+200F)", "‏"],
+    ["RLO (U+202E bidi override)", "‮"],
+    ["RLI (U+2067 bidi isolate)", "⁧"],
+    ["BOM / ZWNBSP (U+FEFF)", "﻿"],
+  ])("rejects %s embedded in the emoji string", (_, ch) => {
+    expect(() => validateEmoji(`🎉${ch}🎉`)).toThrow("disallowed characters");
+  });
+
+  // Belt-and-braces — a single forbidden char alone (no surrounding emoji)
+  // must still be rejected, not slip through as "1 char ≤ MAX".
+  it("rejects a value that is ONLY a forbidden char", () => {
+    expect(() => validateEmoji("​")).toThrow("disallowed characters");
+  });
+
+  // Regression guard for the ZWJ exemption: U+200D must NOT be in the
+  // forbidden set. If a future refactor narrows the regex range and
+  // accidentally re-includes ZWJ, this test fails.
+  it("does NOT reject ZWJ on its own (regression guard for family emoji)", () => {
+    expect(() => validateEmoji("a‍b")).not.toThrow();
   });
 });

--- a/backend/src/graphql/types/artist-milestone.ts
+++ b/backend/src/graphql/types/artist-milestone.ts
@@ -7,6 +7,7 @@ import {
   milestoneReactions,
 } from "../../db/schema/index.js";
 import { and, eq, desc, sql } from "drizzle-orm";
+import { validateEmoji, validateUUID } from "../validators.js";
 
 const MAX_MILESTONES_PER_ARTIST = 200;
 import { ArtistType } from "./artist.js";
@@ -203,6 +204,7 @@ builder.mutationFields((t) => ({
       if (!ctx.authUser) {
         throw new GraphQLError("Authentication required");
       }
+      validateUUID(args.id, "milestone id");
 
       const artistId = await getOwnArtistId(ctx.authUser.userId);
 
@@ -258,6 +260,7 @@ builder.mutationFields((t) => ({
       if (!ctx.authUser) {
         throw new GraphQLError("Authentication required");
       }
+      validateUUID(args.id, "milestone id");
 
       const artistId = await getOwnArtistId(ctx.authUser.userId);
 
@@ -309,14 +312,8 @@ builder.mutationFields((t) => ({
       if (!ctx.authUser) {
         throw new GraphQLError("Authentication required");
       }
-
-      const emoji = args.emoji.trim();
-      if (emoji.length === 0) {
-        throw new GraphQLError("Emoji is required");
-      }
-      if (emoji.length > 10) {
-        throw new GraphQLError("Emoji must be 10 characters or less");
-      }
+      validateUUID(args.milestoneId, "milestone id");
+      const emoji = validateEmoji(args.emoji);
 
       // Atomic toggle inside transaction — existence check included.
       return await db.transaction(async (tx) => {
@@ -357,7 +354,16 @@ builder.mutationFields((t) => ({
           return null;
         }
 
-        // Enforce per-user reaction limit (max 8 distinct emoji per milestone)
+        // Enforce per-user reaction limit (max 8 distinct emoji per
+        // milestone). The COUNT/INSERT pair still races under READ
+        // COMMITTED — the count-bounded path here predates the
+        // SELECT FOR UPDATE convention in
+        // `.claude/rules/backend-implementation.md`. Tracked as a
+        // separate Phase 1 hardening Issue (linked from this PR's
+        // description) so the present PR can stay scoped to the emoji
+        // expansion. The ON CONFLICT clause below at least makes "two
+        // callers add the same emoji at once" race-safe (idempotent
+        // toggle on); only the 8-limit overrun remains.
         const [{ count }] = await tx
           .select({ count: sql<number>`count(*)::int` })
           .from(milestoneReactions)
@@ -371,7 +377,11 @@ builder.mutationFields((t) => ({
           throw new GraphQLError("Maximum 8 reactions per milestone");
         }
 
-        // Was off → now on
+        // Was off → now on. ON CONFLICT DO NOTHING tolerates the narrow
+        // race where two parallel "toggle on" requests for the same
+        // (milestone, user, emoji) survive the DELETE branch above and
+        // both reach INSERT — without it, the second one surfaces a
+        // unique-constraint 500 to the client.
         const [reaction] = await tx
           .insert(milestoneReactions)
           .values({
@@ -379,8 +389,37 @@ builder.mutationFields((t) => ({
             userId: ctx.authUser!.userId,
             emoji,
           })
+          .onConflictDoNothing({
+            target: [
+              milestoneReactions.milestoneId,
+              milestoneReactions.userId,
+              milestoneReactions.emoji,
+            ],
+          })
           .returning();
-        return reaction;
+        if (reaction) return reaction;
+
+        // ON CONFLICT swallowed the INSERT — read the existing row so
+        // the GraphQL contract (returns the active reaction object)
+        // still holds.
+        const [existing] = await tx
+          .select()
+          .from(milestoneReactions)
+          .where(
+            and(
+              eq(milestoneReactions.milestoneId, args.milestoneId),
+              eq(milestoneReactions.userId, ctx.authUser!.userId),
+              eq(milestoneReactions.emoji, emoji),
+            ),
+          )
+          .limit(1);
+        if (!existing) {
+          // Should not happen — DELETE returned 0 above and ON CONFLICT
+          // implies a row exists — but surface a generic error rather
+          // than an undefined return.
+          throw new GraphQLError("Failed to toggle reaction");
+        }
+        return existing;
       });
     },
   }),

--- a/backend/src/graphql/types/reaction.ts
+++ b/backend/src/graphql/types/reaction.ts
@@ -115,37 +115,47 @@ builder.mutationFields((t) => ({
       // sequence into a single race-safe path: parallel double-clicks no
       // longer race past `existing` and surface as 500 ("Failed to create
       // reaction") on the unique-constraint violation.
-      const [inserted] = await db
-        .insert(reactions)
-        .values({
-          postId: args.postId,
-          userId: ctx.authUser.userId,
-          emoji,
-        })
-        .onConflictDoNothing({
-          target: [reactions.postId, reactions.userId, reactions.emoji],
-        })
-        .returning();
+      //
+      // Wrapped in a transaction so the INSERT-or-DELETE pair stays
+      // atomic from the client's perspective and stays symmetric with
+      // `toggleMilestoneReaction` (which has been transactional from
+      // the start). Without this wrapper the failure mode is benign
+      // today — DELETE following a swallowed INSERT cannot leave a
+      // stale row — but the symmetry makes future "add a per-user cap
+      // here too" / "audit-log this mutation" extensions straightforward.
+      return await db.transaction(async (tx) => {
+        const [inserted] = await tx
+          .insert(reactions)
+          .values({
+            postId: args.postId,
+            userId: ctx.authUser!.userId,
+            emoji,
+          })
+          .onConflictDoNothing({
+            target: [reactions.postId, reactions.userId, reactions.emoji],
+          })
+          .returning();
 
-      if (inserted) {
-        // Toggle on: row was newly created.
-        return inserted;
-      }
+        if (inserted) {
+          // Toggle on: row was newly created.
+          return inserted;
+        }
 
-      // Row already existed → toggle off. DELETE returns 0 rows iff a
-      // concurrent caller has already toggled off in the gap, which is the
-      // exact same observable end state we want — so we always return null
-      // here without distinguishing the two paths.
-      await db
-        .delete(reactions)
-        .where(
-          and(
-            eq(reactions.postId, args.postId),
-            eq(reactions.userId, ctx.authUser.userId),
-            eq(reactions.emoji, emoji),
-          ),
-        );
-      return null;
+        // Row already existed → toggle off. DELETE returns 0 rows iff a
+        // concurrent caller has already toggled off in the gap, which is
+        // the exact same observable end state we want — so we always
+        // return null here without distinguishing the two paths.
+        await tx
+          .delete(reactions)
+          .where(
+            and(
+              eq(reactions.postId, args.postId),
+              eq(reactions.userId, ctx.authUser!.userId),
+              eq(reactions.emoji, emoji),
+            ),
+          );
+        return null;
+      });
     },
   }),
 
@@ -160,26 +170,28 @@ builder.mutationFields((t) => ({
       }
       validateUUID(args.id, "reaction id");
 
-      // Single query with both id and userId to avoid existence oracle
-      const [reaction] = await db
-        .select()
-        .from(reactions)
+      // Single DELETE with both id and userId. Two pieces of safety:
+      //   1. Ownership: the userId predicate makes the DELETE a no-op
+      //      for someone else's reaction id, even if a future refactor
+      //      drops the explicit ownership SELECT we used to run here.
+      //      DELETE-then-throw with a guarded WHERE is more
+      //      future-proof than SELECT-then-DELETE because the WHERE is
+      //      what actually authorizes the row removal.
+      //   2. Enumeration: returning the same "Reaction not found"
+      //      message for "row missing" and "row owned by someone else"
+      //      keeps existence indistinguishable from non-ownership.
+      const [deleted] = await db
+        .delete(reactions)
         .where(
           and(
             eq(reactions.id, args.id),
             eq(reactions.userId, ctx.authUser.userId),
           ),
         )
-        .limit(1);
-      if (!reaction) {
+        .returning();
+      if (!deleted) {
         throw new GraphQLError("Reaction not found");
       }
-
-      const [deleted] = await db
-        .delete(reactions)
-        .where(eq(reactions.id, args.id))
-        .returning();
-
       return deleted;
     },
   }),

--- a/backend/src/graphql/types/reaction.ts
+++ b/backend/src/graphql/types/reaction.ts
@@ -4,7 +4,7 @@ import { db } from "../../db/index.js";
 import { posts, reactions, users } from "../../db/schema/index.js";
 import { and, eq, sql, desc } from "drizzle-orm";
 import { isAuthorVisibleToViewer } from "../access.js";
-import { validateUUID } from "../validators.js";
+import { validateEmoji, validateUUID } from "../validators.js";
 import { PostType } from "./post.js";
 import { PublicUserType, publicUserColumns } from "./user.js";
 
@@ -80,15 +80,7 @@ builder.mutationFields((t) => ({
         throw new GraphQLError("Authentication required");
       }
       validateUUID(args.postId, "post id");
-
-      // Validate emoji
-      const emoji = args.emoji.trim();
-      if (emoji.length === 0) {
-        throw new GraphQLError("Emoji is required");
-      }
-      if (emoji.length > 10) {
-        throw new GraphQLError("Emoji must be 10 characters or less");
-      }
+      const emoji = validateEmoji(args.emoji);
 
       // Verify post exists AND its author is visible to the viewer.
       // Child / non-public authors must not be reachable as reaction targets;
@@ -117,39 +109,43 @@ builder.mutationFields((t) => ({
         throw new GraphQLError("Post not found");
       }
 
-      // Check if reaction already exists
-      const [existing] = await db
-        .select()
-        .from(reactions)
+      // Idempotent toggle: try to INSERT first; on unique-constraint
+      // collision the (postId, userId, emoji) row already exists and we
+      // DELETE instead. This collapses the previous SELECT → DELETE/INSERT
+      // sequence into a single race-safe path: parallel double-clicks no
+      // longer race past `existing` and surface as 500 ("Failed to create
+      // reaction") on the unique-constraint violation.
+      const [inserted] = await db
+        .insert(reactions)
+        .values({
+          postId: args.postId,
+          userId: ctx.authUser.userId,
+          emoji,
+        })
+        .onConflictDoNothing({
+          target: [reactions.postId, reactions.userId, reactions.emoji],
+        })
+        .returning();
+
+      if (inserted) {
+        // Toggle on: row was newly created.
+        return inserted;
+      }
+
+      // Row already existed → toggle off. DELETE returns 0 rows iff a
+      // concurrent caller has already toggled off in the gap, which is the
+      // exact same observable end state we want — so we always return null
+      // here without distinguishing the two paths.
+      await db
+        .delete(reactions)
         .where(
           and(
             eq(reactions.postId, args.postId),
             eq(reactions.userId, ctx.authUser.userId),
             eq(reactions.emoji, emoji),
           ),
-        )
-        .limit(1);
-
-      if (existing) {
-        // Toggle off: delete and return null
-        await db.delete(reactions).where(eq(reactions.id, existing.id));
-        return null;
-      }
-
-      // Toggle on: create
-      try {
-        const [reaction] = await db
-          .insert(reactions)
-          .values({
-            postId: args.postId,
-            userId: ctx.authUser.userId,
-            emoji,
-          })
-          .returning();
-        return reaction;
-      } catch {
-        throw new GraphQLError("Failed to create reaction");
-      }
+        );
+      return null;
     },
   }),
 
@@ -296,7 +292,19 @@ builder.objectFields(PostType, (t) => ({
       return rows.map((r) => r.emoji);
     },
   }),
-  // Aggregated counts only (no user info) — intentionally public
+  // Aggregated counts only (no user info) — intentionally public.
+  //
+  // Phase 0 trade-off: this resolver does NOT apply
+  // `isAuthorVisibleToViewer`. With everyone in the family-launch tier
+  // running `profileVisibility: "public"`, the only emoji content
+  // surfaced here is from authors that are already visible elsewhere.
+  // Phase 1 SNS expansion needs to plug this — once child / private
+  // authors become routinely reachable through public bots and feed
+  // links, leaking their reaction emoji set turns into a
+  // micro-enumeration oracle. Tracked as a separate Issue (linked from
+  // this PR's description); the surrounding `Post.reactions` and
+  // `reactions(postId)` already enforce the same guard so the upgrade
+  // is mechanical.
   reactionCounts: t.field({
     type: [ReactionCountType],
     resolve: async (post) => {

--- a/backend/src/graphql/validators.ts
+++ b/backend/src/graphql/validators.ts
@@ -266,6 +266,83 @@ export function ageFromBirthYearMonth(value: string): number {
   return age;
 }
 
+/**
+ * Maximum UTF-16 code-unit length permitted for a reaction emoji string
+ * after trimming. Long enough to accommodate ZWJ sequences such as
+ * 👨‍👩‍👧‍👦 (11 code units), 👨🏻‍❤️‍💋‍👨🏿 (17), the longest
+ * RGI sequences in current Unicode emoji data (~24), and a small headroom
+ * for future Unicode revisions, while still bounding storage on the
+ * unique-keyed `(post_id, user_id, emoji)` row. Must match `varchar(64)`
+ * on `reactions.emoji` and `milestone_reactions.emoji` (see
+ * `db/schema/reaction.ts` / `milestone-reaction.ts`).
+ *
+ * Note on units: this limit counts JavaScript `String.length` (UTF-16
+ * code units), whereas PostgreSQL `varchar(64)` counts Unicode
+ * codepoints. A single 4-byte emoji (e.g. 🔥, U+1F525) is 2 code units
+ * here but 1 codepoint in Postgres, so anything we accept always fits
+ * the column. There is no input we reject that the DB would accept,
+ * and no input we accept that the DB would truncate. Future allowlist
+ * work (Idea 004 paid packs) should keep this asymmetry in mind when
+ * picking a stricter bound.
+ */
+export const MAX_EMOJI_LENGTH = 64;
+
+/**
+ * Reject Unicode control and bidirectional / format characters that have no
+ * place in a reaction emoji string. The picker UI (emoji_picker_flutter)
+ * cannot produce these, so any input containing them is either a non-picker
+ * client or an attempt to embed invisible payload. Specifically:
+ *
+ * - U+0000-U+001F, U+007F-U+009F: C0 / C1 control chars (NUL, LF,
+ *   DEL, etc.). Break logs, JSON, and screen reader output.
+ * - U+200B (ZWSP), U+200C (ZWNJ), U+200E (LRM), U+200F (RLM):
+ *   zero-width space / non-joiner and bidirectional marks. Hide payload
+ *   inside what looks like a single emoji and can flip line direction in
+ *   adjacent UI text. ZWJ (U+200D) is INTENTIONALLY EXCLUDED —
+ *   family / profession emoji depend on it (e.g. man + ZWJ + woman + ZWJ
+ *   + girl + ZWJ + boy renders as a single family glyph).
+ * - U+202A-U+202E, U+2066-U+2069: bidi override / isolate. Allow an
+ *   attacker to render reaction text as right-to-left or override visual
+ *   ordering of surrounding labels (Trojan Source family).
+ * - U+FEFF: byte-order mark / ZWNBSP. Same hiding-payload concern as ZWSP.
+ *
+ * Variation selectors (U+FE00-U+FE0F) are kept (e.g. heart + VS-16 = ❤️).
+ */
+const REACTION_EMOJI_FORBIDDEN_RE =
+  // eslint-disable-next-line no-control-regex
+  /[\u0000-\u001F\u007F-\u009F\u200B\u200C\u200E\u200F\u202A-\u202E\u2066-\u2069\uFEFF]/;
+
+/**
+ * Validate a reaction emoji string.
+ *
+ * Returns the trimmed value so callers can persist exactly what was checked
+ * (avoid the accidental "validate trimmed, store untrimmed" footgun).
+ *
+ * Phase 0 keeps the value space free-form within the length / forbidden-char
+ * envelope: the picker constrains the input on the client, and the family
+ * Phase 0 deployment has no need for a server-side allowlist. Phase 1's
+ * default-set / paid-pack model (Idea 004) is the natural place to add an
+ * allowlist; this helper is the single point that needs to change.
+ */
+export function validateEmoji(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new GraphQLError("Emoji is required");
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new GraphQLError("Emoji is required");
+  }
+  if (trimmed.length > MAX_EMOJI_LENGTH) {
+    throw new GraphQLError(
+      `Emoji must be ${MAX_EMOJI_LENGTH} characters or less`,
+    );
+  }
+  if (REACTION_EMOJI_FORBIDDEN_RE.test(trimmed)) {
+    throw new GraphQLError("Emoji contains disallowed characters");
+  }
+  return trimmed;
+}
+
 const COPPA_MIN_AGE = 13;
 
 /**

--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -646,5 +646,23 @@
   "@colorPresetLabel": {
     "description": "Semantics label for each tappable color swatch in the track color picker preset grid. Read by screen readers as e.g. 'Color #f97316'.",
     "placeholders": { "hex": { "type": "String" } }
+  },
+
+  "search": "Search",
+  "@search": {
+    "description": "Generic search placeholder used in input fields and search bars (e.g. emoji picker hint, future global search). Single word imperative verb to keep it short on narrow inputs."
+  },
+  "reactionPickerTitle": "Add reaction",
+  "@reactionPickerTitle": {
+    "description": "Title shown at the top of the emoji picker bottom sheet that opens when the user taps the '+' button next to the inline quick-pick reactions in the post detail view. Also used as the tooltip / Semantics label on the '+' button itself."
+  },
+  "reactionPickerHint": "Tap an emoji to add or remove",
+  "@reactionPickerHint": {
+    "description": "Hint text shown inside the emoji picker bottom sheet, just below the title. Explains the toggle semantics (each tap on an emoji adds or removes that reaction; the sheet stays open across multiple taps until the user dismisses it)."
+  },
+  "reactWith": "React with {emoji}",
+  "@reactWith": {
+    "description": "Semantics label for each individual quick-pick emoji button in the post detail view (the inline 3 + ‘+’ row). Read by screen readers as e.g. 'React with party-popper'.",
+    "placeholders": { "emoji": { "type": "String" } }
   }
 }

--- a/frontend/lib/l10n/app_ja.arb
+++ b/frontend/lib/l10n/app_ja.arb
@@ -448,5 +448,10 @@
   "editTrack": "トラックを編集",
   "failedUpdateTrack": "トラックの更新に失敗しました",
   "failedUpdateTrackRetry": "トラックの更新に失敗しました。再試行してください。",
-  "colorPresetLabel": "色 {hex}"
+  "colorPresetLabel": "色 {hex}",
+
+  "search": "検索",
+  "reactionPickerTitle": "リアクションを追加",
+  "reactionPickerHint": "絵文字をタップで追加・解除",
+  "reactWith": "{emoji} でリアクション"
 }

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -2485,6 +2485,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Color {hex}'**
   String colorPresetLabel(String hex);
+
+  /// Generic search placeholder used in input fields and search bars (e.g. emoji picker hint, future global search). Single word imperative verb to keep it short on narrow inputs.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get search;
+
+  /// Title shown at the top of the emoji picker bottom sheet that opens when the user taps the '+' button next to the inline quick-pick reactions in the post detail view. Also used as the tooltip / Semantics label on the '+' button itself.
+  ///
+  /// In en, this message translates to:
+  /// **'Add reaction'**
+  String get reactionPickerTitle;
+
+  /// Hint text shown inside the emoji picker bottom sheet, just below the title. Explains the toggle semantics (each tap on an emoji adds or removes that reaction; the sheet stays open across multiple taps until the user dismisses it).
+  ///
+  /// In en, this message translates to:
+  /// **'Tap an emoji to add or remove'**
+  String get reactionPickerHint;
+
+  /// Semantics label for each individual quick-pick emoji button in the post detail view (the inline 3 + ‘+’ row). Read by screen readers as e.g. 'React with party-popper'.
+  ///
+  /// In en, this message translates to:
+  /// **'React with {emoji}'**
+  String reactWith(String emoji);
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -1346,4 +1346,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String colorPresetLabel(String hex) {
     return 'Color $hex';
   }
+
+  @override
+  String get search => 'Search';
+
+  @override
+  String get reactionPickerTitle => 'Add reaction';
+
+  @override
+  String get reactionPickerHint => 'Tap an emoji to add or remove';
+
+  @override
+  String reactWith(String emoji) {
+    return 'React with $emoji';
+  }
 }

--- a/frontend/lib/l10n/app_localizations_ja.dart
+++ b/frontend/lib/l10n/app_localizations_ja.dart
@@ -1303,4 +1303,18 @@ class AppLocalizationsJa extends AppLocalizations {
   String colorPresetLabel(String hex) {
     return '色 $hex';
   }
+
+  @override
+  String get search => '検索';
+
+  @override
+  String get reactionPickerTitle => 'リアクションを追加';
+
+  @override
+  String get reactionPickerHint => '絵文字をタップで追加・解除';
+
+  @override
+  String reactWith(String emoji) {
+    return '$emoji でリアクション';
+  }
 }

--- a/frontend/lib/widgets/timeline/post_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/post_detail_sheet.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:math' show Random;
+import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
@@ -17,7 +19,18 @@ import '../common/related_post_picker.dart';
 import 'seed_art_painter.dart';
 import '../../l10n/l10n.dart';
 
+/// Curated quick-pick palette. Only 3 of these are surfaced at a time
+/// (`_randomPresets`) — the rest live behind the "+" button which opens
+/// the full Unicode-wide picker via [showModalBottomSheet]. The list
+/// itself stays small so each per-post-open shuffle still feels
+/// purposeful rather than chaotic.
 const _reactionPresets = ['🔥', '❤️', '👏', '✨', '😍', '🎵', '💪', '🎸'];
+
+/// Number of [_reactionPresets] surfaced inline in the detail view's
+/// reaction row before the "+" button. Tied to [tapTargetMin]-sized cells
+/// — bumping this up significantly will overflow narrow viewports
+/// (mobile portrait, 420 px desktop side panel).
+const _inlineQuickPickCount = 3;
 
 /// Show the post detail bottom sheet (mobile).
 void showPostDetailSheet(
@@ -173,6 +186,15 @@ class _PostDetailContentState extends State<PostDetailContent> {
   bool _isConnecting = false;
   List<Post>? _cachedSyncedPosts;
 
+  /// Quick-pick emojis surfaced inline next to the "+" button. Drawn once
+  /// per detail-screen-open from [_reactionPresets] so users see a
+  /// rotating hint of "what other people might react with" without
+  /// having to open the picker. Stable for the lifetime of this State,
+  /// not regenerated in [build] (Random allocation in build() is banned
+  /// by `.claude/rules/frontend-implementation.md > "build() 内で
+  /// リソースオブジェクトを生成しない"`).
+  late List<String> _randomPresets;
+
   // Multi-image carousel (initialized in initState, reset in didUpdateWidget)
   late PageController _pageController;
   int _currentPage = 0;
@@ -273,6 +295,9 @@ class _PostDetailContentState extends State<PostDetailContent> {
     _myReactions = Set.from(widget.post.myReactions);
     _outgoingConnections = List.from(widget.post.outgoingConnections);
     _incomingConnections = List.from(widget.post.incomingConnections);
+    _randomPresets = ([
+      ..._reactionPresets,
+    ]..shuffle(Random())).take(_inlineQuickPickCount).toList();
     _pageController = PageController();
     // Initialize Quill resources for delta posts
     if (widget.post.bodyFormat == BodyFormat.delta &&
@@ -294,6 +319,14 @@ class _PostDetailContentState extends State<PostDetailContent> {
       _pageController.dispose();
       _pageController = PageController();
       _currentPage = 0;
+      // Re-roll the inline quick-pick emojis when the same Widget is
+      // recycled for a different post (desktop side panel reuses one
+      // PostDetailContent State across multiple post.id values). Without
+      // this, the user keeps seeing the previous post's three random
+      // emojis on the new one.
+      _randomPresets = ([
+        ..._reactionPresets,
+      ]..shuffle(Random())).take(_inlineQuickPickCount).toList();
     }
   }
 
@@ -397,13 +430,20 @@ class _PostDetailContentState extends State<PostDetailContent> {
       if (success) {
         final wasActive = _myReactions.contains(emoji);
         setState(() {
+          // Replace the Set instance instead of mutating it in place —
+          // matches the immutable `_reactionCounts` update pattern in
+          // `_updateCount`. Without this, downstream consumers that
+          // diff by Set identity (rather than contents) would skip
+          // their rebuild.
+          final next = Set<String>.from(_myReactions);
           if (wasActive) {
-            _myReactions.remove(emoji);
+            next.remove(emoji);
             _updateCount(emoji, -1);
           } else {
-            _myReactions.add(emoji);
+            next.add(emoji);
             _updateCount(emoji, 1);
           }
+          _myReactions = next;
         });
         widget.onReactionsChanged?.call(
           widget.post.id,
@@ -416,19 +456,28 @@ class _PostDetailContentState extends State<PostDetailContent> {
     }
   }
 
+  /// Apply [delta] (+1 / -1) to the local count for [emoji].
+  ///
+  /// Always rebuilds the list as a fresh instance instead of mutating
+  /// the existing `_reactionCounts` in place. Same-reference list
+  /// updates can cause Flutter to skip rebuilds for downstream
+  /// consumers — see `.claude/rules/frontend-implementation.md > "リスト
+  /// state の更新は新しいインスタンスで"`.
   void _updateCount(String emoji, int delta) {
     final idx = _reactionCounts.indexWhere((r) => r.emoji == emoji);
+    final next = [..._reactionCounts];
     if (idx >= 0) {
-      final newCount = _reactionCounts[idx].count + delta;
+      final newCount = next[idx].count + delta;
       if (newCount <= 0) {
-        _reactionCounts.removeAt(idx);
+        next.removeAt(idx);
       } else {
-        _reactionCounts[idx] = ReactionCount(emoji: emoji, count: newCount);
+        next[idx] = ReactionCount(emoji: emoji, count: newCount);
       }
     } else if (delta > 0) {
-      _reactionCounts.add(ReactionCount(emoji: emoji, count: 1));
+      next.add(ReactionCount(emoji: emoji, count: 1));
     }
-    _reactionCounts.sort((a, b) => b.count.compareTo(a.count));
+    next.sort((a, b) => b.count.compareTo(a.count));
+    _reactionCounts = next;
   }
 
   @override
@@ -731,87 +780,268 @@ class _PostDetailContentState extends State<PostDetailContent> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Existing reactions (compact pills)
+        // Existing reactions (compact pills). Wrapped in the same
+        // Opacity / hit-test guard as the quick-pick row so a slow
+        // mutation reply can't be raced by re-tapping a count pill —
+        // the pill would otherwise invert its own optimistic update
+        // mid-flight.
         if (_reactionCounts.isNotEmpty) ...[
-          Wrap(
-            spacing: spaceXs,
-            runSpacing: spaceXs,
-            children: _reactionCounts.map((r) {
-              final canInteract = widget.onToggleReaction != null;
-              final isActive = canInteract && _myReactions.contains(r.emoji);
-              return GestureDetector(
-                onTap: canInteract ? () => _toggleReaction(r.emoji) : null,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: spaceSm,
-                    vertical: 5,
-                  ),
-                  decoration: BoxDecoration(
-                    color: isActive
-                        ? trackColor.withValues(alpha: opacitySubtle)
-                        : colorSurface2,
-                    borderRadius: BorderRadius.circular(radiusXl),
-                    border: Border.all(
+          Opacity(
+            opacity: _isToggling ? opacityDisabled : 1.0,
+            child: Wrap(
+              spacing: spaceXs,
+              runSpacing: spaceXs,
+              children: _reactionCounts.map((r) {
+                final canInteract = widget.onToggleReaction != null;
+                final isActive = canInteract && _myReactions.contains(r.emoji);
+                return GestureDetector(
+                  onTap: (canInteract && !_isToggling)
+                      ? () => _toggleReaction(r.emoji)
+                      : null,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: spaceSm,
+                      vertical: 5,
+                    ),
+                    decoration: BoxDecoration(
                       color: isActive
-                          ? trackColor.withValues(alpha: opacityBorder)
-                          : colorBorder,
+                          ? trackColor.withValues(alpha: opacitySubtle)
+                          : colorSurface2,
+                      borderRadius: BorderRadius.circular(radiusXl),
+                      border: Border.all(
+                        color: isActive
+                            ? trackColor.withValues(alpha: opacityBorder)
+                            : colorBorder,
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          r.emoji,
+                          style: const TextStyle(fontSize: fontSizeLg),
+                        ),
+                        const SizedBox(width: spaceXs),
+                        Text(
+                          '${r.count}',
+                          style: TextStyle(
+                            color: isActive ? trackColor : colorTextMuted,
+                            fontSize: fontSizeMd,
+                            fontWeight: weightSemibold,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        r.emoji,
-                        style: const TextStyle(fontSize: fontSizeLg),
-                      ),
-                      const SizedBox(width: spaceXs),
-                      Text(
-                        '${r.count}',
-                        style: TextStyle(
-                          color: isActive ? trackColor : colorTextMuted,
-                          fontSize: fontSizeMd,
-                          fontWeight: weightSemibold,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            }).toList(),
+                );
+              }).toList(),
+            ),
           ),
           const SizedBox(height: spaceSm),
         ],
-        // Emoji picker — only shown when reactions are interactive
+        // Quick-pick row: 3 random presets + "+" button. Only rendered
+        // when reactions are interactive (fan-mode read-only views pass
+        // a null `onToggleReaction`).
         if (widget.onToggleReaction != null)
-          Wrap(
-            spacing: spaceXxs,
-            runSpacing: spaceXxs,
-            children: _reactionPresets.map((emoji) {
-              final isActive = _myReactions.contains(emoji);
-              return GestureDetector(
-                onTap: () => _toggleReaction(emoji),
-                child: Container(
-                  width: 34,
-                  height: 34,
-                  decoration: BoxDecoration(
-                    color: isActive
-                        ? trackColor.withValues(alpha: opacitySubtle)
-                        : Colors.transparent,
-                    borderRadius: BorderRadius.circular(radiusMd),
-                  ),
-                  alignment: Alignment.center,
-                  child: Text(
-                    emoji,
-                    style: TextStyle(
-                      fontSize: fontSizeLg,
-                      color: isActive ? null : colorInteractiveMuted,
-                    ),
-                  ),
-                ),
-              );
-            }).toList(),
+          Opacity(
+            opacity: _isToggling ? opacityDisabled : 1.0,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final emoji in _randomPresets) ...[
+                  _buildQuickPickButton(trackColor, emoji),
+                  const SizedBox(width: spaceXxs),
+                ],
+                _buildOpenPickerButton(),
+              ],
+            ),
           ),
       ],
+    );
+  }
+
+  Widget _buildQuickPickButton(Color trackColor, String emoji) {
+    final isActive = _myReactions.contains(emoji);
+    return Semantics(
+      button: true,
+      label: context.l10n.reactWith(emoji),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _isToggling ? null : () => _toggleReaction(emoji),
+        child: SizedBox(
+          width: tapTargetMin,
+          height: tapTargetMin,
+          child: Container(
+            margin: const EdgeInsets.all(spaceXxs),
+            decoration: BoxDecoration(
+              color: isActive
+                  ? trackColor.withValues(alpha: opacitySubtle)
+                  : Colors.transparent,
+              borderRadius: BorderRadius.circular(radiusMd),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              emoji,
+              style: TextStyle(
+                fontSize: fontSizeLg,
+                color: isActive ? null : colorInteractiveMuted,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildOpenPickerButton() {
+    return Semantics(
+      button: true,
+      label: context.l10n.reactionPickerTitle,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _isToggling ? null : () => _openEmojiPicker(),
+        child: SizedBox(
+          width: tapTargetMin,
+          height: tapTargetMin,
+          child: Container(
+            margin: const EdgeInsets.all(spaceXxs),
+            decoration: BoxDecoration(
+              color: colorSurface2,
+              borderRadius: BorderRadius.circular(radiusMd),
+              border: Border.all(color: colorBorder),
+            ),
+            alignment: Alignment.center,
+            child: const Icon(
+              Icons.add,
+              size: fontSizeLg,
+              color: colorInteractiveMuted,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Open the full Unicode-wide emoji picker as a modal bottom sheet.
+  ///
+  /// The sheet is intentionally NOT auto-dismissed on selection —
+  /// `onEmojiSelected` only forwards to [_toggleReaction], which mutates
+  /// the parent detail view's local state so the count badge updates
+  /// behind the open sheet. Users close the sheet themselves with the
+  /// drag handle / system back gesture once they're done picking.
+  Future<void> _openEmojiPicker() async {
+    if (widget.onToggleReaction == null) return;
+    // Resolve l10n + Config from the State.context BEFORE opening the
+    // sheet so the sheet's Strings and EmojiPicker theme stay locked to
+    // the post being viewed. The DraggableScrollableSheet builder below
+    // shadows the outer `context` parameter as `sheetInnerContext` so
+    // we can never accidentally reach back through a stale ancestor.
+    final l10n = context.l10n;
+    final pickerConfig = _buildEmojiPickerConfig(l10n);
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        return DraggableScrollableSheet(
+          expand: false,
+          initialChildSize: 0.6,
+          minChildSize: 0.4,
+          maxChildSize: 0.92,
+          builder: (sheetInnerContext, scrollController) {
+            return Container(
+              decoration: const BoxDecoration(
+                color: colorSurface1,
+                borderRadius: BorderRadius.vertical(
+                  top: Radius.circular(radiusSheet),
+                ),
+              ),
+              child: Column(
+                children: [
+                  const SizedBox(height: spaceSm),
+                  Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: colorBorder,
+                      borderRadius: BorderRadius.circular(radiusFull),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: spaceLg,
+                      vertical: spaceMd,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(l10n.reactionPickerTitle, style: textHeading),
+                        const SizedBox(height: spaceXxs),
+                        Text(l10n.reactionPickerHint, style: textCaption),
+                      ],
+                    ),
+                  ),
+                  Expanded(
+                    child: EmojiPicker(
+                      scrollController: scrollController,
+                      onEmojiSelected: (_, emoji) {
+                        // Don't close the sheet — the user toggles
+                        // multiple emojis and dismisses themselves.
+                        _toggleReaction(emoji.emoji);
+                      },
+                      config: pickerConfig,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  /// EmojiPicker [Config] tuned for Gleisner's dark theme. Uses
+  /// `gleisner_tokens.dart` color tokens throughout — the library's
+  /// default theme is light-on-light and would look like a transplanted
+  /// keyboard on the surface-0 background. Receives `l10n` explicitly
+  /// so it can be invoked from the State.context BEFORE the sheet
+  /// opens (see [_openEmojiPicker]) and stays stable for the lifetime
+  /// of the open sheet.
+  Config _buildEmojiPickerConfig(AppLocalizations l10n) {
+    return Config(
+      height: 256,
+      checkPlatformCompatibility: true,
+      emojiViewConfig: const EmojiViewConfig(
+        backgroundColor: colorSurface1,
+        emojiSizeMax: 28,
+        verticalSpacing: spaceXxs,
+        horizontalSpacing: spaceXxs,
+      ),
+      categoryViewConfig: const CategoryViewConfig(
+        backgroundColor: colorSurface0,
+        iconColor: colorInteractiveMuted,
+        iconColorSelected: colorTextPrimary,
+        indicatorColor: colorAccentGold,
+        dividerColor: colorBorder,
+        backspaceColor: colorInteractiveMuted,
+      ),
+      bottomActionBarConfig: const BottomActionBarConfig(
+        backgroundColor: colorSurface0,
+        buttonColor: colorSurface2,
+        buttonIconColor: colorTextPrimary,
+        showBackspaceButton: false,
+      ),
+      searchViewConfig: SearchViewConfig(
+        backgroundColor: colorSurface1,
+        buttonIconColor: colorInteractiveMuted,
+        hintText: l10n.search,
+      ),
+      skinToneConfig: const SkinToneConfig(
+        dialogBackgroundColor: colorSurface2,
+        indicatorColor: colorAccentGold,
+      ),
     );
   }
 

--- a/frontend/lib/widgets/timeline/post_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/post_detail_sheet.dart
@@ -295,9 +295,7 @@ class _PostDetailContentState extends State<PostDetailContent> {
     _myReactions = Set.from(widget.post.myReactions);
     _outgoingConnections = List.from(widget.post.outgoingConnections);
     _incomingConnections = List.from(widget.post.incomingConnections);
-    _randomPresets = ([
-      ..._reactionPresets,
-    ]..shuffle(Random())).take(_inlineQuickPickCount).toList();
+    _randomPresets = _pickRandomPresets();
     _pageController = PageController();
     // Initialize Quill resources for delta posts
     if (widget.post.bodyFormat == BodyFormat.delta &&
@@ -324,10 +322,17 @@ class _PostDetailContentState extends State<PostDetailContent> {
       // PostDetailContent State across multiple post.id values). Without
       // this, the user keeps seeing the previous post's three random
       // emojis on the new one.
-      _randomPresets = ([
-        ..._reactionPresets,
-      ]..shuffle(Random())).take(_inlineQuickPickCount).toList();
+      _randomPresets = _pickRandomPresets();
     }
+  }
+
+  /// Draw [_inlineQuickPickCount] emojis from [_reactionPresets] in a
+  /// per-call random order. Centralized so the `initState` first-draw
+  /// and the `didUpdateWidget` post-recycle re-roll stay in lockstep.
+  List<String> _pickRandomPresets() {
+    return ([
+      ..._reactionPresets,
+    ]..shuffle(Random())).take(_inlineQuickPickCount).toList();
   }
 
   @override

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -177,6 +177,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.1"
+  emoji_picker_flutter:
+    dependency: "direct main"
+    description:
+      name: emoji_picker_flutter
+      sha256: "984d3e9b9cf3175df9a868ce4a2d9611491e80e5d3b8e2b1e8991a4998972885"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.0"
   fake_async:
     dependency: transitive
     description:
@@ -1004,6 +1012,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.23"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   # "More colors" HSV picker fallback. Already a transitive dep via
   # flutter_quill; declared explicitly to satisfy `depend_on_referenced_packages`.
   flutter_colorpicker: ^1.1.0
+  emoji_picker_flutter: ^4.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Replaces the fixed 8-emoji quick-pick row in the post detail view with
a "3 random presets + ＋" row that opens a full Unicode-wide picker
(`emoji_picker_flutter`) in a non-auto-dismissing bottom sheet, and
broadens the storage / validation envelope on the backend so ZWJ family
/ profession sequences, skin-tone modifiers, regional flags, and
variation selectors no longer get truncated by `varchar(10)`.

## Backend

- Migrate `reactions.emoji` and `milestone_reactions.emoji` from
  `varchar(10)` → `varchar(64)` (PostgreSQL 11+ online-safe widening,
  no rewrite). Add single-column indexes on `reactions(post_id)` and
  `milestone_reactions(milestone_id)` for the aggregation paths.
- Extract `validateEmoji` into `validators.ts` with a
  `MAX_EMOJI_LENGTH=64` cap, length / empty checks, and a forbidden-char
  regex covering C0 / C1 controls, ZWSP / ZWNJ / LRM / RLM, bidi
  override / isolate, and ZWNBSP. ZWJ (U+200D) is intentionally allowed
  so family / profession glyphs survive validation. Trojan Source class
  inputs are explicitly rejected.
- Rewrite `toggleReaction` as `INSERT ... ON CONFLICT DO NOTHING
  RETURNING` + DELETE fallback so parallel double-clicks no longer
  surface unique-constraint 500s.
- Apply the same `validateEmoji` + ON CONFLICT pattern to
  `toggleMilestoneReaction`. Add `validateUUID` to milestone update /
  delete / toggle reaction paths so raw `invalid input syntax for type
  uuid` Postgres errors do not leak through GraphQL.

## Frontend

- Add `emoji_picker_flutter ^4.4.0`.
- Replace the fixed 8-button preset Wrap with a 4-button Row sized at
  `tapTargetMin (44 dp)` with Semantics labels: 3 emojis are drawn from
  the curated preset list (rerolled per detail-view open via initState
  / didUpdateWidget) and the 4th is a `＋` that opens the picker as a
  `DraggableScrollableSheet` modal. The sheet does NOT auto-dismiss on
  selection — each tap forwards to `_toggleReaction` so reaction counts
  update in the background, and the user dismisses the sheet themselves.
- The picker `Config` is themed entirely from `gleisner_tokens.dart`
  (surface / border / text / accent gold) so it does not look like a
  transplanted light-theme keyboard on the dark backdrop. The Config
  is built once with `AppLocalizations` resolved from State.context
  before the sheet opens, eliminating a stale-context capture risk.
- Switch `_reactionCounts` and `_myReactions` mutations to immutable
  list / set rebuilds (matches the existing immutable update pattern
  in `.claude/rules/frontend-implementation.md`) and gate the existing
  reaction-count pill row with the same `_isToggling` Opacity /
  hit-test guard as the new quick-pick row, so a slow mutation reply
  cannot be raced by a re-tap.
- Add `search`, `reactionPickerTitle`, `reactionPickerHint`, and
  `reactWith({emoji})` ARB keys in en/ja with `@key` descriptions, and
  regenerate `AppLocalizations`.

Timeline display (node card pills) is intentionally unchanged.

## Tests

- New `validateEmoji` unit tests cover ZWJ family (11 code units),
  kiss-with-skin-tone deeper sequence, 64-char boundary, the forbidden
  character classes (NUL / DEL / C1 / ZWSP / ZWNJ / LRM / RLM / RLO /
  RLI / BOM), the ZWJ regression guard, and non-string defensive input.
- Reaction integration tests gain 5 new cases: 64-char boundary, >64
  rejection, ZWJ family acceptance, control / bidi rejection, and a
  parallel-toggle race that asserts no GraphQL errors and a
  deterministic 0/1 final row count. The BOM test uses a sandwich
  layout because `String.prototype.trim()` strips a leading/trailing
  U+FEFF.
- New milestone reaction integration block (previously had no
  `toggleMilestoneReaction` coverage at all) covers toggle on/off,
  64-char boundary, >64 rejection, ZWJ family, control char rejection,
  unauthenticated rejection, malformed UUID rejection, and the same
  parallel-toggle race.

## Phase 1 follow-ups (intentionally NOT in this PR)

Surfaced during multi-agent review and tracked as separate issues so
this PR can stay scoped to the emoji expansion. Each Phase 1 item
must land before SNS expansion exposes child / non-family viewers
to these resolvers:

- #393 — `Post.reactionCounts` lacks `isAuthorVisibleToViewer` (Phase 0
  is family-public-only so the gap is dormant; SNS turns it into a
  micro-enumeration oracle).
- #394 — `toggleMilestoneReaction` 8-cap COUNT-then-INSERT still
  races; ON CONFLICT closes only the same-emoji-twice subrace.
  SELECT FOR UPDATE conversion is the documented pattern.
- #395 — `reactions` (post-level) has no per-user cap, only
  `milestone_reactions` does. Asymmetric and exploitable once the
  picker exposes the full Unicode set to non-family users.
- #396 — Pre-existing N+1 on `Post.reactions` / `ReactionType.user` /
  `ReactionType.post` (predates this PR; surfaced by review).

## Verification

- `cd backend && pnpm test` — 660 pass + 1 skipped (33 files)
- `cd backend && pnpm lint` — clean
- `cd backend && pnpm format:check` — clean
- `cd frontend && dart analyze lib/` — clean
- `cd frontend && dart format --set-exit-if-changed` — stable (0 changed)
- `cd frontend && flutter test --platform chrome` — 349 pass

## Migration safety

`varchar(10) → varchar(64)` widens an existing column without
rewriting rows or rebuilding the unique index — every existing value
fits trivially into the new bound. No `USING` clause needed. The two
new single-column indexes use plain `CREATE INDEX` (not
`CONCURRENTLY`); both tables are small enough at Phase 0 launch
(~10² rows) that the brief ACCESS EXCLUSIVE lock is acceptable. Will
be re-evaluated as `CREATE INDEX CONCURRENTLY` before Phase 1 SNS
expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)