### PR TITLE
fix(reactions): show "your reactions" chip strip inside the picker sheet

### DIFF
--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -664,5 +664,9 @@
   "@reactWith": {
     "description": "Semantics label for each individual quick-pick emoji button in the post detail view (the inline 3 + ‘+’ row). Read by screen readers as e.g. 'React with party-popper'.",
     "placeholders": { "emoji": { "type": "String" } }
+  },
+  "yourReactions": "Your reactions",
+  "@yourReactions": {
+    "description": "Section label inside the emoji picker bottom sheet, above a chip row that shows the emojis the current viewer has already reacted with on this post. Tapping a chip removes that reaction. Lets users see what they've already selected so the picker feels persistent rather than fire-and-forget."
   }
 }

--- a/frontend/lib/l10n/app_ja.arb
+++ b/frontend/lib/l10n/app_ja.arb
@@ -453,5 +453,6 @@
   "search": "検索",
   "reactionPickerTitle": "リアクションを追加",
   "reactionPickerHint": "絵文字をタップで追加・解除",
-  "reactWith": "{emoji} でリアクション"
+  "reactWith": "{emoji} でリアクション",
+  "yourReactions": "あなたのリアクション"
 }

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -2509,6 +2509,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'React with {emoji}'**
   String reactWith(String emoji);
+
+  /// Section label inside the emoji picker bottom sheet, above a chip row that shows the emojis the current viewer has already reacted with on this post. Tapping a chip removes that reaction. Lets users see what they've already selected so the picker feels persistent rather than fire-and-forget.
+  ///
+  /// In en, this message translates to:
+  /// **'Your reactions'**
+  String get yourReactions;
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -1360,4 +1360,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String reactWith(String emoji) {
     return 'React with $emoji';
   }
+
+  @override
+  String get yourReactions => 'Your reactions';
 }

--- a/frontend/lib/l10n/app_localizations_ja.dart
+++ b/frontend/lib/l10n/app_localizations_ja.dart
@@ -1317,4 +1317,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String reactWith(String emoji) {
     return '$emoji でリアクション';
   }
+
+  @override
+  String get yourReactions => 'あなたのリアクション';
 }

--- a/frontend/lib/widgets/timeline/post_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/post_detail_sheet.dart
@@ -955,55 +955,126 @@ class _PostDetailContentState extends State<PostDetailContent> {
           minChildSize: 0.4,
           maxChildSize: 0.92,
           builder: (sheetInnerContext, scrollController) {
-            return Container(
-              decoration: const BoxDecoration(
-                color: colorSurface1,
-                borderRadius: BorderRadius.vertical(
-                  top: Radius.circular(radiusSheet),
-                ),
-              ),
-              child: Column(
-                children: [
-                  const SizedBox(height: spaceSm),
-                  Container(
-                    width: 40,
-                    height: 4,
-                    decoration: BoxDecoration(
-                      color: colorBorder,
-                      borderRadius: BorderRadius.circular(radiusFull),
+            // The picker library does not expose a "this emoji is
+            // already toggled on" highlight, and the modal route's
+            // own Element subtree is independent of the parent
+            // PostDetailContent State — so without an explicit
+            // `setSheetState` the chip strip below would never
+            // re-render after a toggle. StatefulBuilder gives us a
+            // local setState scoped to the sheet contents.
+            return StatefulBuilder(
+              builder: (statefulCtx, setSheetState) {
+                return Container(
+                  decoration: const BoxDecoration(
+                    color: colorSurface1,
+                    borderRadius: BorderRadius.vertical(
+                      top: Radius.circular(radiusSheet),
                     ),
                   ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: spaceLg,
-                      vertical: spaceMd,
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(l10n.reactionPickerTitle, style: textHeading),
-                        const SizedBox(height: spaceXxs),
-                        Text(l10n.reactionPickerHint, style: textCaption),
-                      ],
-                    ),
+                  child: Column(
+                    children: [
+                      const SizedBox(height: spaceSm),
+                      Container(
+                        width: 40,
+                        height: 4,
+                        decoration: BoxDecoration(
+                          color: colorBorder,
+                          borderRadius: BorderRadius.circular(radiusFull),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: spaceLg,
+                          vertical: spaceMd,
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(l10n.reactionPickerTitle, style: textHeading),
+                            const SizedBox(height: spaceXxs),
+                            Text(l10n.reactionPickerHint, style: textCaption),
+                            if (_myReactions.isNotEmpty) ...[
+                              const SizedBox(height: spaceMd),
+                              Text(l10n.yourReactions, style: textLabel),
+                              const SizedBox(height: spaceXs),
+                              _buildSheetActiveReactionsRow(setSheetState),
+                            ],
+                          ],
+                        ),
+                      ),
+                      Expanded(
+                        child: EmojiPicker(
+                          scrollController: scrollController,
+                          onEmojiSelected: (_, emoji) async {
+                            // Don't close the sheet — the user toggles
+                            // multiple emojis and dismisses themselves.
+                            // Await so the sheet's chip strip re-renders
+                            // only after the parent state has been
+                            // mutated (or rolled back).
+                            await _toggleReaction(emoji.emoji);
+                            if (statefulCtx.mounted) setSheetState(() {});
+                          },
+                          config: pickerConfig,
+                        ),
+                      ),
+                    ],
                   ),
-                  Expanded(
-                    child: EmojiPicker(
-                      scrollController: scrollController,
-                      onEmojiSelected: (_, emoji) {
-                        // Don't close the sheet — the user toggles
-                        // multiple emojis and dismisses themselves.
-                        _toggleReaction(emoji.emoji);
-                      },
-                      config: pickerConfig,
-                    ),
-                  ),
-                ],
-              ),
+                );
+              },
             );
           },
         );
       },
+    );
+  }
+
+  /// "Your reactions" chip strip rendered above the EmojiPicker grid
+  /// inside [_openEmojiPicker]'s sheet. Each chip is a `[emoji ×]`
+  /// affordance that toggles the reaction off when tapped. The strip
+  /// is what makes a tap on the picker grid feel persistent: as soon
+  /// as a new emoji is added it shows up here, and tapping it again
+  /// removes it. Receives the sheet's local `setSheetState` so the
+  /// strip can re-render after the parent State mutates `_myReactions`.
+  Widget _buildSheetActiveReactionsRow(StateSetter setSheetState) {
+    return Wrap(
+      spacing: spaceXs,
+      runSpacing: spaceXs,
+      children: _myReactions.map((emoji) {
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: _isToggling
+              ? null
+              : () async {
+                  await _toggleReaction(emoji);
+                  if (mounted) setSheetState(() {});
+                },
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: spaceSm,
+              vertical: 5,
+            ),
+            decoration: BoxDecoration(
+              color: colorAccentGold.withValues(alpha: opacitySubtle),
+              borderRadius: BorderRadius.circular(radiusXl),
+              border: Border.all(
+                color: colorAccentGold.withValues(alpha: opacityBorder),
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(emoji, style: const TextStyle(fontSize: fontSizeLg)),
+                const SizedBox(width: spaceXs),
+                const Icon(
+                  Icons.close,
+                  size: fontSizeSm,
+                  color: colorInteractiveMuted,
+                ),
+              ],
+            ),
+          ),
+        );
+      }).toList(),
     );
   }
 


### PR DESCRIPTION
Fixes the "tap feels invisible" feedback gap inside the full-Unicode
picker sheet that #397 introduced.

## Problem

`emoji_picker_flutter` does not expose a per-emoji "this is already
toggled on" highlight, and the modal route renders inside a detached
`Element` subtree that does not rebuild when the parent
`PostDetailContent` State mutates `_myReactions`. The previous wiring:

1. User taps an emoji in the picker grid.
2. `onEmojiSelected` calls `_toggleReaction`, which mutates the
   parent `_myReactions` / `_reactionCounts` and updates the count
   badge BEHIND the sheet.
3. The sheet itself never re-renders, so the user sees nothing
   change inside the picker.

User feedback: "selection state disappears immediately after I tap
— it doesn't feel like I selected anything".

## Fix

Add a "Your reactions" chip strip directly above the picker grid:

- Wrap the sheet body in a `StatefulBuilder` so we can re-render
  the strip after each toggle without rebuilding the whole post
  detail tree.
- The strip lists `_myReactions` as `[emoji ×]` chips. Tapping a
  chip toggles that reaction off; the chip disappears immediately
  on completion. New emojis from the picker grid appear here on
  the next frame so the user has a persistent record of every
  selection.
- `onEmojiSelected` now `await`s `_toggleReaction` and calls
  `setSheetState` only after the parent state has been mutated
  (or rolled back on mutation failure). The chip strip therefore
  stays in lockstep with the count badge under the sheet.
- The strip is hidden when the viewer has no active reactions —
  no need to show an empty state right after opening the picker.

Style follows the existing reaction pill row (gold accent border /
fill at low opacity, `radiusXl` pill shape).

## i18n

- Adds `yourReactions` ARB key in en / ja with `@key` description.

## Scope

Frontend only. No backend changes, no schema changes, no auth
changes. Touches one widget file (`post_detail_sheet.dart`) and
the four l10n files. Eligible for review skip under
"ローンチ圧モードの規律" but small enough that a quick visual
verification (open a post → tap two emojis in the picker → see
both chips appear / tap a chip → chip disappears immediately) is
the most useful check.

## Verification

- `cd frontend && dart analyze lib/` — clean
- `cd frontend && dart format --set-exit-if-changed` — stable
- `cd frontend && flutter test --platform chrome` — 349 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)