### PR TITLE
fix(milestone): show milestone detail sheet on public timeline

### DIFF
--- a/frontend/lib/widgets/timeline/milestone_detail_sheet.dart
+++ b/frontend/lib/widgets/timeline/milestone_detail_sheet.dart
@@ -11,8 +11,19 @@ import '../../utils/month_names.dart';
 const _reactionPresets = ['🔥', '❤️', '👏', '✨', '😍', '🎵', '💪', '🎸'];
 
 /// Show the milestone detail bottom sheet.
-/// The sheet watches [timelineProvider] for live reaction state —
-/// no local state duplication.
+///
+/// Pass the milestone object directly so the sheet has a usable source of
+/// truth even on the public timeline (`/@username`), where the data lives in
+/// `publicTimelineProvider` rather than `timelineProvider`. When
+/// `onToggleReaction` is non-null (authenticated path), the sheet additionally
+/// watches `timelineProvider` for live reaction count / `myReactions` updates
+/// after a toggle. Unauthenticated viewers don't toggle, so the snapshot
+/// passed in is sufficient and we skip the provider watch entirely.
+///
+/// Previously the sheet looked up the milestone by id in `timelineProvider`,
+/// which is unloaded on `/@username`, so the build returned
+/// `SizedBox.shrink()` and the modal appeared to "not open" for unauthenticated
+/// viewers.
 void showMilestoneDetailSheet(
   BuildContext context,
   ArtistMilestone milestone, {
@@ -23,33 +34,37 @@ void showMilestoneDetailSheet(
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
     builder: (_) => _MilestoneDetailSheet(
-      milestoneId: milestone.id,
+      initialMilestone: milestone,
       onToggleReaction: onToggleReaction,
     ),
   );
 }
 
 class _MilestoneDetailSheet extends ConsumerWidget {
-  final String milestoneId;
+  final ArtistMilestone initialMilestone;
   final Future<bool?> Function(String milestoneId, String emoji)?
   onToggleReaction;
 
   const _MilestoneDetailSheet({
-    required this.milestoneId,
+    required this.initialMilestone,
     this.onToggleReaction,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Watch provider for live updates — single source of truth
-    final artist = ref.watch(timelineProvider).artist;
-    final milestone = artist?.milestones
-        .where((m) => m.id == milestoneId)
-        .firstOrNull;
-
-    if (milestone == null) {
-      return const SizedBox.shrink();
-    }
+    // The passed `initialMilestone` is the source of truth. We always
+    // `ref.watch(timelineProvider)` (Riverpod's rule against conditional
+    // watches) and only consult its data on the authenticated path —
+    // unauthenticated viewers run against `publicTimelineProvider` so the
+    // `timelineProvider.artist` they read is always null and the live data
+    // path harmlessly no-ops.
+    final timelineArtist = ref.watch(timelineProvider).artist;
+    final fresh = onToggleReaction != null
+        ? timelineArtist?.milestones
+              .where((m) => m.id == initialMilestone.id)
+              .firstOrNull
+        : null;
+    final milestone = fresh ?? initialMilestone;
 
     final reactionCounts = milestone.reactionCounts;
     final myReactions = milestone.myReactions.toSet();
@@ -184,7 +199,7 @@ class _MilestoneDetailSheet extends ConsumerWidget {
                           final isOwn = myReactions.contains(r.emoji);
                           return GestureDetector(
                             onTap: () =>
-                                onToggleReaction!(milestoneId, r.emoji),
+                                onToggleReaction!(milestone.id, r.emoji),
                             child: _ReactionPill(
                               emoji: r.emoji,
                               count: r.count,
@@ -202,7 +217,7 @@ class _MilestoneDetailSheet extends ConsumerWidget {
                       children: _reactionPresets.map((emoji) {
                         final isOwn = myReactions.contains(emoji);
                         return GestureDetector(
-                          onTap: () => onToggleReaction!(milestoneId, emoji),
+                          onTap: () => onToggleReaction!(milestone.id, emoji),
                           child: Container(
                             width: 36,
                             height: 36,

--- a/frontend/test/widgets/timeline/milestone_detail_sheet_test.dart
+++ b/frontend/test/widgets/timeline/milestone_detail_sheet_test.dart
@@ -1,0 +1,105 @@
+// Regression test for the public-timeline milestone sheet.
+//
+// Symptom: tapping a milestone diamond on `/@username` (unauthenticated)
+// appeared to do nothing — the modal route opened but the builder rendered
+// `SizedBox.shrink()` because the sheet looked the milestone up via
+// `timelineProvider`, which is unloaded for unauthenticated viewers (their
+// data lives in `publicTimelineProvider`).
+//
+// Fix: the sheet now uses the milestone object passed into
+// `showMilestoneDetailSheet` as its source of truth, and only watches
+// `timelineProvider` for live reaction updates when the caller supplies
+// `onToggleReaction` (authenticated path). The unauthenticated path therefore
+// no longer depends on provider state at all.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gleisner_web/l10n/app_localizations.dart';
+import 'package:gleisner_web/models/artist.dart';
+import 'package:gleisner_web/widgets/timeline/milestone_detail_sheet.dart';
+
+ArtistMilestone _milestone({
+  String id = 'm1',
+  String title = 'First gig at the Tiny Stage',
+  String? description = 'Played to ~30 people. Felt every note.',
+}) {
+  return ArtistMilestone(
+    id: id,
+    category: 'performance',
+    title: title,
+    description: description,
+    date: '2025-08-14',
+    position: 0,
+  );
+}
+
+Widget _hostApp({required VoidCallback onTap}) {
+  return ProviderScope(
+    child: MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (ctx) => Center(
+            child: ElevatedButton(onPressed: onTap, child: const Text('open')),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('showMilestoneDetailSheet (public / unauthenticated path)', () {
+    testWidgets(
+      'renders milestone content even when timelineProvider has no artist',
+      (tester) async {
+        final milestone = _milestone();
+        late BuildContext capturedCtx;
+
+        await tester.pumpWidget(
+          _hostApp(
+            onTap: () {
+              // Public path — caller does NOT supply `onToggleReaction`.
+              showMilestoneDetailSheet(capturedCtx, milestone);
+            },
+          ),
+        );
+        // Capture a context that is below MaterialApp / Localizations so the
+        // sheet's `context.l10n` lookup succeeds.
+        capturedCtx = tester.element(find.byType(ElevatedButton));
+
+        await tester.tap(find.byType(ElevatedButton));
+        await tester.pumpAndSettle();
+
+        // The pre-fix bug rendered SizedBox.shrink() here. We assert the
+        // milestone title and description (the "did the sheet actually open"
+        // signals) are visible.
+        expect(find.text(milestone.title), findsOneWidget);
+        expect(find.text(milestone.description!), findsOneWidget);
+        // Reaction UI is gated on `onToggleReaction != null`; on the public
+        // path it must stay hidden.
+        expect(find.text('🔥'), findsNothing);
+      },
+    );
+
+    testWidgets('renders milestone with no description without crashing', (
+      tester,
+    ) async {
+      final milestone = _milestone(description: null);
+      late BuildContext capturedCtx;
+
+      await tester.pumpWidget(
+        _hostApp(onTap: () => showMilestoneDetailSheet(capturedCtx, milestone)),
+      );
+      capturedCtx = tester.element(find.byType(ElevatedButton));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(milestone.title), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Bug report: tapping a milestone diamond on `/@username` (unauthenticated
public timeline) did nothing visible. Reproduced on iPhone Safari, but
the bug is platform-independent — every milestone on every public
timeline was affected, despite the user describing it as "the bottom-most
one." Confirmed by user testing that "他のmilestoneも開かない".

## Root cause

`_MilestoneDetailSheet` was watching `timelineProvider` (the
authenticated timeline notifier) and looking the milestone up by id:

```dart
final artist = ref.watch(timelineProvider).artist;
final milestone = artist?.milestones.where((m) => m.id == milestoneId).firstOrNull;
if (milestone == null) return const SizedBox.shrink();
```

On `/@username` the data lives in `publicTimelineProvider`, so
`timelineProvider.artist` is always null for unauthenticated viewers and
`firstOrNull` always returns null. The modal route opened, but the
builder returned `SizedBox.shrink()` — 0×0 content under a transparent
modal background. From the user's perspective, the tap "did nothing."

## Fix

Pass the milestone object straight into the sheet and treat it as the
source of truth. On the authenticated path (`onToggleReaction != null`)
the sheet additionally watches `timelineProvider` for live reaction
updates after a toggle, and falls back to the passed milestone when the
provider has nothing fresh.

The `ref.watch(timelineProvider)` call itself is unconditional — Riverpod
warns against placing `ref.watch` behind a runtime branch, and on the
public path the watched state is always the default `TimelineState()` so
it's a harmless no-op anyway.

## Verification

- [x] `dart analyze lib/` — clean
- [x] `dart format` — no diff
- [x] `flutter test --platform chrome` — 2 new + 60 existing timeline / constellation tests pass
- [x] Multi-agent review (security + flutter-ui) → synthesis: マージ可、Critical/Important なし
- [ ] Manual smoke (user): `/@<some-artist>` unauthenticated → tap a milestone → detail sheet opens with title + description visible

### New tests (`test/widgets/timeline/milestone_detail_sheet_test.dart`)

- `renders milestone content even when timelineProvider has no artist` — the regression case
- `renders milestone with no description without crashing` — boundary case for description-less milestones

## Out of scope (deferred)

These were flagged by review but are not part of this bug fix:

- **per-user reaction cap race / `reactionCounts` author visibility / N+1**
  on milestones — tracked in Phase 1 hardening Issues #393–#396.
- **Optimistic-rebuild boundary polish** flagged at confidence < 80 by
  the Flutter UI reviewer; existing optimistic-update pattern handles it.
- **The `_MilestoneDetailSheet` reaction UI itself** — the bug only
  affected the unauthenticated path, where reactions are gated off
  (`onToggleReaction == null`) anyway. Authenticated path is unchanged.

## Notes

- Single file changed in `lib/`. Constructor of the private
  `_MilestoneDetailSheet` widget changes, but `showMilestoneDetailSheet`
  (the public entry point) keeps the same signature, so no callers need
  updating.
- The sheet's parent now holds the source of truth for the milestone
  object, which matches how `MilestoneNodeCard` already passes it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)