### PR TITLE
fix(post): prevent accidental dismiss of create/edit dialogs on tap-outside

### DIFF
--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -420,6 +420,7 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                       if (isDesktop(screenWidth)) {
                         showDialog(
                           context: context,
+                          barrierDismissible: false,
                           builder: (dialogContext) => Dialog(
                             backgroundColor: colorSurface0,
                             insetPadding: const EdgeInsets.symmetric(
@@ -901,6 +902,7 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
     if (isDesktop(screenWidth)) {
       showDialog(
         context: context,
+        barrierDismissible: false,
         builder: (dialogContext) => Dialog(
           backgroundColor: colorSurface0,
           insetPadding: const EdgeInsets.symmetric(


### PR DESCRIPTION
## Summary

On tablets and desktop, the create-post and edit-post dialogs (shown via `showDialog` on wide screens) were dismissible by tapping outside the dialog because `barrierDismissible` defaults to `true`. This caused users to lose in-progress input on tablets where the post UI is presented as a dialog rather than a full-screen route.

Set `barrierDismissible: false` on both dialogs so the only exit is the explicit back/close button in the AppBar.

Mobile route-based navigation (`/create-post`) is unaffected — it already requires an explicit back gesture.

A follow-up PR will add draft autosave so even unexpected closures (crash, tab close, accidental app kill) do not lose input.

## Test plan

- [ ] Open create-post dialog on tablet/desktop layout → tap outside → dialog stays open
- [ ] Open edit-post dialog on tablet/desktop layout → tap outside → dialog stays open
- [ ] Back/close button in AppBar still works
- [ ] Mobile route (`/create-post`) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)