### PR TITLE
fix(auth): extend JWT TTL from 24h to 30d (Phase 0 logout UX hotfix)

### DIFF
--- a/backend/src/auth/jwt.ts
+++ b/backend/src/auth/jwt.ts
@@ -8,7 +8,13 @@ import {
 import { env } from "../env.js";
 
 const ALG = "EdDSA";
-const TOKEN_EXPIRY = "24h";
+// Phase 0: 30d single-token TTL is a pragmatic trade-off until #409
+// (refresh-token rotation, PR-D of the Phase 1 authz batch). The previous
+// 24h TTL caused daily forced re-login on iPad child accounts where the
+// parent had switched to a child profile via switchToChild — the TTL clock
+// started at switch time, not at last activity, so a child using the iPad
+// once per evening was almost certain to be logged out by the next day.
+const TOKEN_EXPIRY = "30d";
 
 let privateKey: CryptoKey;
 let publicKey: CryptoKey;


### PR DESCRIPTION
## Summary

Phase 0 hotfix: extend JWT TTL from 24h to 30d to stop daily forced re-login on iPad child accounts.

## Symptom (reported by Phase 0 user)

- iPhone (parent direct use): never logs out
- iPad (parent → `switchToChild` → child uses): logs out roughly every 24h, sometimes sooner if the iPad sits unused for a few hours

## Root cause

`backend/src/auth/jwt.ts` issued JWTs with a fixed 24h `TOKEN_EXPIRY`, and there is no refresh-token mechanism. `switchToChild` issues a fresh JWT, so the 24h clock restarts at the switch moment — not at last user activity. A child using the iPad once per evening will almost always find the app logged out the next day.

The iPhone case did not surface because the parent opens the app frequently enough that the `me` query never fires inside the expired window.

## Change

Single-line constant change: `"24h"` → `"30d"`, with a comment block pointing to #409 (refresh-token rotation, PR-D of the Phase 1 authz batch) which is the proper fix.

## Security trade-off

Revocation today is JWT_PRIVATE_KEY rotation only (a global logout). 30d does not change that — a leaked token is unrevocable regardless of TTL. The blast radius widens from "24h of misuse" to "30d of misuse", which is the cost we are paying to unblock family use. The structural fix (per-session refresh tokens, individual revocation, short-lived access) lands in #409.

Phase 0 is family lifelog scope (`memory/project_phased_launch_strategy.md`), so the population at risk from a leaked token is the family itself. We accept this trade-off until Phase 1 SNS opening.

## What changed

- `backend/src/auth/jwt.ts`: `TOKEN_EXPIRY` 24h → 30d + comment block

## What did NOT change

- JWT structure, signing algorithm (EdDSA), claim shape (`sub`, `gid`, `iat`, `exp`, `iss`)
- HTTP authentication middleware behaviour
- `me` / `switchToChild` / `switchBackToGuardian` / `logout` mutations
- Frontend token storage or refresh handling

Existing 24h tokens issued before this deploy remain valid until their natural expiry (no global logout).

## Verification

```
cd backend
mise run lint           # ✅
pnpm format:check       # ✅ All matched files use Prettier code style
pnpm build              # ✅ tsc clean
pnpm test               # ✅ 660 pass / 1 skipped
```

## Related

- Closes the iPad-daily-logout report (Phase 0 user feedback, 2026-05-11)
- Tracked-by: #409 (refresh-token rotation, Phase 1 authz batch PR-D)
- Updates yatima `memory/project_phase1_authz_batch.md` (separate commit on the umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
