### PR TITLE
fix(timeline): serialize eventAt in UTC to preserve absolute time

### DIFF
--- a/backend/drizzle/0017_eventat_jst_backfill.sql
+++ b/backend/drizzle/0017_eventat_jst_backfill.sql
@@ -38,6 +38,20 @@
 --   migration before applying — do not apply the migration with a
 --   cutoff that's already in the past relative to live posts on the
 --   buggy code path.
+-- Runtime safety net: refuse to run if the cutoff is already in the past
+-- relative to the migration apply time. This forces an explicit bump of
+-- the cutoff (and a regenerated migration) rather than silently shifting
+-- post-deploy rows that are already on the corrected code path.
+DO $$
+BEGIN
+  IF '2026-05-10T12:00:00Z'::timestamptz <= now() THEN
+    RAISE EXCEPTION
+      'Backfill 0017 aborted: cutoff 2026-05-10T12:00:00Z is no longer in the future (now = %). '
+      'Bump the cutoff in this migration to a time after the deploy and regenerate before applying.',
+      now();
+  END IF;
+END $$;
+--> statement-breakpoint
 UPDATE "posts"
 SET "event_at" = "event_at" - INTERVAL '9 hours'
 WHERE "event_at" IS NOT NULL

--- a/backend/drizzle/0017_eventat_jst_backfill.sql
+++ b/backend/drizzle/0017_eventat_jst_backfill.sql
@@ -21,10 +21,24 @@
 --   would no longer hold — but by then the buggy code path is gone, so
 --   no further backfills are needed.
 --
--- Idempotency:
---   This is a one-shot data fix. Running it twice would double-shift the
---   data. The migration runner records this as applied in
---   drizzle.__drizzle_migrations, so it will not re-run on the same DB.
+-- Idempotency / scope-limiting:
+--   The Drizzle migration runner records this as applied in
+--   drizzle.__drizzle_migrations and won't re-run it on the same DB.
+--   But that table is per-DB; clones, restored backups, or environments
+--   that run the migration after the frontend fix has already shipped
+--   could in principle re-execute it. To make the SQL itself idempotent
+--   we also gate on `created_at < '<frontend-fix cutoff>'` — rows newer
+--   than the cutoff were written by the corrected (toUtc()) code path
+--   and must NOT be shifted, regardless of how many times this runs.
+--
+--   Cutoff: 2026-05-10T12:00:00Z (= 21:00 JST on the day of the fix).
+--   The PR is intended to deploy before that local-evening cutoff;
+--   anything created after is on the corrected path. If the deploy
+--   slips past 21:00 JST, push the cutoff forward and regenerate the
+--   migration before applying — do not apply the migration with a
+--   cutoff that's already in the past relative to live posts on the
+--   buggy code path.
 UPDATE "posts"
 SET "event_at" = "event_at" - INTERVAL '9 hours'
-WHERE "event_at" IS NOT NULL;
+WHERE "event_at" IS NOT NULL
+  AND "created_at" < '2026-05-10T12:00:00Z';

--- a/backend/drizzle/0017_eventat_jst_backfill.sql
+++ b/backend/drizzle/0017_eventat_jst_backfill.sql
@@ -1,0 +1,30 @@
+-- Backfill posts.event_at to correct the JST-as-UTC bug.
+--
+-- Background:
+--   The Flutter `EventAtPicker` returns a local DateTime (no timezone offset),
+--   and the create/edit paths used to call `toIso8601String()` on it directly,
+--   producing a naive ISO string like "2026-05-10T13:45:00.000". The backend
+--   parsed this with `new Date(...)`, which on a UTC server treats it as UTC,
+--   so a user inputting "13:45 JST" got stored as "13:45 UTC" (= 22:45 JST).
+--
+--   The frontend fix (toUtc().toIso8601String()) lands in the same release.
+--   This migration shifts existing event_at values that were captured under
+--   the buggy code path back to the user-intended absolute time.
+--
+-- Scope assumption:
+--   Phase 0 launched 2026-05-06 as a family lifelog with all current users
+--   in Asia/Tokyo (+09:00). Every event_at row currently in the DB was
+--   written by the buggy path, so a uniform `-9 hours` shift restores the
+--   intended absolute time for every existing row.
+--
+--   If/when Phase 1 onboards users in other timezones, this assumption
+--   would no longer hold — but by then the buggy code path is gone, so
+--   no further backfills are needed.
+--
+-- Idempotency:
+--   This is a one-shot data fix. Running it twice would double-shift the
+--   data. The migration runner records this as applied in
+--   drizzle.__drizzle_migrations, so it will not re-run on the same DB.
+UPDATE "posts"
+SET "event_at" = "event_at" - INTERVAL '9 hours'
+WHERE "event_at" IS NOT NULL;

--- a/backend/drizzle/meta/0017_snapshot.json
+++ b/backend/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1997 @@
+{
+  "id": "93fade9d-3c5c-409a-88ca-044ff5e341aa",
+  "prevId": "54ffa868-0826-42e0-a5bf-0af706057822",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analytics_events": {
+      "name": "analytics_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analytics_event_type_created_idx": {
+          "name": "analytics_event_type_created_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_event_user_id_idx": {
+          "name": "analytics_event_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_event_session_id_idx": {
+          "name": "analytics_event_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_genres": {
+      "name": "artist_genres",
+      "schema": "",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_genres_artist_id_artists_id_fk": {
+          "name": "artist_genres_artist_id_artists_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_genres_genre_id_genres_id_fk": {
+          "name": "artist_genres_genre_id_genres_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_genres_artist_id_genre_id_pk": {
+          "name": "artist_genres_artist_id_genre_id_pk",
+          "columns": [
+            "artist_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_links": {
+      "name": "artist_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_category": {
+          "name": "link_category",
+          "type": "link_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_links_artist_id_artists_id_fk": {
+          "name": "artist_links_artist_id_artists_id_fk",
+          "tableFrom": "artist_links",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_milestones": {
+      "name": "artist_milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "milestone_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artist_milestones_artist_id_idx": {
+          "name": "artist_milestones_artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_milestones_artist_id_artists_id_fk": {
+          "name": "artist_milestones_artist_id_artists_id_fk",
+          "tableFrom": "artist_milestones",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_username": {
+          "name": "artist_username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_since": {
+          "name": "active_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tuned_in_count": {
+          "name": "tuned_in_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artists_featured_visibility_idx": {
+          "name": "artists_featured_visibility_idx",
+          "columns": [
+            {
+              "expression": "is_featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artists_user_id_users_id_fk": {
+          "name": "artists_user_id_users_id_fk",
+          "tableFrom": "artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artists_user_id_unique": {
+          "name": "artists_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "artists_artist_username_unique": {
+          "name": "artists_artist_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_post_id_posts_id_fk": {
+          "name": "comments_post_id_posts_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "connection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_connection": {
+          "name": "unique_connection",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_source_id_posts_id_fk": {
+          "name": "connections_source_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_target_id_posts_id_fk": {
+          "name": "connections_target_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_neq_target": {
+          "name": "source_neq_target",
+          "value": "\"connections\".\"source_id\" != \"connections\".\"target_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.constellations": {
+      "name": "constellations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_post_id": {
+          "name": "anchor_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "constellations_artist_id_artists_id_fk": {
+          "name": "constellations_artist_id_artists_id_fk",
+          "tableFrom": "constellations",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "constellations_anchor_post_id_posts_id_fk": {
+          "name": "constellations_anchor_post_id_posts_id_fk",
+          "tableFrom": "constellations",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "anchor_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "constellations_anchor_post_id_unique": {
+          "name": "constellations_anchor_post_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anchor_post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "name": "follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "follower_neq_following": {
+          "name": "follower_neq_following",
+          "value": "\"follows\".\"follower_id\" != \"follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_promoted": {
+          "name": "is_promoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "genres_normalized_name_unique": {
+          "name": "genres_normalized_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "normalized_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_users_id_fk": {
+          "name": "invites_created_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_used_by_users_id_fk": {
+          "name": "invites_used_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_reactions": {
+      "name": "milestone_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "milestone_reactions_milestone_id_idx": {
+          "name": "milestone_reactions_milestone_id_idx",
+          "columns": [
+            {
+              "expression": "milestone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "milestone_reactions_milestone_id_artist_milestones_id_fk": {
+          "name": "milestone_reactions_milestone_id_artist_milestones_id_fk",
+          "tableFrom": "milestone_reactions",
+          "tableTo": "artist_milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_reactions_user_id_users_id_fk": {
+          "name": "milestone_reactions_user_id_users_id_fk",
+          "tableFrom": "milestone_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_reactions_milestone_id_user_id_emoji_unique": {
+          "name": "milestone_reactions_milestone_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_media": {
+      "name": "post_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_media_post_id_position_idx": {
+          "name": "post_media_post_id_position_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_media_post_id_posts_id_fk": {
+          "name": "post_media_post_id_posts_id_fk",
+          "tableFrom": "post_media",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_format": {
+          "name": "body_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'plain'"
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importance": {
+          "name": "importance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_fetched_at": {
+          "name": "og_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_genre": {
+          "name": "article_genre",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_publish": {
+          "name": "external_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_x": {
+          "name": "layout_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "layout_y": {
+          "name": "layout_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_author_og_fetched_idx": {
+          "name": "posts_author_og_fetched_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "og_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_author_media_url_idx": {
+          "name": "posts_author_media_url_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_media_url_og_fetched_idx": {
+          "name": "posts_media_url_og_fetched_idx",
+          "columns": [
+            {
+              "expression": "media_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "og_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_author_visibility_updated_idx": {
+          "name": "posts_author_visibility_updated_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_track_id_tracks_id_fk": {
+          "name": "posts_track_id_tracks_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_post_id_idx": {
+          "name": "reactions_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_post_id_posts_id_fk": {
+          "name": "reactions_post_id_posts_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_user_id_users_id_fk": {
+          "name": "reactions_user_id_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_post_id_user_id_emoji_unique": {
+          "name": "reactions_post_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracks": {
+      "name": "tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_artist_track_name": {
+          "name": "unique_artist_track_name",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracks_artist_id_artists_id_fk": {
+          "name": "tracks_artist_id_artists_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tune_ins": {
+      "name": "tune_ins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tune_ins_user_id_users_id_fk": {
+          "name": "tune_ins_user_id_users_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tune_ins_artist_id_artists_id_fk": {
+          "name": "tune_ins_artist_id_artists_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tune_ins_user_id_artist_id_pk": {
+          "name": "tune_ins_user_id_artist_id_pk",
+          "columns": [
+            "user_id",
+            "artist_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "did": {
+          "name": "did",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_salt": {
+          "name": "password_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_private_key": {
+          "name": "encrypted_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_salt": {
+          "name": "encryption_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_year_month": {
+          "name": "birth_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_id": {
+          "name": "guardian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_guardian_id_idx": {
+          "name": "users_guardian_id_idx",
+          "columns": [
+            {
+              "expression": "guardian_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_guardian_id_users_id_fk": {
+          "name": "users_guardian_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "guardian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_did_unique": {
+          "name": "users_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_type": {
+      "name": "connection_type",
+      "schema": "public",
+      "values": [
+        "reply",
+        "remix",
+        "reference",
+        "evolution"
+      ]
+    },
+    "public.link_category": {
+      "name": "link_category",
+      "schema": "public",
+      "values": [
+        "social",
+        "music",
+        "video",
+        "website",
+        "store",
+        "other"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "thought",
+        "article",
+        "image",
+        "video",
+        "audio",
+        "link"
+      ]
+    },
+    "public.milestone_category": {
+      "name": "milestone_category",
+      "schema": "public",
+      "values": [
+        "award",
+        "release",
+        "event",
+        "affiliation",
+        "education",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1778256543005,
       "tag": "0016_true_forgotten_one",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1778688000000,
+      "tag": "0017_eventat_jst_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/lib/providers/create_post_provider.dart
+++ b/frontend/lib/providers/create_post_provider.dart
@@ -183,7 +183,11 @@ class CreatePostNotifier extends Notifier<CreatePostState>
             'mediaUrls': ?mediaUrls,
             'thumbnailUrl': ?thumbnailUrl,
             'duration': ?duration,
-            if (eventAt != null) 'eventAt': eventAt.toIso8601String(),
+            // Always serialize as UTC. `EventAtPicker` returns a local DateTime;
+            // `toIso8601String()` on a local DateTime omits the timezone offset,
+            // which the backend would interpret as server-local (UTC on Railway)
+            // and store the wrong absolute time. See PR / Issue for details.
+            if (eventAt != null) 'eventAt': eventAt.toUtc().toIso8601String(),
             'importance': state.importance,
             'visibility': state.visibility,
             if (state.articleGenre != null)

--- a/frontend/lib/providers/timeline_provider.dart
+++ b/frontend/lib/providers/timeline_provider.dart
@@ -585,7 +585,7 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
     bool clearThumbnail = false,
     int? duration,
     bool clearDuration = false,
-    String? eventAt,
+    DateTime? eventAt,
     bool clearEventAt = false,
     double? importance,
     String? visibility,
@@ -634,7 +634,10 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
             if (clearThumbnail) 'thumbnailUrl': null,
             'duration': ?duration,
             if (clearDuration) 'duration': null,
-            'eventAt': ?eventAt,
+            // Centralize UTC serialization here so callers can hand us a
+            // local-zone DateTime (what `EventAtPicker.onChanged` emits)
+            // without worrying about offset stripping.
+            if (eventAt != null) 'eventAt': eventAt.toUtc().toIso8601String(),
             if (clearEventAt) 'eventAt': null,
             'importance': ?importance,
             'articleGenre': ?articleGenre,

--- a/frontend/lib/providers/timeline_provider.dart
+++ b/frontend/lib/providers/timeline_provider.dart
@@ -101,8 +101,10 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
   /// Do NOT call from production code paths. If you find yourself
   /// reaching for this outside `test/`, the right answer is usually a
   /// real action method on the Notifier (e.g. `addPost`, `loadArtist`).
-  /// Removable once Riverpod 3.x exposes a first-class
-  /// `ProviderContainer.overrideWithState` for `Notifier` subclasses.
+  /// Retire once Riverpod offers a first-class way to override a
+  /// `Notifier`'s state from `ProviderContainer.overrides` without
+  /// going through the public mutation API. (As of Riverpod 2.x there
+  /// is no such hook for `Notifier` subclasses.)
   @visibleForTesting
   void debugSetState(TimelineState newState) => state = newState;
 

--- a/frontend/lib/providers/timeline_provider.dart
+++ b/frontend/lib/providers/timeline_provider.dart
@@ -91,7 +91,18 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
     return const TimelineState();
   }
 
-  /// For testing only — set state directly.
+  /// Test-only state seed.
+  ///
+  /// Used by tests that need a Notifier with pre-populated `posts` /
+  /// `artist` etc. without round-tripping through `loadArtist` and the
+  /// graphql_flutter normalizing cache (which conflates fixtures that
+  /// share a Post id across query + mutation responses).
+  ///
+  /// Do NOT call from production code paths. If you find yourself
+  /// reaching for this outside `test/`, the right answer is usually a
+  /// real action method on the Notifier (e.g. `addPost`, `loadArtist`).
+  /// Removable once Riverpod 3.x exposes a first-class
+  /// `ProviderContainer.overrideWithState` for `Notifier` subclasses.
   @visibleForTesting
   void debugSetState(TimelineState newState) => state = newState;
 
@@ -653,6 +664,11 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
       if (data == null) return null;
 
       final updated = Post.fromJson(data);
+
+      // The mutation `await` may have been racing the user closing the
+      // edit sheet. If the Notifier got disposed in the meantime,
+      // writing to `state` throws `tried to use a disposed notifier`.
+      if (disposed) return updated;
 
       // Replace post in local state
       final posts = state.posts.map((p) {

--- a/frontend/lib/providers/unassigned_posts_provider.dart
+++ b/frontend/lib/providers/unassigned_posts_provider.dart
@@ -30,6 +30,9 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
     return const UnassignedPostsState();
   }
 
+  @visibleForTesting
+  void debugSetState(UnassignedPostsState newState) => state = newState;
+
   Future<void> load() async {
     state = const UnassignedPostsState(isLoading: true);
     try {
@@ -126,9 +129,19 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
       final data = result.data?['updatePost'] as Map<String, dynamic>?;
       if (data == null) return null;
       final updated = Post.fromJson(data);
-      // If reassigned to a track, remove from list
+      // If reassigned to a track, drop from the unassigned list. Otherwise
+      // splice the updated post back into state so callers (e.g. edit
+      // sheet on the unassigned list) immediately see the new eventAt /
+      // title / body without having to wait for the next load().
       if (updated.trackId != null) {
         removePost(updated.id);
+      } else {
+        state = UnassignedPostsState(
+          posts: state.posts
+              .map((p) => p.id == updated.id ? updated : p)
+              .toList(),
+          isLoading: state.isLoading,
+        );
       }
       return updated;
     } catch (e) {

--- a/frontend/lib/providers/unassigned_posts_provider.dart
+++ b/frontend/lib/providers/unassigned_posts_provider.dart
@@ -31,9 +31,11 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
   }
 
   /// Test-only state seed. See `TimelineNotifier.debugSetState` for the
-  /// rationale (avoiding graphql_flutter cache cross-talk between
+  /// full rationale: avoiding graphql_flutter cache cross-talk between
   /// `myUnassignedPosts` query fixtures and `updatePost` mutation
-  /// fixtures that share Post ids). Do NOT call from production paths.
+  /// fixtures that share Post ids, plus the retirement condition once
+  /// Riverpod offers a first-class state override for `Notifier`
+  /// subclasses. Do NOT call from production paths.
   @visibleForTesting
   void debugSetState(UnassignedPostsState newState) => state = newState;
 

--- a/frontend/lib/providers/unassigned_posts_provider.dart
+++ b/frontend/lib/providers/unassigned_posts_provider.dart
@@ -30,6 +30,10 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
     return const UnassignedPostsState();
   }
 
+  /// Test-only state seed. See `TimelineNotifier.debugSetState` for the
+  /// rationale (avoiding graphql_flutter cache cross-talk between
+  /// `myUnassignedPosts` query fixtures and `updatePost` mutation
+  /// fixtures that share Post ids). Do NOT call from production paths.
   @visibleForTesting
   void debugSetState(UnassignedPostsState newState) => state = newState;
 
@@ -129,6 +133,11 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
       final data = result.data?['updatePost'] as Map<String, dynamic>?;
       if (data == null) return null;
       final updated = Post.fromJson(data);
+      // The mutation `await` may have been racing the user closing the
+      // edit sheet. If the Notifier got disposed in the meantime,
+      // writing to `state` (or calling `removePost` which also writes
+      // state) would throw `tried to use a disposed notifier`.
+      if (disposed) return updated;
       // If reassigned to a track, drop from the unassigned list. Otherwise
       // splice the updated post back into state so callers (e.g. edit
       // sheet on the unassigned list) immediately see the new eventAt /

--- a/frontend/lib/providers/unassigned_posts_provider.dart
+++ b/frontend/lib/providers/unassigned_posts_provider.dart
@@ -67,7 +67,7 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
     bool clearThumbnail = false,
     int? duration,
     bool clearDuration = false,
-    String? eventAt,
+    DateTime? eventAt,
     bool clearEventAt = false,
     double? importance,
     String? visibility,
@@ -109,7 +109,10 @@ class UnassignedPostsNotifier extends Notifier<UnassignedPostsState>
             if (clearThumbnail) 'thumbnailUrl': null,
             'duration': ?duration,
             if (clearDuration) 'duration': null,
-            'eventAt': ?eventAt,
+            // See comment in TimelineNotifier.updatePost: callers pass a
+            // local DateTime; we centralize the toUtc().toIso8601String()
+            // conversion here.
+            if (eventAt != null) 'eventAt': eventAt.toUtc().toIso8601String(),
             if (clearEventAt) 'eventAt': null,
             'importance': ?importance,
             'visibility': ?visibility,

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -110,7 +110,11 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
     _selectedTrackId = widget.post.trackId;
     _thumbnailUrl = widget.post.thumbnailUrl;
     _durationSeconds = widget.post.duration;
-    _eventAt = widget.post.eventAt;
+    // The backend returns eventAt as a `Z`-suffixed UTC ISO string, which
+    // `DateTime.parse` lifts to `isUtc == true`. The form holds a
+    // wall-clock local DateTime so the picker / formatter see the user's
+    // actual input time. We convert back to UTC at submit time.
+    _eventAt = widget.post.eventAt?.toLocal();
     _articleGenre = widget.post.articleGenre;
     _externalPublish = widget.post.externalPublish;
     _mediaUrls = List.of(widget.post.imageUrls);
@@ -205,8 +209,9 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
             duration: _durationSeconds,
             clearDuration:
                 _durationSeconds == null && widget.post.duration != null,
-            // toUtc() before serialization: see comment in create_post_provider.dart
-            eventAt: _eventAt?.toUtc().toIso8601String(),
+            // Pass the local DateTime directly; the provider centralizes
+            // the toUtc() + ISO conversion to keep the type contract.
+            eventAt: _eventAt,
             clearEventAt: _eventAt == null && widget.post.eventAt != null,
             importance: _importance,
             visibility: _visibility,
@@ -236,8 +241,9 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
             duration: _durationSeconds,
             clearDuration:
                 _durationSeconds == null && widget.post.duration != null,
-            // toUtc() before serialization: see comment in create_post_provider.dart
-            eventAt: _eventAt?.toUtc().toIso8601String(),
+            // Pass the local DateTime directly; the provider centralizes
+            // the toUtc() + ISO conversion to keep the type contract.
+            eventAt: _eventAt,
             clearEventAt: _eventAt == null && widget.post.eventAt != null,
             importance: _importance,
             visibility: _visibility,

--- a/frontend/lib/screens/edit_post/edit_post_screen.dart
+++ b/frontend/lib/screens/edit_post/edit_post_screen.dart
@@ -205,7 +205,8 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
             duration: _durationSeconds,
             clearDuration:
                 _durationSeconds == null && widget.post.duration != null,
-            eventAt: _eventAt?.toIso8601String(),
+            // toUtc() before serialization: see comment in create_post_provider.dart
+            eventAt: _eventAt?.toUtc().toIso8601String(),
             clearEventAt: _eventAt == null && widget.post.eventAt != null,
             importance: _importance,
             visibility: _visibility,
@@ -235,7 +236,8 @@ class _EditPostScreenState extends ConsumerState<EditPostScreen> {
             duration: _durationSeconds,
             clearDuration:
                 _durationSeconds == null && widget.post.duration != null,
-            eventAt: _eventAt?.toIso8601String(),
+            // toUtc() before serialization: see comment in create_post_provider.dart
+            eventAt: _eventAt?.toUtc().toIso8601String(),
             clearEventAt: _eventAt == null && widget.post.eventAt != null,
             importance: _importance,
             visibility: _visibility,

--- a/frontend/lib/widgets/common/event_at_picker.dart
+++ b/frontend/lib/widgets/common/event_at_picker.dart
@@ -4,6 +4,20 @@ import '../../theme/gleisner_tokens.dart';
 
 /// Date+time picker for post event date ("when did this happen?").
 /// Shared between create_post and edit_post screens.
+///
+/// Timezone contract:
+/// - [eventAt] may arrive as either a UTC `DateTime` (e.g. parsed from a
+///   `Z`-suffixed ISO string returned by the backend) or a local
+///   `DateTime`. The widget always calls `.toLocal()` internally for
+///   display and for picker initial values, so callers can pass either.
+/// - [onChanged] always emits a *local* `DateTime` (`isUtc == false`),
+///   reflecting what the user picked in their wall-clock time.
+///   **Callers that send the value to the backend MUST call `.toUtc()`
+///   before serializing**, otherwise `toIso8601String()` produces a
+///   naive (offset-less) string that the server parses as its own local
+///   time. Provider-layer `updatePost` / `submit` methods now accept
+///   `DateTime?` and handle this conversion centrally — prefer that
+///   over passing pre-serialized strings around.
 class EventAtPicker extends StatelessWidget {
   final DateTime? eventAt;
   final ValueChanged<DateTime?> onChanged;
@@ -26,7 +40,7 @@ class EventAtPicker extends StatelessWidget {
             onTap: () => _pickDateTime(context),
             child: Text(
               eventAt != null
-                  ? _format(eventAt!)
+                  ? _format(eventAt!.toLocal())
                   : context.l10n.eventDateOptional,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: eventAt != null ? colorTextPrimary : colorTextMuted,
@@ -55,9 +69,12 @@ class EventAtPicker extends StatelessWidget {
 
   Future<void> _pickDateTime(BuildContext context) async {
     final now = DateTime.now();
+    // Always operate on local-zone wall-clock time, regardless of whether
+    // the incoming `eventAt` is UTC or local. See class doc.
+    final localEventAt = eventAt?.toLocal();
     final date = await showDatePicker(
       context: context,
-      initialDate: eventAt ?? now,
+      initialDate: localEventAt ?? now,
       firstDate: DateTime(2000),
       lastDate: now,
     );
@@ -65,12 +82,14 @@ class EventAtPicker extends StatelessWidget {
 
     final time = await showTimePicker(
       context: context,
-      initialTime: eventAt != null
-          ? TimeOfDay(hour: eventAt!.hour, minute: eventAt!.minute)
+      initialTime: localEventAt != null
+          ? TimeOfDay(hour: localEventAt.hour, minute: localEventAt.minute)
           : TimeOfDay.now(),
     );
     if (time == null) return;
 
+    // `DateTime(...)` (no `.utc`) returns a naive local DateTime — caller
+    // must `.toUtc()` before serializing.
     onChanged(
       DateTime(date.year, date.month, date.day, time.hour, time.minute),
     );

--- a/frontend/test/models/post_test.dart
+++ b/frontend/test/models/post_test.dart
@@ -84,6 +84,32 @@ void main() {
       final post = Post.fromJson(json);
       expect(post.duration, isNull);
     });
+
+    test('parses Z-suffixed eventAt as a UTC DateTime', () {
+      // The backend serializes eventAt with `.toISOString()` which always
+      // yields a `Z`-suffixed UTC ISO string. The model must lift that to
+      // an `isUtc == true` DateTime so the rest of the app can use the
+      // toLocal()/toUtc() round-trip contract documented on EventAtPicker.
+      // Round-trip through 05:30 UTC = 14:30 JST (+09:00).
+      final json = {...validJson, 'eventAt': '2026-01-15T05:30:00.000Z'};
+      final post = Post.fromJson(json);
+      expect(post.eventAt, isNotNull);
+      expect(post.eventAt!.isUtc, isTrue);
+      expect(post.eventAt!.toUtc().hour, 5);
+      expect(post.eventAt!.toUtc().minute, 30);
+      // The absolute instant equals 05:30 UTC regardless of the test
+      // host's TZ — pin it via millisecondsSinceEpoch so the test does
+      // not rely on the runner's default zone.
+      expect(
+        post.eventAt!.millisecondsSinceEpoch,
+        DateTime.utc(2026, 1, 15, 5, 30).millisecondsSinceEpoch,
+      );
+    });
+
+    test('parses null eventAt', () {
+      final post = Post.fromJson({...validJson, 'eventAt': null});
+      expect(post.eventAt, isNull);
+    });
   });
 
   group('Post.formattedDuration', () {

--- a/frontend/test/providers/create_post_provider_test.dart
+++ b/frontend/test/providers/create_post_provider_test.dart
@@ -11,11 +11,16 @@ class _MockLink extends Link {
   final Map<String, dynamic>? data;
   final List<GraphQLError>? errors;
   final Exception? exception;
+  // Captures the variables of the most recent request, for tests that need
+  // to assert on the exact payload sent to the server (e.g. eventAt
+  // serialization).
+  final List<Map<String, dynamic>> capturedVariables = [];
 
   _MockLink({this.data, this.errors, this.exception});
 
   @override
   Stream<Response> request(Request request, [NextLink? forward]) {
+    capturedVariables.add(Map<String, dynamic>.from(request.variables));
     if (exception != null) return Stream.error(exception!);
     return Stream.value(
       Response(
@@ -35,6 +40,20 @@ GraphQLClient _clientWith({
   return GraphQLClient(
     link: _MockLink(data: data, errors: errors, exception: exception),
     cache: GraphQLCache(store: InMemoryStore()),
+  );
+}
+
+({GraphQLClient client, _MockLink link}) _capturingClient({
+  Map<String, dynamic>? data,
+  List<GraphQLError>? errors,
+}) {
+  final link = _MockLink(data: data, errors: errors);
+  return (
+    client: GraphQLClient(
+      link: link,
+      cache: GraphQLCache(store: InMemoryStore()),
+    ),
+    link: link,
   );
 }
 
@@ -204,6 +223,74 @@ void main() {
       final state = container.read(createPostProvider);
       expect(state.error, isNotNull);
       expect(state.isSubmitting, false);
+    });
+
+    test('submit serializes eventAt as a UTC ISO-8601 string', () async {
+      // Regression for the JST-as-UTC timeline ordering bug:
+      // EventAtPicker emits a local DateTime; calling toIso8601String() on
+      // a local DateTime drops the timezone offset, and Node.js then
+      // parses the naive string as server-local time (UTC on Railway),
+      // causing JST inputs to be stored 9 hours in the future.
+      // The fix is to call .toUtc() before .toIso8601String().
+      final captured = _capturingClient(
+        data: {
+          'createPost': {
+            'post': {
+              'id': 'post-1',
+              'mediaType': 'thought',
+              'title': 'Hello',
+              'importance': 0.5,
+              'createdAt': '2026-05-10T14:02:00.000Z',
+              'updatedAt': '2026-05-10T14:02:00.000Z',
+              'author': {'id': 'u1', 'username': 'me'},
+            },
+            'track': {
+              'id': 'track-1',
+              'name': 'Music',
+              'color': '#4A90D9',
+              'createdAt': '2026-01-01T00:00:00.000Z',
+            },
+          },
+        },
+      );
+      final container = _createContainer(client: captured.client);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(createPostProvider.notifier);
+      notifier.selectTrack(_testTrack);
+      notifier.selectMediaType(MediaType.thought);
+
+      // A local DateTime — what EventAtPicker hands back to callers.
+      final localEventAt = DateTime(2026, 5, 10, 13, 45);
+
+      await notifier.submit(
+        title: 'Hello',
+        body: 'World',
+        mediaUrl: null,
+        eventAt: localEventAt,
+      );
+
+      // Two requests are issued: getUploadUrl (none for thought) and
+      // createPost. We only care about the one that carries eventAt.
+      final createCall = captured.link.capturedVariables.firstWhere(
+        (v) => v.containsKey('eventAt'),
+      );
+      final serialized = createCall['eventAt'] as String;
+
+      // Must end with `Z` so the backend's `new Date(...)` parses it as
+      // an absolute UTC instant rather than as server-local time.
+      expect(
+        serialized.endsWith('Z'),
+        isTrue,
+        reason: 'eventAt must be serialized in UTC: got "$serialized"',
+      );
+
+      // And the absolute moment must equal the local input — i.e. round-
+      // tripping must not shift the user's intended time.
+      expect(
+        DateTime.parse(serialized).millisecondsSinceEpoch,
+        localEventAt.millisecondsSinceEpoch,
+      );
     });
 
     test('copyWith preserves error when not explicitly set', () {

--- a/frontend/test/providers/timeline_provider_test.dart
+++ b/frontend/test/providers/timeline_provider_test.dart
@@ -471,6 +471,11 @@ void main() {
       final updateRequest = pair.link.requests.firstWhere(
         (r) => r.variables.containsKey('eventAt'),
       );
+      // Explicit "key is present" assertion in addition to the
+      // firstWhere selector — keeps the contract visible as
+      // documentation (sending an explicit eventAt key is what makes
+      // the backend distinguish "set value" from "no change").
+      expect(updateRequest.variables.containsKey('eventAt'), isTrue);
       final serialized = updateRequest.variables['eventAt'] as String;
 
       expect(

--- a/frontend/test/providers/timeline_provider_test.dart
+++ b/frontend/test/providers/timeline_provider_test.dart
@@ -414,6 +414,76 @@ void main() {
       // No state change at all — Riverpod's listener bus stays quiet.
       expect(identical(original, after), isTrue);
     });
+
+    // Regression for the JST-as-UTC eventAt bug. Mirrors the create_post
+    // side coverage in create_post_provider_test.dart but exercises the
+    // edit path: callers hand `updatePost` a local DateTime (what
+    // EventAtPicker.onChanged emits) and the provider must convert to
+    // UTC before serializing. A naive toIso8601String() on a local
+    // DateTime would drop the offset and the backend would store the
+    // wrong absolute time.
+    test('updatePost serializes eventAt as a UTC ISO-8601 string', () async {
+      final pair = _clientAndLinkWith(
+        data: {
+          '__typename': 'Mutation',
+          'updatePost': {
+            '__typename': 'Post',
+            'id': 'edit-target',
+            'mediaType': 'thought',
+            'title': 'updated',
+            'importance': 0.5,
+            'createdAt': '2026-05-10T05:00:00.000Z',
+            'updatedAt': '2026-05-10T05:00:00.000Z',
+            'eventAt': '2026-05-10T04:45:00.000Z',
+            'author': {
+              '__typename': 'PublicUser',
+              'id': 'u1',
+              'username': 'alice',
+            },
+          },
+        },
+      );
+      final container = _createContainer(client: pair.client);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(timelineProvider.notifier);
+      // Seed state.posts so updatePost's `firstWhere` doesn't throw.
+      final existing = Post(
+        id: 'edit-target',
+        mediaType: MediaType.thought,
+        importance: 0.5,
+        createdAt: DateTime.utc(2026, 5, 10, 5),
+        updatedAt: DateTime.utc(2026, 5, 10, 5),
+        author: const PostAuthor(id: 'u1', username: 'alice'),
+      );
+      notifier.debugSetState(
+        container.read(timelineProvider).copyWith(posts: [existing]),
+      );
+
+      // What EventAtPicker.onChanged hands the screen: a naive local
+      // DateTime (isUtc == false).
+      final localEventAt = DateTime(2026, 5, 10, 13, 45);
+
+      await notifier.updatePost(id: 'edit-target', eventAt: localEventAt);
+
+      // Find the updatePost mutation among captured requests and check
+      // the eventAt variable.
+      final updateRequest = pair.link.requests.firstWhere(
+        (r) => r.variables.containsKey('eventAt'),
+      );
+      final serialized = updateRequest.variables['eventAt'] as String;
+
+      expect(
+        serialized.endsWith('Z'),
+        isTrue,
+        reason: 'eventAt must be UTC-serialized: got "$serialized"',
+      );
+      // Round-trip preserves the user's intended absolute moment.
+      expect(
+        DateTime.parse(serialized).millisecondsSinceEpoch,
+        localEventAt.millisecondsSinceEpoch,
+      );
+    });
   });
 
   // Regression tests for Issue #191. The backend fires OGP fetch

--- a/frontend/test/providers/unassigned_posts_provider_test.dart
+++ b/frontend/test/providers/unassigned_posts_provider_test.dart
@@ -202,6 +202,54 @@ void main() {
       },
     );
 
+    // Companion to the splice test: the `clearEventAt: true` flag tells
+    // the backend to NULL out eventAt, and the response carries
+    // `eventAt: null`. The splice path must propagate that null back
+    // into state so the UI doesn't keep showing the old timestamp.
+    test(
+      'splices null eventAt into state when clearEventAt clears it',
+      () async {
+        final pair = _clientAndLinkWith(
+          data: {
+            '__typename': 'Mutation',
+            'updatePost': _postJson(id: 'p-clear', eventAt: null),
+          },
+        );
+        final container = _createContainer(client: pair.client);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(unassignedPostsProvider.notifier);
+        // Seed with a post that already has a non-null eventAt so we can
+        // observe the clear actually changing state, not just matching
+        // an already-null field.
+        final original = Post.fromJson(
+          _postJson(id: 'p-clear', eventAt: '2026-05-10T04:45:00.000Z'),
+        );
+        notifier.debugSetState(UnassignedPostsState(posts: [original]));
+        expect(
+          container.read(unassignedPostsProvider).posts.single.eventAt,
+          isNotNull,
+        );
+
+        await notifier.updatePost(id: 'p-clear', clearEventAt: true);
+
+        // The mutation request must carry an explicit `eventAt: null`
+        // (not a missing key — that would mean "no change").
+        final updateRequest = pair.link.requests.firstWhere(
+          (r) => r.operation.operationName != null,
+          orElse: () => pair.link.requests.first,
+        );
+        expect(updateRequest.variables.containsKey('eventAt'), isTrue);
+        expect(updateRequest.variables['eventAt'], isNull);
+
+        // And the splice must reflect the cleared value in state.
+        final after = container.read(unassignedPostsProvider).posts;
+        expect(after, hasLength(1));
+        expect(after.single.id, 'p-clear');
+        expect(after.single.eventAt, isNull);
+      },
+    );
+
     test('drops the post from state when trackId becomes non-null', () async {
       final pair = _clientAndLinkWith(
         data: {

--- a/frontend/test/providers/unassigned_posts_provider_test.dart
+++ b/frontend/test/providers/unassigned_posts_provider_test.dart
@@ -1,0 +1,230 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+import 'package:gleisner_web/graphql/client.dart';
+import 'package:gleisner_web/models/post.dart';
+import 'package:gleisner_web/providers/unassigned_posts_provider.dart';
+
+class _MockLink extends Link {
+  final Map<String, dynamic>? data;
+  final List<GraphQLError>? errors;
+  final List<Request> requests = [];
+
+  _MockLink({this.data, this.errors});
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    requests.add(request);
+    // Mirror create_post_provider_test's mock: graphql_flutter writes the
+    // response to its normalizing cache, and passing the raw `response`
+    // map avoids cache-writer surprises that can otherwise mark the
+    // OperationResult as exception (which the provider then short-circuits).
+    return Stream.value(
+      Response(
+        data: data,
+        errors: errors,
+        response: {'data': data, if (errors != null) 'errors': errors},
+      ),
+    );
+  }
+}
+
+({GraphQLClient client, _MockLink link}) _clientAndLinkWith({
+  Map<String, dynamic>? data,
+  List<GraphQLError>? errors,
+}) {
+  final link = _MockLink(data: data, errors: errors);
+  return (
+    client: GraphQLClient(
+      link: link,
+      cache: GraphQLCache(store: InMemoryStore()),
+    ),
+    link: link,
+  );
+}
+
+ProviderContainer _createContainer({required GraphQLClient client}) {
+  return ProviderContainer(
+    overrides: [graphqlClientProvider.overrideWithValue(client)],
+  );
+}
+
+// Build a Post-shaped JSON value matching the full `postFields` fragment
+// (lib/graphql/queries/post.dart). Every field requested by the document
+// must be present in the mock response, otherwise graphql_flutter's
+// response normalizer raises PartialDataException → OperationException
+// and the provider's `result.hasException` short-circuits.
+Map<String, dynamic> _postJson({
+  required String id,
+  String? trackId,
+  String? title = 'updated',
+  String? eventAt,
+}) {
+  return {
+    '__typename': 'Post',
+    'id': id,
+    'mediaType': 'thought',
+    'title': title,
+    'body': null,
+    'bodyFormat': 'plain',
+    'mediaUrl': null,
+    'thumbnailUrl': null,
+    'duration': null,
+    'eventAt': eventAt,
+    'importance': 0.5,
+    'visibility': 'public',
+    'layoutX': null,
+    'layoutY': null,
+    'contentHash': null,
+    'articleGenre': null,
+    'externalPublish': false,
+    'ogTitle': null,
+    'ogDescription': null,
+    'ogImage': null,
+    'ogSiteName': null,
+    'createdAt': '2026-05-10T05:00:00.000Z',
+    'updatedAt': '2026-05-10T05:00:00.000Z',
+    'author': {
+      '__typename': 'PublicUser',
+      'id': 'u1',
+      'username': 'alice',
+      'displayName': 'Alice',
+      'avatarUrl': null,
+    },
+    'track': trackId == null
+        ? null
+        : {
+            '__typename': 'Track',
+            'id': trackId,
+            'name': 'Music',
+            'color': '#4A90D9',
+          },
+    'reactionCounts': const <Map<String, dynamic>>[],
+    'myReactions': const <String>[],
+    'outgoingConnections': const <Map<String, dynamic>>[],
+    'incomingConnections': const <Map<String, dynamic>>[],
+    'constellation': null,
+    'media': const <Map<String, dynamic>>[],
+  };
+}
+
+void main() {
+  group('UnassignedPostsNotifier.updatePost', () {
+    // Mirrors the timeline-side coverage for the JST-as-UTC bug. Callers
+    // hand a local DateTime; the provider must serialize as UTC ISO so
+    // the backend stores the user's intended absolute moment.
+    test('serializes eventAt as a UTC ISO-8601 string', () async {
+      final pair = _clientAndLinkWith(
+        data: {
+          '__typename': 'Mutation',
+          'updatePost': _postJson(
+            id: 'unassigned-1',
+            eventAt: '2026-05-10T04:45:00.000Z',
+          ),
+        },
+      );
+      final container = _createContainer(client: pair.client);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(unassignedPostsProvider.notifier);
+
+      // What EventAtPicker.onChanged emits — a naive local DateTime.
+      final localEventAt = DateTime(2026, 5, 10, 13, 45);
+
+      await notifier.updatePost(id: 'unassigned-1', eventAt: localEventAt);
+
+      final updateRequest = pair.link.requests.firstWhere(
+        (r) => r.variables.containsKey('eventAt'),
+      );
+      final serialized = updateRequest.variables['eventAt'] as String;
+
+      expect(
+        serialized.endsWith('Z'),
+        isTrue,
+        reason: 'eventAt must be UTC-serialized: got "$serialized"',
+      );
+      expect(
+        DateTime.parse(serialized).millisecondsSinceEpoch,
+        localEventAt.millisecondsSinceEpoch,
+      );
+    });
+
+    // Unassigned posts that stay unassigned after an edit (e.g. user
+    // updates only eventAt / title / body) must reflect the server
+    // response in state.posts so the same screen sees the change
+    // immediately. Posts that get reassigned (trackId becomes non-null)
+    // must drop out of the unassigned list.
+    test(
+      'splices the updated post back into state when trackId stays null',
+      () async {
+        // Use debugSetState to seed an initial post directly. We avoid
+        // load() in this test because graphql_flutter's normalizing cache
+        // can conflate the load() and updatePost responses (same Post id
+        // → cache merges fields), making the splice assertion flaky.
+        final pair = _clientAndLinkWith(
+          data: {
+            '__typename': 'Mutation',
+            'updatePost': _postJson(
+              id: 'p-stay',
+              title: 'new',
+              eventAt: '2026-05-10T04:45:00.000Z',
+            ),
+          },
+        );
+        final container = _createContainer(client: pair.client);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(unassignedPostsProvider.notifier);
+
+        final original = Post.fromJson(_postJson(id: 'p-stay', title: 'old'));
+        notifier.debugSetState(UnassignedPostsState(posts: [original]));
+        expect(container.read(unassignedPostsProvider).posts, hasLength(1));
+        expect(
+          container.read(unassignedPostsProvider).posts.single.title,
+          'old',
+        );
+
+        await notifier.updatePost(
+          id: 'p-stay',
+          title: 'new',
+          eventAt: DateTime(2026, 5, 10, 13, 45),
+        );
+
+        final after = container.read(unassignedPostsProvider).posts;
+        expect(after, hasLength(1));
+        expect(after.single.id, 'p-stay');
+        // Server response is reflected in state without waiting for a
+        // refetch — the regression Important #2 was protecting against.
+        expect(after.single.title, 'new');
+        expect(after.single.eventAt, isNotNull);
+        expect(after.single.eventAt!.isUtc, isTrue);
+      },
+    );
+
+    test('drops the post from state when trackId becomes non-null', () async {
+      final pair = _clientAndLinkWith(
+        data: {
+          '__typename': 'Mutation',
+          'updatePost': _postJson(
+            id: 'p-reassign',
+            title: 'old',
+            trackId: 'track-x',
+          ),
+        },
+      );
+      final container = _createContainer(client: pair.client);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(unassignedPostsProvider.notifier);
+      final original = Post.fromJson(_postJson(id: 'p-reassign', title: 'old'));
+      notifier.debugSetState(UnassignedPostsState(posts: [original]));
+      expect(container.read(unassignedPostsProvider).posts, hasLength(1));
+
+      await notifier.updatePost(id: 'p-reassign', trackId: 'track-x');
+
+      // Reassigned to a track → leaves the unassigned list.
+      expect(container.read(unassignedPostsProvider).posts, isEmpty);
+    });
+  });
+}

--- a/frontend/test/providers/unassigned_posts_provider_test.dart
+++ b/frontend/test/providers/unassigned_posts_provider_test.dart
@@ -234,12 +234,13 @@ void main() {
         await notifier.updatePost(id: 'p-clear', clearEventAt: true);
 
         // The mutation request must carry an explicit `eventAt: null`
-        // (not a missing key — that would mean "no change").
+        // (not a missing key — that would mean "no change"). Select by
+        // `containsKey('eventAt')` rather than by operation name so the
+        // assertion stays precise even if a future test in this file
+        // adds a `load()` query before updatePost.
         final updateRequest = pair.link.requests.firstWhere(
-          (r) => r.operation.operationName != null,
-          orElse: () => pair.link.requests.first,
+          (r) => r.variables.containsKey('eventAt'),
         );
-        expect(updateRequest.variables.containsKey('eventAt'), isTrue);
         expect(updateRequest.variables['eventAt'], isNull);
 
         // And the splice must reflect the cleared value in state.


### PR DESCRIPTION
## Symptom

タイムラインの並び順が、`eventAt` を設定した投稿だけ意図と逆に並ぶ。

再現:

1. 13:45 のイベント日時を設定して投稿A
2. 続けて 14:02 にイベント日時なしで投稿B
3. 期待: 上から **B → A**（B のほうが新しい時刻）
4. 実際: 上から **A → B**

## Root cause

`EventAtPicker._pickDateTime` は **ローカル DateTime** を返す
(`frontend/lib/widgets/common/event_at_picker.dart:74-76`)。

それを `create_post_provider.dart:186` と `edit_post_screen.dart:208,238` で
`toIso8601String()` で文字列化していた。**ローカル DateTime に対する
`toIso8601String()` はタイムゾーンを含まない**ため、`"2026-05-10T13:45:00.000"`
のような naive ISO 文字列になる。

バックエンド (`backend/src/graphql/types/post.ts:604`) は `new Date(args.eventAt)` で
パースしているが、Node.js は naive ISO を **サーバーのローカルタイム** として解釈する。
Railway は UTC なので、JST 13:45 が **13:45 UTC（= JST 22:45）として保存**されていた。

タイムラインは `displayDate = eventAt ?? createdAt` の絶対時刻で降順ソート
(`utils/constellation_layout.dart:166-172`)。`createdAt` は `defaultNow()` で
正しく UTC 保存されているため、

* A: `displayDate = 2026-05-10T13:45Z`（buggy）
* B: `displayDate = 2026-05-10T05:02Z`（正しい 14:02 JST）

となり、A が「より新しい」と判定されて上に並ぶ。

## Fix

### Frontend

3 箇所の serialization 境界で `.toUtc()` を挟む:

* `frontend/lib/providers/create_post_provider.dart:186`
* `frontend/lib/screens/edit_post/edit_post_screen.dart:208, 238`

`Post.fromJson` (`models/post.dart:419`) の `DateTime.parse` は `Z` 付き ISO を
正しく UTC として読めるので追加修正は不要。

回帰テスト: `test/providers/create_post_provider_test.dart` に
「ローカル DateTime を渡したとき、リクエスト変数の `eventAt` が `Z` で終わり、
かつパースし直した絶対時刻が入力と一致する」アサーションを追加。

### Backend / DB backfill

`backend/drizzle/0017_eventat_jst_backfill.sql` で既存データを `-9 hours` シフト。

Phase 0 は家族ライフログ（全ユーザー Asia/Tokyo）であり、現在 DB に存在する
`event_at IS NOT NULL` の行はすべて buggy パスで書かれた値なので、一律 9 時間
戻すことで「ユーザーが意図した絶対時刻」を復元できる。マイグレーションランナーが
適用済みフラグを持つので二重シフトは起きない。

> Phase 1 で TZ がばらつくユーザーが入る頃には buggy パスは消えているため、
> 後続のバックフィルは不要。

## Verification

```
cd backend && pnpm format:check && pnpm lint && pnpm build  # ✅
cd frontend && dart format --set-exit-if-changed lib/providers/create_post_provider.dart \
   lib/screens/edit_post/edit_post_screen.dart \
   test/providers/create_post_provider_test.dart                                       # ✅
flutter analyze lib/providers/create_post_provider.dart \
   lib/screens/edit_post/edit_post_screen.dart \
   test/providers/create_post_provider_test.dart                                       # ✅
flutter test test/providers/create_post_provider_test.dart --platform chrome           # ✅ 17/17
```

## Operator action

リリース時、本番 DB に対して `pnpm db:migrate` を実行する（または
`0017_eventat_jst_backfill.sql` を直接適用）。フロント修正と同一リリースで
当てるのが望ましい — フロント新版が出たあとに新規作成された `event_at` は
正しい UTC で書かれるため、それより前の行だけが backfill 対象。

🤖 Generated with [Claude Code](https://claude.com/claude-code)