### PR TITLE
fix(timeline): close detail sheets on artist switch

### DIFF
--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -97,7 +97,10 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
     // Listen for pending artist (set by Artist Page after Tune In)
     // Using ref.listenManual avoids the multi-fire issue of ref.watch in build()
     ref.listenManual(pendingArtistProvider, (prev, next) {
-      if (next != null) {
+      // Guard against late listener fires after dispose. `_switchToArtist`
+      // now calls `Navigator.of(context).popUntil`; without this guard the
+      // call would land on a disposed `context`.
+      if (next != null && mounted) {
         ref.read(pendingArtistProvider.notifier).clear();
         ref.read(tuneInProvider.notifier).loadMyTuneIns();
         _switchToArtist(next);
@@ -152,6 +155,25 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
   }
 
   void _switchToArtist(String artistUsername) {
+    // Tear down any modal sheets/dialogs anchored on the previous artist's
+    // data before swapping `timelineProvider`. Without this, an open
+    // PostDetailSheet / MilestoneDetailSheet survives the switch, can no
+    // longer find its post in the new timeline, and renders an empty
+    // (visually black) modal that the user must close manually.
+    //
+    // `PopupRoute` is the common ancestor of `ModalBottomSheetRoute`,
+    // `DialogRoute`, and the menu routes used by `PopupMenuButton` /
+    // `DropdownButton`, so this clears all of them. The underlying
+    // TimelineScreen route is a `PageRoute`, so `popUntil` stops immediately
+    // when no modals are open.
+    //
+    // We use `Navigator.of(context)` (not `rootNavigator: true`) on purpose:
+    // every detail sheet / dialog spawned from this screen is opened with
+    // this same `context`, which resolves to the StatefulShellBranch's
+    // child Navigator. Targeting the root navigator would overshoot into
+    // GoRouter's own routes.
+    Navigator.of(context).popUntil((route) => route is! PopupRoute);
+
     if (_ownArtistUsername != null && artistUsername == _ownArtistUsername) {
       // Switch to own timeline (Artist Mode)
       _viewingArtistUsername = null;
@@ -299,6 +321,16 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                       onTap: () async {
                         final artistId = timeline.artist?.id;
                         if (artistId == null) return;
+                        // 0. Close any modal sheets/dialogs anchored on the
+                        //    current artist *before* awaiting the mutation,
+                        //    so the user can't fire a reaction toggle (or
+                        //    similar) against the soon-to-be-stale postId
+                        //    during the in-flight `toggleTuneIn`. The
+                        //    `popUntil` inside `_switchToArtist` below is a
+                        //    redundant safety net for non-Tune-Out paths.
+                        Navigator.of(
+                          context,
+                        ).popUntil((route) => route is! PopupRoute);
                         // 1. Tune out
                         await ref
                             .read(tuneInProvider.notifier)


### PR DESCRIPTION
## バグ

アーティストAのタイムラインで詳細シートを開いたまま、アバターレイルからアーティストBに切り替えると、Aの詳細シートが開いたまま残る（中身は真っ黒）。通常通り閉じることは可能。タブレットで再現。

## 根本原因

`_switchToArtist()` (timeline_screen.dart) は `setState` + `loadArtist` のみで、**開いている modal route を片付けていなかった**。Navigator stack 上に残ったシートは:

1. `timelineProvider` のデータがアーティストBに置き換わる
2. シート内の `widget.allPosts.firstWhere((p) => p.id == widget.post.id)` 等が miss
3. `SizedBox.shrink()` フォールバック → 透明な `DraggableScrollableSheet` 越しにダーク背景が透けて「真っ黒」に見える

## 修正

`_switchToArtist()` 冒頭に `Navigator.of(context).popUntil((r) => r is! PopupRoute)` を追加。`PopupRoute` は `ModalBottomSheetRoute` / `DialogRoute` / popup menu / dropdown menu の共通祖先なのでまとめて除去できる。`PageRoute` の TimelineScreen 自体には触らない。`Navigator.of(context)` は StatefulShellBranch の子 Navigator を指し、シート開閉と同一スコープ（`rootNavigator: true` を使わない理由はコメントに明記）。

呼び出し元 4 経路全てに同じ保護がかかる:
- avatar rail tap
- `pendingArtistProvider` listener
- Tune Out flow（こちらは race 対策で `await toggleTuneIn` 前に**前倒し**で `popUntil` を呼ぶ）
- 初回 fan default

## マルチエージェントレビュー指摘の反映

`security-reviewer` + `flutter-ui-reviewer` 並列実行 → `synthesis-reviewer` 集約。Important 3 件を本 PR 内で対応:

1. **Tune Out flow の async ギャップ**: `await toggleTuneIn` 中にユーザーが旧 postId で reaction を発火できるウィンドウを潰すため、Tune Out onTap 冒頭で `popUntil` を呼ぶ
2. **`pendingArtistProvider` listener の `mounted` ガード**: dispose 後発火で `Navigator.of(context).popUntil` が disposed context を参照しないように
3. **コメント強化**: `rootNavigator: true` を使わない理由 + `PopupRoute` の包括範囲を明記

`_addConnection` の pre-existing mutation race と regression test は別 Issue / fast-follow（synthesis 判定）。

## 検証

- `dart analyze lib/`: No issues found
- `dart format --set-exit-if-changed .`: clean (155 files unchanged)
- `flutter test --platform chrome`: All 351 tests passed

## 動作確認のお願い

タブレットで:
1. アーティスト A のタイムラインで適当な投稿の詳細シートを開く
2. アバターレイルから別のアーティスト B をタップ
3. → 詳細シートが自動で閉じ、B のタイムラインが正常に表示されることを確認

マイルストーン詳細シートでも同様の挙動になるはず。

## 次の段取り

- 本 PR レビュー → マージ後、yatima 側の submodule bump をお願いします
- fast-follow 候補（別 Issue 起票するか相談）:
  - `_addConnection` の mutation race（pre-existing）
  - `TimelineScreen` の widget/integration 回帰テスト（StatefulShellRoute セットアップコスト高）

🤖 Generated with [Claude Code](https://claude.com/claude-code)