### PR TITLE
feat(post): add draft autosave + discard-confirm to the post composer

### DIFF
--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -668,5 +668,25 @@
   "yourReactions": "Your reactions",
   "@yourReactions": {
     "description": "Section label inside the emoji picker bottom sheet, above a chip row that shows the emojis the current viewer has already reacted with on this post. Tapping a chip removes that reaction. Lets users see what they've already selected so the picker feels persistent rather than fire-and-forget."
+  },
+  "discardPostConfirmTitle": "Discard draft?",
+  "@discardPostConfirmTitle": {
+    "description": "Title of the confirmation dialog shown when the user tries to leave the post composer (close button, browser back, system back, dialog dismiss) while there is unsaved input. The 'draft' here refers to the in-progress post being composed."
+  },
+  "discardPostConfirmMessage": "You have unsaved input. Discard it?",
+  "@discardPostConfirmMessage": {
+    "description": "Body text of the discard-draft confirmation dialog. Asks the user to choose between throwing away the in-progress post or returning to continue editing."
+  },
+  "discardButton": "Discard",
+  "@discardButton": {
+    "description": "Confirm action on the discard-draft dialog. Tapping this throws away the in-progress post and closes the composer. Styled as a destructive action."
+  },
+  "keepEditingButton": "Keep editing",
+  "@keepEditingButton": {
+    "description": "Cancel action on the discard-draft dialog. Tapping this dismisses the dialog and returns the user to the composer with their input intact."
+  },
+  "draftRestoredSnackbar": "Restored your previous draft.",
+  "@draftRestoredSnackbar": {
+    "description": "Snackbar shown when the post composer opens and finds a previously-saved draft for the current user. Confirms to the user that text and selections they entered before an unexpected closure are now back."
   }
 }

--- a/frontend/lib/l10n/app_ja.arb
+++ b/frontend/lib/l10n/app_ja.arb
@@ -454,5 +454,10 @@
   "reactionPickerTitle": "リアクションを追加",
   "reactionPickerHint": "絵文字をタップで追加・解除",
   "reactWith": "{emoji} でリアクション",
-  "yourReactions": "あなたのリアクション"
+  "yourReactions": "あなたのリアクション",
+  "discardPostConfirmTitle": "下書きを破棄しますか？",
+  "discardPostConfirmMessage": "入力中の内容があります。破棄してよろしいですか？",
+  "discardButton": "破棄する",
+  "keepEditingButton": "編集を続ける",
+  "draftRestoredSnackbar": "前回の入力内容を復元しました"
 }

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -2515,6 +2515,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Your reactions'**
   String get yourReactions;
+
+  /// Title of the confirmation dialog shown when the user tries to leave the post composer (close button, browser back, system back, dialog dismiss) while there is unsaved input. The 'draft' here refers to the in-progress post being composed.
+  ///
+  /// In en, this message translates to:
+  /// **'Discard draft?'**
+  String get discardPostConfirmTitle;
+
+  /// Body text of the discard-draft confirmation dialog. Asks the user to choose between throwing away the in-progress post or returning to continue editing.
+  ///
+  /// In en, this message translates to:
+  /// **'You have unsaved input. Discard it?'**
+  String get discardPostConfirmMessage;
+
+  /// Confirm action on the discard-draft dialog. Tapping this throws away the in-progress post and closes the composer. Styled as a destructive action.
+  ///
+  /// In en, this message translates to:
+  /// **'Discard'**
+  String get discardButton;
+
+  /// Cancel action on the discard-draft dialog. Tapping this dismisses the dialog and returns the user to the composer with their input intact.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep editing'**
+  String get keepEditingButton;
+
+  /// Snackbar shown when the post composer opens and finds a previously-saved draft for the current user. Confirms to the user that text and selections they entered before an unexpected closure are now back.
+  ///
+  /// In en, this message translates to:
+  /// **'Restored your previous draft.'**
+  String get draftRestoredSnackbar;
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -1363,4 +1363,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get yourReactions => 'Your reactions';
+
+  @override
+  String get discardPostConfirmTitle => 'Discard draft?';
+
+  @override
+  String get discardPostConfirmMessage => 'You have unsaved input. Discard it?';
+
+  @override
+  String get discardButton => 'Discard';
+
+  @override
+  String get keepEditingButton => 'Keep editing';
+
+  @override
+  String get draftRestoredSnackbar => 'Restored your previous draft.';
 }

--- a/frontend/lib/l10n/app_localizations_ja.dart
+++ b/frontend/lib/l10n/app_localizations_ja.dart
@@ -1320,4 +1320,19 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get yourReactions => 'あなたのリアクション';
+
+  @override
+  String get discardPostConfirmTitle => '下書きを破棄しますか？';
+
+  @override
+  String get discardPostConfirmMessage => '入力中の内容があります。破棄してよろしいですか？';
+
+  @override
+  String get discardButton => '破棄する';
+
+  @override
+  String get keepEditingButton => '編集を続ける';
+
+  @override
+  String get draftRestoredSnackbar => '前回の入力内容を復元しました';
 }

--- a/frontend/lib/models/create_post_draft.dart
+++ b/frontend/lib/models/create_post_draft.dart
@@ -1,0 +1,189 @@
+import 'dart:convert';
+
+import 'post.dart';
+
+/// Persisted draft of an in-progress post. Stored in shared_preferences
+/// under a user-scoped key so unexpected closures (crash, tab close,
+/// accidental dialog dismiss) do not lose input.
+///
+/// Intentionally minimal:
+/// - Selections that reference other domain objects (track, connections)
+///   are stored as IDs only and re-resolved on load. The track is looked up
+///   from the user's own tracks; connections are not persisted to avoid
+///   leaking private post IDs into local storage.
+/// - The `userId` field is the trust boundary: [CreatePostDraftService]
+///   refuses to return a draft whose `userId` does not match the
+///   currently-authenticated user.
+class CreatePostDraft {
+  final String userId;
+  final int step;
+  final String? selectedTrackId;
+  final MediaType? selectedMediaType;
+  final String visibility;
+  final double importance;
+  final ArticleGenre? articleGenre;
+  final bool externalPublish;
+  final String title;
+  final String body;
+  final String? bodyFormat;
+  final String? mediaUrl;
+  final List<String>? mediaUrls;
+  final String? thumbnailUrl;
+  final int? durationSeconds;
+  final DateTime? eventAt;
+  final DateTime savedAt;
+
+  const CreatePostDraft({
+    required this.userId,
+    this.step = 0,
+    this.selectedTrackId,
+    this.selectedMediaType,
+    this.visibility = 'public',
+    this.importance = 0.5,
+    this.articleGenre,
+    this.externalPublish = false,
+    this.title = '',
+    this.body = '',
+    this.bodyFormat,
+    this.mediaUrl,
+    this.mediaUrls,
+    this.thumbnailUrl,
+    this.durationSeconds,
+    this.eventAt,
+    required this.savedAt,
+  });
+
+  /// True when the draft holds enough state to bother restoring or
+  /// confirming discard. A bare-step-0 draft with no track is treated as
+  /// "empty" and skipped.
+  bool get hasMeaningfulInput {
+    if (step > 0) return true;
+    if (selectedTrackId != null) return true;
+    if (title.isNotEmpty || body.isNotEmpty) return true;
+    if (mediaUrl != null && mediaUrl!.isNotEmpty) return true;
+    if (mediaUrls != null && mediaUrls!.isNotEmpty) return true;
+    return false;
+  }
+
+  String toJsonString() => jsonEncode({
+    'userId': userId,
+    'step': step,
+    'selectedTrackId': selectedTrackId,
+    'selectedMediaType': selectedMediaType?.name,
+    'visibility': visibility,
+    'importance': importance,
+    'articleGenre': articleGenre?.name,
+    'externalPublish': externalPublish,
+    'title': title,
+    'body': body,
+    'bodyFormat': bodyFormat,
+    'mediaUrl': mediaUrl,
+    'mediaUrls': mediaUrls,
+    'thumbnailUrl': thumbnailUrl,
+    'durationSeconds': durationSeconds,
+    'eventAt': eventAt?.toUtc().toIso8601String(),
+    'savedAt': savedAt.toUtc().toIso8601String(),
+  });
+
+  /// Decode and validate a serialized draft. Returns null when the payload
+  /// is malformed, the required `userId` is missing, or the saved userId
+  /// does not match [expectedUserId]. All enum / numeric / list fields are
+  /// validated against allow-lists so a tampered payload cannot inject
+  /// unexpected values into the form state.
+  static CreatePostDraft? tryDecode(
+    String raw, {
+    required String expectedUserId,
+  }) {
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) return null;
+
+      final userId = decoded['userId'];
+      if (userId is! String || userId.isEmpty) return null;
+      if (userId != expectedUserId) return null;
+
+      final stepRaw = decoded['step'];
+      final step = stepRaw is int ? stepRaw.clamp(0, 2) : 0;
+
+      final mediaType = _parseMediaType(decoded['selectedMediaType']);
+
+      const visibilityAllowed = {'public', 'draft'};
+      final visibilityRaw = decoded['visibility'];
+      final visibility =
+          visibilityRaw is String && visibilityAllowed.contains(visibilityRaw)
+          ? visibilityRaw
+          : 'public';
+
+      final importanceRaw = decoded['importance'];
+      final importance = importanceRaw is num
+          ? importanceRaw.toDouble().clamp(0.0, 1.0)
+          : 0.5;
+
+      final articleGenre = _parseArticleGenre(decoded['articleGenre']);
+
+      final externalPublish = decoded['externalPublish'] == true;
+
+      String stringOrEmpty(dynamic v) => v is String ? v : '';
+      String? nullableString(dynamic v) =>
+          v is String && v.isNotEmpty ? v : null;
+      int? nullableInt(dynamic v) => v is int ? v : null;
+
+      List<String>? nullableStringList(dynamic v) {
+        if (v is! List) return null;
+        final out = <String>[];
+        for (final e in v) {
+          if (e is String && e.isNotEmpty) out.add(e);
+        }
+        return out.isEmpty ? null : out;
+      }
+
+      DateTime? nullableDateTime(dynamic v) {
+        if (v is! String) return null;
+        return DateTime.tryParse(v);
+      }
+
+      final savedAtRaw = decoded['savedAt'];
+      final savedAt = savedAtRaw is String
+          ? (DateTime.tryParse(savedAtRaw) ?? DateTime.now())
+          : DateTime.now();
+
+      return CreatePostDraft(
+        userId: userId,
+        step: step,
+        selectedTrackId: nullableString(decoded['selectedTrackId']),
+        selectedMediaType: mediaType,
+        visibility: visibility,
+        importance: importance,
+        articleGenre: articleGenre,
+        externalPublish: externalPublish,
+        title: stringOrEmpty(decoded['title']),
+        body: stringOrEmpty(decoded['body']),
+        bodyFormat: nullableString(decoded['bodyFormat']),
+        mediaUrl: nullableString(decoded['mediaUrl']),
+        mediaUrls: nullableStringList(decoded['mediaUrls']),
+        thumbnailUrl: nullableString(decoded['thumbnailUrl']),
+        durationSeconds: nullableInt(decoded['durationSeconds']),
+        eventAt: nullableDateTime(decoded['eventAt']),
+        savedAt: savedAt,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static MediaType? _parseMediaType(dynamic raw) {
+    if (raw is! String) return null;
+    for (final m in MediaType.values) {
+      if (m.name == raw) return m;
+    }
+    return null;
+  }
+
+  static ArticleGenre? _parseArticleGenre(dynamic raw) {
+    if (raw is! String) return null;
+    for (final g in ArticleGenre.values) {
+      if (g.name == raw) return g;
+    }
+    return null;
+  }
+}

--- a/frontend/lib/providers/auth_provider.dart
+++ b/frontend/lib/providers/auth_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 import '../graphql/client.dart';
+import 'create_post_draft_provider.dart';
 import 'disposable_notifier.dart';
 import 'featured_artist_provider.dart';
 import '../graphql/queries/auth.dart';
@@ -214,6 +215,14 @@ class AuthNotifier extends Notifier<AuthState> with DisposableNotifier {
   }
 
   Future<void> logout() async {
+    // Clear any in-progress post draft for the user we're logging out as,
+    // so an attacker who logs in next on the same device cannot recover
+    // it. The composer's user-id-scoped load path is the primary defense
+    // (it rejects mismatched drafts); this is the secondary cleanup.
+    final outgoingUserId = state.user?.id;
+    if (outgoingUserId != null) {
+      await ref.read(createPostDraftServiceProvider).clear(outgoingUserId);
+    }
     await _storage.delete(key: 'jwt');
     _client.cache.store.reset();
     ref.invalidate(featuredArtistProvider);

--- a/frontend/lib/providers/auth_provider.dart
+++ b/frontend/lib/providers/auth_provider.dart
@@ -215,18 +215,31 @@ class AuthNotifier extends Notifier<AuthState> with DisposableNotifier {
   }
 
   Future<void> logout() async {
-    // Clear any in-progress post draft for the user we're logging out as,
-    // so an attacker who logs in next on the same device cannot recover
-    // it. The composer's user-id-scoped load path is the primary defense
-    // (it rejects mismatched drafts); this is the secondary cleanup.
+    // Capture the id BEFORE we tear down state — once `state` flips to
+    // unauthenticated, `state.user` is gone and we can no longer scope
+    // the draft cleanup below to the outgoing account.
     final outgoingUserId = state.user?.id;
-    if (outgoingUserId != null) {
-      await ref.read(createPostDraftServiceProvider).clear(outgoingUserId);
-    }
+    // 1. Tear down auth state first. Any listener that watches
+    //    `authProvider` (e.g. the composer's listenManual) will see the
+    //    user change synchronously and stop persisting its own draft
+    //    BEFORE step 2 runs. This avoids a window in which the JWT is
+    //    gone but a composer's debounce timer is still alive.
     await _storage.delete(key: 'jwt');
     _client.cache.store.reset();
     ref.invalidate(featuredArtistProvider);
     state = const AuthState(status: AuthStatus.unauthenticated);
+    // 2. Best-effort draft cleanup. The composer's per-user key +
+    //    load-time userId check is the primary defense — this is a
+    //    redundant cleanup so users who never reopen the composer still
+    //    don't leave a draft behind. Failures here must not cascade into
+    //    a half-logged-out state, so swallow + log.
+    if (outgoingUserId != null) {
+      try {
+        await ref.read(createPostDraftServiceProvider).clear(outgoingUserId);
+      } catch (e) {
+        debugPrint('[Auth] post-logout draft clear failed: $e');
+      }
+    }
   }
 
   /// Delete the current user's account. Requires password re-confirmation.

--- a/frontend/lib/providers/create_post_draft_provider.dart
+++ b/frontend/lib/providers/create_post_draft_provider.dart
@@ -2,8 +2,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/create_post_draft_service.dart';
 
-/// Singleton service provider. Override in tests with an in-memory
-/// [SharedPreferences] (see test/services/create_post_draft_service_test.dart).
-final createPostDraftServiceProvider = Provider<CreatePostDraftService>(
-  (ref) => CreatePostDraftService(),
-);
+/// Service provider for the post-composer draft store.
+///
+/// `autoDispose` is intentional: the service eagerly resolves
+/// `SharedPreferences.getInstance()` in its constructor and caches the
+/// result for its lifetime. If a transient init failure leaves it
+/// permanently no-op'd (e.g. a Web tab that briefly lost storage access),
+/// re-opening the composer rebuilds the provider and gives storage another
+/// chance. The service itself is cheap to construct.
+///
+/// Override in tests with an in-memory [SharedPreferences]
+/// (see test/services/create_post_draft_service_test.dart).
+final createPostDraftServiceProvider =
+    Provider.autoDispose<CreatePostDraftService>(
+      (ref) => CreatePostDraftService(),
+    );

--- a/frontend/lib/providers/create_post_draft_provider.dart
+++ b/frontend/lib/providers/create_post_draft_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/create_post_draft_service.dart';
+
+/// Singleton service provider. Override in tests with an in-memory
+/// [SharedPreferences] (see test/services/create_post_draft_service_test.dart).
+final createPostDraftServiceProvider = Provider<CreatePostDraftService>(
+  (ref) => CreatePostDraftService(),
+);

--- a/frontend/lib/providers/create_post_draft_provider.dart
+++ b/frontend/lib/providers/create_post_draft_provider.dart
@@ -4,16 +4,26 @@ import '../services/create_post_draft_service.dart';
 
 /// Service provider for the post-composer draft store.
 ///
-/// `autoDispose` is intentional: the service eagerly resolves
-/// `SharedPreferences.getInstance()` in its constructor and caches the
-/// result for its lifetime. If a transient init failure leaves it
-/// permanently no-op'd (e.g. a Web tab that briefly lost storage access),
-/// re-opening the composer rebuilds the provider and gives storage another
-/// chance. The service itself is cheap to construct.
+/// **Keep-alive (NOT autoDispose) — intentional, revisited across reviews.**
+///
+/// We initially used `Provider.autoDispose` to let a transient init failure
+/// (Web tab that briefly lost localStorage access) recover when the user
+/// re-opens the composer. In practice that recovery path is dominated by
+/// app restart — losing localStorage between two composer opens within a
+/// single session is exceedingly rare — while autoDispose introduces a
+/// subtler hazard: `auth_provider.logout()` calls `ref.read` on this
+/// provider from outside the composer's lifecycle, which spawns a
+/// "create → immediately-discarded" instance. Today the service has no
+/// `dispose()` and the in-flight cleanup completes regardless, but the
+/// moment the service grows a teardown hook we'd be staring at a
+/// use-after-dispose bug.
+///
+/// Keep-alive is the simpler invariant. The trade-off is documented here
+/// rather than encoded as autoDispose so the next reviewer doesn't flip it
+/// back.
 ///
 /// Override in tests with an in-memory [SharedPreferences]
 /// (see test/services/create_post_draft_service_test.dart).
-final createPostDraftServiceProvider =
-    Provider.autoDispose<CreatePostDraftService>(
-      (ref) => CreatePostDraftService(),
-    );
+final createPostDraftServiceProvider = Provider<CreatePostDraftService>(
+  (ref) => CreatePostDraftService(),
+);

--- a/frontend/lib/providers/create_post_provider.dart
+++ b/frontend/lib/providers/create_post_provider.dart
@@ -2,11 +2,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 import '../graphql/client.dart';
+import 'create_post_draft_provider.dart';
 import 'disposable_notifier.dart';
 import '../graphql/mutations/connection.dart';
 import '../graphql/mutations/post.dart';
+import '../models/create_post_draft.dart';
 import '../models/post.dart';
 import '../models/track.dart';
+import '../services/create_post_draft_service.dart';
 import '../utils/sentinel.dart';
 
 /// A pending connection: target post + connection type.
@@ -73,13 +76,84 @@ class CreatePostState {
 class CreatePostNotifier extends Notifier<CreatePostState>
     with DisposableNotifier {
   late GraphQLClient _client;
+  late CreatePostDraftService _draftService;
 
   @override
   CreatePostState build() {
     _client = ref.watch(graphqlClientProvider);
+    _draftService = ref.watch(createPostDraftServiceProvider);
     initDisposable();
     return const CreatePostState();
   }
+
+  /// Restore meta-state (track, mediaType, visibility, etc.) from a draft.
+  /// Text fields (title/body/quill/media URLs) are restored by the screen
+  /// directly into its TextEditingControllers — the Notifier does not own
+  /// them. [resolvedTrack] is looked up by the screen from the user's own
+  /// tracks; if null (the track was deleted since the draft was saved),
+  /// the draft is restored with no track selected and step clamped to 0.
+  void restoreFromDraft(CreatePostDraft draft, {Track? resolvedTrack}) {
+    final track = resolvedTrack;
+    final mediaType = draft.selectedMediaType;
+    // Clamp step backward when the upstream selections are missing so the
+    // form doesn't try to render step 2 without a track.
+    var step = draft.step;
+    if (track == null) {
+      step = 0;
+    } else if (mediaType == null && step >= 2) {
+      step = 1;
+    }
+    state = CreatePostState(
+      step: step,
+      selectedTrack: track,
+      selectedMediaType: mediaType,
+      visibility: draft.visibility,
+      importance: draft.importance,
+      articleGenre: draft.articleGenre,
+      externalPublish: draft.externalPublish,
+      selectedConnections: const [],
+    );
+  }
+
+  /// Persist the current composer state alongside text-field values from
+  /// the screen. Debounce is owned by the screen.
+  Future<void> persistDraft({
+    required String userId,
+    required String title,
+    required String body,
+    String? bodyFormat,
+    String? mediaUrl,
+    List<String>? mediaUrls,
+    String? thumbnailUrl,
+    int? durationSeconds,
+    DateTime? eventAt,
+  }) async {
+    final draft = CreatePostDraft(
+      userId: userId,
+      step: state.step,
+      selectedTrackId: state.selectedTrack?.id,
+      selectedMediaType: state.selectedMediaType,
+      visibility: state.visibility,
+      importance: state.importance,
+      articleGenre: state.articleGenre,
+      externalPublish: state.externalPublish,
+      title: title,
+      body: body,
+      bodyFormat: bodyFormat,
+      mediaUrl: mediaUrl,
+      mediaUrls: mediaUrls,
+      thumbnailUrl: thumbnailUrl,
+      durationSeconds: durationSeconds,
+      eventAt: eventAt,
+      savedAt: DateTime.now().toUtc(),
+    );
+    await _draftService.save(draft);
+  }
+
+  Future<CreatePostDraft?> loadDraft(String userId) =>
+      _draftService.load(userId);
+
+  Future<void> clearDraft(String userId) => _draftService.clear(userId);
 
   void selectTrack(Track track) {
     state = state.copyWith(selectedTrack: track, step: 1, error: null);

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -8,7 +9,9 @@ import 'package:go_router/go_router.dart';
 
 import '../../models/post.dart';
 import '../../models/track.dart' show Track, parseHexColor;
+import '../../providers/auth_provider.dart';
 import '../../providers/create_post_provider.dart';
+import '../../providers/my_artist_provider.dart';
 import '../../providers/timeline_provider.dart';
 import '../../utils/constellation_layout.dart';
 import '../../utils/ime_safe_focus.dart';
@@ -58,18 +61,45 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
   // Multi-image support for image type posts
   List<String> _mediaUrls = [];
 
+  // Draft autosave ---------------------------------------------------------
+  // Userid captured from `authProvider` after the first frame. All save/load/
+  // clear calls are scoped to this id so a leftover draft from a previous
+  // session cannot be re-applied to another account.
+  String? _activeUserId;
+  // Drains controller-listener events into a single deferred save so we
+  // don't hit shared_preferences on every keystroke.
+  Timer? _saveDebounce;
+  static const _saveDebounceDuration = Duration(milliseconds: 1500);
+  // True while submit is in-flight or just succeeded — prevents the listener
+  // from re-saving stale state after we have already cleared the draft.
+  bool _suppressPersistence = false;
+  // True after `_initDraft` finishes so subsequent state changes know it is
+  // safe to write (we don't want to overwrite a not-yet-loaded draft).
+  bool _draftLoaded = false;
+
   @override
   void initState() {
     super.initState();
-    // Clear stale upload error/progress from a previous screen visit. The
-    // provider is shared (non-autoDispose) so state otherwise persists.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) ref.read(mediaUploadProvider.notifier).reset();
+    _titleController.addListener(_scheduleSave);
+    _bodyController.addListener(_scheduleSave);
+    _mediaUrlController.addListener(_scheduleSave);
+    _quillController.addListener(_scheduleSave);
+    // Persist on every meta-state change (track, mediaType, visibility, etc).
+    // We use listenManual + initState because watch-in-build would cause
+    // repeated scheduling on every rebuild.
+    ref.listenManual(createPostProvider, (_, _) => _scheduleSave());
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
+      // Clear stale upload error/progress from a previous screen visit. The
+      // provider is shared (non-autoDispose) so state otherwise persists.
+      ref.read(mediaUploadProvider.notifier).reset();
+      await _initDraft();
     });
   }
 
   @override
   void dispose() {
+    _saveDebounce?.cancel();
     _pickMediaGeneration++; // invalidate any in-flight upload
     _titleController.dispose();
     _bodyController.dispose();
@@ -81,6 +111,181 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     // Provider reset is handled in _submit() success path.
     // autoDispose cleans up when no watchers remain.
     super.dispose();
+  }
+
+  /// Restore a previously-saved draft (if any) for the current user. Called
+  /// once after the first frame. The user's own tracks are resolved through
+  /// `myArtistProvider` rather than `timelineProvider`, since the latter
+  /// holds whichever artist the user is currently browsing (fan mode would
+  /// otherwise resolve to someone else's tracks).
+  Future<void> _initDraft() async {
+    final user = ref.read(authProvider).user;
+    if (user == null) {
+      _draftLoaded = true;
+      return;
+    }
+    _activeUserId = user.id;
+    final draft = await ref
+        .read(createPostProvider.notifier)
+        .loadDraft(user.id);
+    if (!mounted) {
+      _draftLoaded = true;
+      return;
+    }
+    if (draft == null) {
+      _draftLoaded = true;
+      return;
+    }
+    // Resolve the track from the user's own tracks. A null result means the
+    // track was deleted between save and load — `restoreFromDraft` will
+    // clamp the step back to 0 in that case.
+    final myArtist = ref.read(myArtistProvider);
+    final track = (draft.selectedTrackId != null && myArtist != null)
+        ? myArtist.tracks
+              .where((t) => t.id == draft.selectedTrackId)
+              .firstOrNull
+        : null;
+    ref
+        .read(createPostProvider.notifier)
+        .restoreFromDraft(draft, resolvedTrack: track);
+    // Hydrate text fields. Removing then re-adding the listener avoids an
+    // immediate re-save round-trip.
+    _titleController.removeListener(_scheduleSave);
+    _bodyController.removeListener(_scheduleSave);
+    _mediaUrlController.removeListener(_scheduleSave);
+    _quillController.removeListener(_scheduleSave);
+    _titleController.text = draft.title;
+    _bodyController.text = draft.body;
+    _mediaUrlController.text = draft.mediaUrl ?? '';
+    if (draft.bodyFormat == 'delta' && draft.body.isNotEmpty) {
+      try {
+        final delta = jsonDecode(draft.body);
+        if (delta is List) {
+          _quillController.document = Document.fromJson(delta);
+        }
+      } catch (_) {
+        // Malformed delta — fall back to plain body in the body field.
+      }
+    }
+    _titleController.addListener(_scheduleSave);
+    _bodyController.addListener(_scheduleSave);
+    _mediaUrlController.addListener(_scheduleSave);
+    _quillController.addListener(_scheduleSave);
+
+    setState(() {
+      _mediaUrls = draft.mediaUrls ?? [];
+      _thumbnailUrl = draft.thumbnailUrl;
+      _durationSeconds = draft.durationSeconds;
+      _eventAt = draft.eventAt;
+    });
+    _draftLoaded = true;
+    // Surface restoration so the user knows their input came back.
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.draftRestoredSnackbar)),
+      );
+    }
+  }
+
+  void _scheduleSave() {
+    if (_suppressPersistence) return;
+    if (!_draftLoaded) return;
+    _saveDebounce?.cancel();
+    _saveDebounce = Timer(_saveDebounceDuration, _persistDraftNow);
+  }
+
+  Future<void> _persistDraftNow() async {
+    if (!mounted) return;
+    final userId = _activeUserId;
+    if (userId == null) return;
+    if (_suppressPersistence) return;
+    await ref
+        .read(createPostProvider.notifier)
+        .persistDraft(
+          userId: userId,
+          title: _titleController.text,
+          body: _isArticleSelected()
+              ? jsonEncode(_quillController.document.toDelta().toJson())
+              : _bodyController.text,
+          bodyFormat: _isArticleSelected() ? 'delta' : null,
+          mediaUrl: _mediaUrlController.text.isEmpty
+              ? null
+              : _mediaUrlController.text,
+          mediaUrls: _mediaUrls.isEmpty ? null : _mediaUrls,
+          thumbnailUrl: _thumbnailUrl,
+          durationSeconds: _durationSeconds,
+          eventAt: _eventAt,
+        );
+  }
+
+  bool _isArticleSelected() =>
+      ref.read(createPostProvider).selectedMediaType == MediaType.article;
+
+  /// True when at least one composer input has user-entered content. Used to
+  /// decide whether the back/dismiss path needs a discard confirmation.
+  bool _hasMeaningfulInput() {
+    final state = ref.read(createPostProvider);
+    if (state.step > 0) return true;
+    if (state.selectedTrack != null) return true;
+    if (_titleController.text.isNotEmpty) return true;
+    if (_bodyController.text.isNotEmpty) return true;
+    if (_mediaUrlController.text.isNotEmpty) return true;
+    if (_mediaUrls.isNotEmpty) return true;
+    if (!_quillController.document.isEmpty()) return true;
+    return false;
+  }
+
+  /// Show the discard confirmation. Returns true when the user chose to
+  /// throw away their input, false when they chose to keep editing.
+  /// Returns true immediately when there is nothing to throw away.
+  Future<bool> _confirmDiscard() async {
+    if (!_hasMeaningfulInput()) return true;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(context.l10n.discardPostConfirmTitle),
+        content: Text(context.l10n.discardPostConfirmMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(context.l10n.keepEditingButton),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(
+              context.l10n.discardButton,
+              style: const TextStyle(color: colorError),
+            ),
+          ),
+        ],
+      ),
+    );
+    return result == true;
+  }
+
+  /// Confirm + clear the draft + close the composer. Used both by the
+  /// AppBar back button at step 0 and the system-back path via [PopScope].
+  Future<void> _discardAndClose() async {
+    final ok = await _confirmDiscard();
+    if (!ok || !mounted) return;
+    _suppressPersistence = true;
+    _saveDebounce?.cancel();
+    final userId = _activeUserId;
+    if (userId != null) {
+      await ref.read(createPostProvider.notifier).clearDraft(userId);
+    }
+    if (!mounted) return;
+    ref.read(createPostProvider.notifier).reset();
+    if (widget.onSuccess != null) {
+      // Dialog presentation — onSuccess pops the dialog AND refreshes the
+      // timeline. For an explicit discard we just want to close the dialog,
+      // so pop directly instead.
+      Navigator.of(context).pop();
+    } else if (Navigator.of(context).canPop()) {
+      Navigator.of(context).pop();
+    } else {
+      context.go('/timeline');
+    }
   }
 
   Future<void> _pickMedia(MediaType mediaType) async {
@@ -196,6 +401,16 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
 
     if (result != null && mounted) {
       final (postedTrack, post) = result;
+      // Block the persistence listener before clearing — otherwise the
+      // ensureTrackSelected / addPost calls below could re-schedule a save
+      // and re-write the draft we are about to delete.
+      _suppressPersistence = true;
+      _saveDebounce?.cancel();
+      final userId = _activeUserId;
+      if (userId != null) {
+        await ref.read(createPostProvider.notifier).clearDraft(userId);
+      }
+      if (!mounted) return;
       final notifier = ref.read(timelineProvider.notifier);
       notifier.ensureTrackSelected(postedTrack.id);
       notifier.addPost(post);
@@ -219,67 +434,81 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     final timeline = ref.watch(timelineProvider);
     final tracks = timeline.artist?.tracks ?? [];
 
-    return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () {
-            if (state.step > 0) {
-              // Clear form inputs when going back from form step
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop) return;
+        await _discardAndClose();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () async {
               if (state.step == 2) {
+                // Going from form step back to media-type step would clear the
+                // form inputs; confirm with the user first.
+                if (!await _confirmDiscard()) return;
+                if (!mounted) return;
                 _pickMediaGeneration++; // invalidate any in-flight upload
                 _titleController.clear();
                 _bodyController.clear();
                 _mediaUrlController.clear();
                 _quillController.clear();
-                _thumbnailUrl = null;
-                _durationSeconds = null;
-                _eventAt = null;
-                _mediaUrls = [];
+                setState(() {
+                  _thumbnailUrl = null;
+                  _durationSeconds = null;
+                  _eventAt = null;
+                  _mediaUrls = [];
+                });
                 ref.read(createPostProvider.notifier).clearFormState();
+                ref.read(createPostProvider.notifier).goBack();
+              } else if (state.step > 0) {
+                // step 1 → 0 just changes the selected media type; no input is
+                // lost so no confirmation is needed.
+                ref.read(createPostProvider.notifier).goBack();
+              } else {
+                await _discardAndClose();
               }
-              ref.read(createPostProvider.notifier).goBack();
-            } else {
-              context.go('/timeline');
-            }
-          },
-        ),
-        title: Text(context.l10n.newPost),
-        bottom: PreferredSize(
-          preferredSize: const Size.fromHeight(4),
-          child: LinearProgressIndicator(
-            value: (state.step + 1) / 3,
-            backgroundColor: Theme.of(
-              context,
-            ).colorScheme.surfaceContainerHighest,
+            },
+          ),
+          title: Text(context.l10n.newPost),
+          bottom: PreferredSize(
+            preferredSize: const Size.fromHeight(4),
+            child: LinearProgressIndicator(
+              value: (state.step + 1) / 3,
+              backgroundColor: Theme.of(
+                context,
+              ).colorScheme.surfaceContainerHighest,
+            ),
           ),
         ),
-      ),
-      body: SafeArea(
-        child: AnimatedSwitcher(
-          duration: const Duration(milliseconds: 200),
-          child: switch (state.step) {
-            0 => _TrackStep(tracks: tracks),
-            1 => const _MediaTypeStep(),
-            _ => _FormStep(
-              formKey: _formKey,
-              titleController: _titleController,
-              bodyController: _bodyController,
-              quillController: _quillController,
-              mediaUrlController: _mediaUrlController,
-              thumbnailUrl: _thumbnailUrl,
-              durationSeconds: _durationSeconds,
-              urlFocusNode: _urlFocusNode,
-              linkTitleFocusNode: _linkTitleFocusNode,
-              linkCaptionFocusNode: _linkCaptionFocusNode,
-              eventAt: _eventAt,
-              onEventAtChanged: (dt) => setState(() => _eventAt = dt),
-              onSubmit: _submit,
-              onPickMedia: _pickMedia,
-              mediaUrls: _mediaUrls,
-              onMediaUrlsChanged: (urls) => setState(() => _mediaUrls = urls),
-            ),
-          },
+        body: SafeArea(
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 200),
+            child: switch (state.step) {
+              0 => _TrackStep(tracks: tracks),
+              1 => const _MediaTypeStep(),
+              _ => _FormStep(
+                formKey: _formKey,
+                titleController: _titleController,
+                bodyController: _bodyController,
+                quillController: _quillController,
+                mediaUrlController: _mediaUrlController,
+                thumbnailUrl: _thumbnailUrl,
+                durationSeconds: _durationSeconds,
+                urlFocusNode: _urlFocusNode,
+                linkTitleFocusNode: _linkTitleFocusNode,
+                linkCaptionFocusNode: _linkCaptionFocusNode,
+                eventAt: _eventAt,
+                onEventAtChanged: (dt) => setState(() => _eventAt = dt),
+                onSubmit: _submit,
+                onPickMedia: _pickMedia,
+                mediaUrls: _mediaUrls,
+                onMediaUrlsChanged: (urls) => setState(() => _mediaUrls = urls),
+              ),
+            },
+          ),
         ),
       ),
     );

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -85,6 +85,12 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
   // don't tear these down ourselves.
   ProviderSubscription<CreatePostState>? _composerSub;
   ProviderSubscription<AuthState>? _authSub;
+  // Subscribed to `_quillController.document.changes` rather than the
+  // controller itself: `QuillController` extends ChangeNotifier and fires
+  // on every cursor/selection change too, which would re-arm the debounce
+  // Timer on each keystroke navigation and churn the GC for long article
+  // editing sessions on Web CanvasKit. We only care about document edits.
+  StreamSubscription<DocChange>? _quillChangesSub;
 
   @override
   void initState() {
@@ -92,7 +98,7 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     _titleController.addListener(_scheduleSave);
     _bodyController.addListener(_scheduleSave);
     _mediaUrlController.addListener(_scheduleSave);
-    _quillController.addListener(_scheduleSave);
+    _subscribeToQuillChanges();
     // Persist on every meta-state change (track, mediaType, visibility, etc).
     // listenManual (not watch-in-build) avoids re-registering the listener
     // on every rebuild.
@@ -133,6 +139,7 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     _saveDebounce?.cancel();
     _composerSub?.close();
     _authSub?.close();
+    _quillChangesSub?.cancel();
     _pickMediaGeneration++; // invalidate any in-flight upload
     _titleController.dispose();
     _bodyController.dispose();
@@ -144,6 +151,17 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     // Provider reset is handled in _submit() success path.
     // autoDispose cleans up when no watchers remain.
     super.dispose();
+  }
+
+  /// (Re-)subscribe to the current Quill document's change stream. Called
+  /// from `initState` and after we swap in a hydrated document in
+  /// `_initDraft` (Document instances are immutable per assignment, so the
+  /// previous stream stops emitting once we reassign).
+  void _subscribeToQuillChanges() {
+    _quillChangesSub?.cancel();
+    _quillChangesSub = _quillController.document.changes.listen(
+      (_) => _scheduleSave(),
+    );
   }
 
   /// Restore a previously-saved draft (if any) for the current user. Called
@@ -177,13 +195,17 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
               .where((t) => t.id == draft.selectedTrackId)
               .firstOrNull
         : null;
-    ref
-        .read(createPostProvider.notifier)
-        .restoreFromDraft(draft, resolvedTrack: track);
-    // Hydrate text fields while persistence is suppressed so we don't
-    // immediately re-write what we just loaded. `_scheduleSave` and
-    // `_persistDraftNow` both early-return on `_suppressPersistence`.
+    // Hydrate all of: Riverpod meta state, text controllers, the Quill
+    // document — all while persistence is suppressed. Including the
+    // `restoreFromDraft` call in here matters because `_composerSub`
+    // listens on createPostProvider and would otherwise schedule one
+    // unneeded save the moment we restore. Both `_scheduleSave` and
+    // `_persistDraftNow` short-circuit on `_suppressPersistence`.
+    var quillDocReplaced = false;
     _withSuppressedSave(() {
+      ref
+          .read(createPostProvider.notifier)
+          .restoreFromDraft(draft, resolvedTrack: track);
       _titleController.text = draft.title;
       _mediaUrlController.text = draft.mediaUrl ?? '';
       // The body store is format-dependent — delta JSON belongs to the Quill
@@ -197,6 +219,7 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
             final delta = jsonDecode(draft.body);
             if (delta is List) {
               _quillController.document = Document.fromJson(delta);
+              quillDocReplaced = true;
             }
           } catch (_) {
             // Malformed delta — leave the Quill doc empty rather than show
@@ -207,6 +230,12 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
         _bodyController.text = draft.body;
       }
     });
+    // The previous subscription was bound to the old Document instance.
+    // After `_quillController.document = ...`, that stream is detached —
+    // re-subscribe so subsequent edits still trigger autosave.
+    if (quillDocReplaced) {
+      _subscribeToQuillChanges();
+    }
 
     if (!mounted) return;
     setState(() {
@@ -215,19 +244,29 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
       _durationSeconds = draft.durationSeconds;
       _eventAt = draft.eventAt;
     });
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.draftRestoredSnackbar),
-          duration: const Duration(seconds: 2),
-        ),
-      );
-    }
+    // setState above already guards on mounted; no second check needed here.
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.draftRestoredSnackbar),
+        duration: const Duration(seconds: 2),
+      ),
+    );
   }
 
   /// Run [fn] with persistence suppressed and restore the previous state
-  /// after. Used during hydration so the controller setters we trigger
-  /// don't kick off a write of the data we just loaded.
+  /// after. Used for any block that programmatically mutates the
+  /// controllers / Riverpod state without wanting to fire autosave:
+  ///
+  /// - draft hydration in `_initDraft` (we just loaded the data, no point
+  ///   re-saving it)
+  /// - step-2 discard back path (we already called `clearDraft` and the
+  ///   `.clear()` calls below would otherwise re-save an empty draft 1.5s
+  ///   later)
+  ///
+  /// The previous value is restored on exit instead of being hardcoded to
+  /// `false` so this can nest inside an outer suppress block (e.g.
+  /// `dispose()` permanent suppress) without unintentionally re-enabling
+  /// saves halfway through teardown.
   void _withSuppressedSave(VoidCallback fn) {
     final prev = _suppressPersistence;
     _suppressPersistence = true;
@@ -254,6 +293,12 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     if (!mounted) return;
     final userId = _activeUserId;
     if (userId == null) return;
+    // All controller / state reads happen synchronously BEFORE the await
+    // so they capture the value at call time. The await below only writes
+    // to shared_preferences via the (lifetime-independent) draft service —
+    // it does not touch any widget state on return, so it is safe even if
+    // the widget is disposed mid-await. If `persistDraft` ever grows to
+    // touch the widget after the await, add another mounted check here.
     await ref
         .read(createPostProvider.notifier)
         .persistDraft(
@@ -520,6 +565,11 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
                       .clearDraft(userId);
                 }
                 if (!mounted) return;
+                // Wrap in `_withSuppressedSave` (not a permanent suppress)
+                // so autosave resumes for the new step. The user is still
+                // editing the same post — they may pick a different media
+                // type next and we want changes from that point on to be
+                // persisted normally.
                 _withSuppressedSave(() {
                   _pickMediaGeneration++; // invalidate any in-flight upload
                   _titleController.clear();

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -106,6 +106,9 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     // the draft on the way out; this listener prevents us from re-writing
     // it 1.5s later from a debounced timer.
     _authSub = ref.listenManual(authProvider, (prev, next) {
+      // Defensive: dispose() closes this subscription, but a late-delivered
+      // change-notification could otherwise touch a torn-down widget.
+      if (!mounted) return;
       final prevId = prev?.user?.id;
       final nextId = next.user?.id;
       if (prevId != nextId) {
@@ -158,11 +161,13 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     final draft = await ref
         .read(createPostProvider.notifier)
         .loadDraft(user.id);
+    // Mark loaded BEFORE the mounted check. Otherwise a widget that is
+    // briefly unmounted during draft load and then survives (e.g. a parent
+    // animation that triggered the early return raced with a remount) would
+    // leave `_draftLoaded` false forever, silently disabling autosave.
+    _draftLoaded = true;
     if (!mounted) return;
-    if (draft == null) {
-      _draftLoaded = true;
-      return;
-    }
+    if (draft == null) return;
     // Resolve the track from the user's own tracks. A null result means the
     // track was deleted between save and load — `restoreFromDraft` will
     // clamp the step back to 0 in that case.
@@ -210,7 +215,6 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
       _durationSeconds = draft.durationSeconds;
       _eventAt = draft.eventAt;
     });
-    _draftLoaded = true;
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -497,23 +501,40 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
             icon: const Icon(Icons.arrow_back),
             onPressed: () async {
               if (state.step == 2) {
-                // Going from form step back to media-type step would clear the
-                // form inputs; confirm with the user first.
+                // Going from form step back to media-type step would clear
+                // the form inputs; confirm with the user first.
                 if (!await _confirmDiscard()) return;
                 if (!mounted) return;
-                _pickMediaGeneration++; // invalidate any in-flight upload
-                _titleController.clear();
-                _bodyController.clear();
-                _mediaUrlController.clear();
-                _quillController.clear();
-                setState(() {
-                  _thumbnailUrl = null;
-                  _durationSeconds = null;
-                  _eventAt = null;
-                  _mediaUrls = [];
+                // The user explicitly chose to throw away the form. Tear
+                // down the persisted draft synchronously BEFORE clearing
+                // the controllers — otherwise the `.clear()` calls below
+                // would fire the controller listeners → schedule a save →
+                // 1.5s later we'd silently overwrite the draft with empty
+                // values, making the next composer-open feel like the
+                // discard never happened.
+                _saveDebounce?.cancel();
+                final userId = _activeUserId;
+                if (userId != null) {
+                  await ref
+                      .read(createPostProvider.notifier)
+                      .clearDraft(userId);
+                }
+                if (!mounted) return;
+                _withSuppressedSave(() {
+                  _pickMediaGeneration++; // invalidate any in-flight upload
+                  _titleController.clear();
+                  _bodyController.clear();
+                  _mediaUrlController.clear();
+                  _quillController.clear();
+                  setState(() {
+                    _thumbnailUrl = null;
+                    _durationSeconds = null;
+                    _eventAt = null;
+                    _mediaUrls = [];
+                  });
+                  ref.read(createPostProvider.notifier).clearFormState();
+                  ref.read(createPostProvider.notifier).goBack();
                 });
-                ref.read(createPostProvider.notifier).clearFormState();
-                ref.read(createPostProvider.notifier).goBack();
               } else if (state.step > 0) {
                 // step 1 → 0 just changes the selected media type; no input is
                 // lost so no confirmation is needed.

--- a/frontend/lib/screens/create_post/create_post_screen.dart
+++ b/frontend/lib/screens/create_post/create_post_screen.dart
@@ -70,12 +70,21 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
   // don't hit shared_preferences on every keystroke.
   Timer? _saveDebounce;
   static const _saveDebounceDuration = Duration(milliseconds: 1500);
-  // True while submit is in-flight or just succeeded — prevents the listener
-  // from re-saving stale state after we have already cleared the draft.
+  // Persistence gate. Set true to immediately block any pending or future
+  // save. Read by `_scheduleSave` AND `_persistDraftNow` — the latter
+  // matters because a Timer that has already fired cannot be cancelled,
+  // so the guard inside the callback is the final safety net for
+  // dispose/logout/submit-success races.
   bool _suppressPersistence = false;
   // True after `_initDraft` finishes so subsequent state changes know it is
   // safe to write (we don't want to overwrite a not-yet-loaded draft).
   bool _draftLoaded = false;
+  // Held subscriptions for explicit close on dispose. Riverpod's automatic
+  // cleanup is best-effort across ConsumerStatefulWidget; an in-flight
+  // notification on a disposed Element can still reach the listener if we
+  // don't tear these down ourselves.
+  ProviderSubscription<CreatePostState>? _composerSub;
+  ProviderSubscription<AuthState>? _authSub;
 
   @override
   void initState() {
@@ -85,9 +94,25 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     _mediaUrlController.addListener(_scheduleSave);
     _quillController.addListener(_scheduleSave);
     // Persist on every meta-state change (track, mediaType, visibility, etc).
-    // We use listenManual + initState because watch-in-build would cause
-    // repeated scheduling on every rebuild.
-    ref.listenManual(createPostProvider, (_, _) => _scheduleSave());
+    // listenManual (not watch-in-build) avoids re-registering the listener
+    // on every rebuild.
+    _composerSub = ref.listenManual(
+      createPostProvider,
+      (_, _) => _scheduleSave(),
+    );
+    // If the authenticated user changes mid-session (logout / account
+    // switch / forced JWT expiry), stop persisting immediately so we don't
+    // re-save a draft for the outgoing user. `auth_provider.logout()` clears
+    // the draft on the way out; this listener prevents us from re-writing
+    // it 1.5s later from a debounced timer.
+    _authSub = ref.listenManual(authProvider, (prev, next) {
+      final prevId = prev?.user?.id;
+      final nextId = next.user?.id;
+      if (prevId != nextId) {
+        _suppressPersistence = true;
+        _saveDebounce?.cancel();
+      }
+    });
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
       // Clear stale upload error/progress from a previous screen visit. The
@@ -99,7 +124,12 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
 
   @override
   void dispose() {
+    // Block any in-flight Timer callback that already escaped `cancel()`
+    // BEFORE tearing down the controllers it would read from.
+    _suppressPersistence = true;
     _saveDebounce?.cancel();
+    _composerSub?.close();
+    _authSub?.close();
     _pickMediaGeneration++; // invalidate any in-flight upload
     _titleController.dispose();
     _bodyController.dispose();
@@ -128,10 +158,7 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     final draft = await ref
         .read(createPostProvider.notifier)
         .loadDraft(user.id);
-    if (!mounted) {
-      _draftLoaded = true;
-      return;
-    }
+    if (!mounted) return;
     if (draft == null) {
       _draftLoaded = true;
       return;
@@ -148,30 +175,35 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
     ref
         .read(createPostProvider.notifier)
         .restoreFromDraft(draft, resolvedTrack: track);
-    // Hydrate text fields. Removing then re-adding the listener avoids an
-    // immediate re-save round-trip.
-    _titleController.removeListener(_scheduleSave);
-    _bodyController.removeListener(_scheduleSave);
-    _mediaUrlController.removeListener(_scheduleSave);
-    _quillController.removeListener(_scheduleSave);
-    _titleController.text = draft.title;
-    _bodyController.text = draft.body;
-    _mediaUrlController.text = draft.mediaUrl ?? '';
-    if (draft.bodyFormat == 'delta' && draft.body.isNotEmpty) {
-      try {
-        final delta = jsonDecode(draft.body);
-        if (delta is List) {
-          _quillController.document = Document.fromJson(delta);
+    // Hydrate text fields while persistence is suppressed so we don't
+    // immediately re-write what we just loaded. `_scheduleSave` and
+    // `_persistDraftNow` both early-return on `_suppressPersistence`.
+    _withSuppressedSave(() {
+      _titleController.text = draft.title;
+      _mediaUrlController.text = draft.mediaUrl ?? '';
+      // The body store is format-dependent — delta JSON belongs to the Quill
+      // controller and must NOT leak into the plain-text body controller,
+      // otherwise switching from `article` to another media type would
+      // surface raw JSON to the user.
+      if (draft.bodyFormat == 'delta') {
+        _bodyController.text = '';
+        if (draft.body.isNotEmpty) {
+          try {
+            final delta = jsonDecode(draft.body);
+            if (delta is List) {
+              _quillController.document = Document.fromJson(delta);
+            }
+          } catch (_) {
+            // Malformed delta — leave the Quill doc empty rather than show
+            // raw JSON in the rich-text editor.
+          }
         }
-      } catch (_) {
-        // Malformed delta — fall back to plain body in the body field.
+      } else {
+        _bodyController.text = draft.body;
       }
-    }
-    _titleController.addListener(_scheduleSave);
-    _bodyController.addListener(_scheduleSave);
-    _mediaUrlController.addListener(_scheduleSave);
-    _quillController.addListener(_scheduleSave);
+    });
 
+    if (!mounted) return;
     setState(() {
       _mediaUrls = draft.mediaUrls ?? [];
       _thumbnailUrl = draft.thumbnailUrl;
@@ -179,11 +211,26 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
       _eventAt = draft.eventAt;
     });
     _draftLoaded = true;
-    // Surface restoration so the user knows their input came back.
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(context.l10n.draftRestoredSnackbar)),
+        SnackBar(
+          content: Text(context.l10n.draftRestoredSnackbar),
+          duration: const Duration(seconds: 2),
+        ),
       );
+    }
+  }
+
+  /// Run [fn] with persistence suppressed and restore the previous state
+  /// after. Used during hydration so the controller setters we trigger
+  /// don't kick off a write of the data we just loaded.
+  void _withSuppressedSave(VoidCallback fn) {
+    final prev = _suppressPersistence;
+    _suppressPersistence = true;
+    try {
+      fn();
+    } finally {
+      _suppressPersistence = prev;
     }
   }
 
@@ -195,10 +242,14 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
   }
 
   Future<void> _persistDraftNow() async {
+    // Order matters: check the gate FIRST, then mounted. A Timer that fired
+    // microseconds before dispose() ran will still execute this callback,
+    // but `dispose()` set `_suppressPersistence` to true synchronously
+    // before tearing down the controllers below us.
+    if (_suppressPersistence) return;
     if (!mounted) return;
     final userId = _activeUserId;
     if (userId == null) return;
-    if (_suppressPersistence) return;
     await ref
         .read(createPostProvider.notifier)
         .persistDraft(

--- a/frontend/lib/services/create_post_draft_service.dart
+++ b/frontend/lib/services/create_post_draft_service.dart
@@ -9,21 +9,47 @@ import '../models/create_post_draft.dart';
 /// logout path is bypassed (e.g. JWT expiry).
 ///
 /// All exceptions are swallowed: a corrupted or unreadable draft must never
-/// block the post composer from opening.
+/// block the post composer from opening. Specifically, if
+/// `SharedPreferences.getInstance()` itself throws — possible on Web when
+/// localStorage is disabled (private/incognito with strict cookie blocking,
+/// some embedded browsers) — every method below becomes a quiet no-op
+/// instead of cascading failures up into the composer.
 class CreatePostDraftService {
   static const String _keyPrefix = 'create_post_draft_';
 
-  final Future<SharedPreferences> Function() _prefsFactory;
+  /// Eagerly-started, cached future. Initialization runs once per instance
+  /// and the same `Future` is awaited by every save/load/clear call.
+  /// Resolves to `null` when the underlying store is unavailable, which
+  /// switches every operation into a no-op.
+  final Future<SharedPreferences?> _prefs;
 
   CreatePostDraftService({Future<SharedPreferences> Function()? prefsFactory})
-    : _prefsFactory = prefsFactory ?? SharedPreferences.getInstance;
+    : _prefs = _initialize(prefsFactory ?? SharedPreferences.getInstance);
+
+  static Future<SharedPreferences?> _initialize(
+    Future<SharedPreferences> Function() factory,
+  ) async {
+    try {
+      return await factory();
+    } catch (e) {
+      // One log line on init failure — every subsequent save/load/clear
+      // becomes a silent no-op so we don't spam logs for a known-broken
+      // environment.
+      debugPrint(
+        '[CreatePostDraftService] SharedPreferences unavailable, '
+        'draft autosave disabled: $e',
+      );
+      return null;
+    }
+  }
 
   String _keyFor(String userId) => '$_keyPrefix$userId';
 
   /// Save (overwrite) the draft for [draft.userId].
   Future<void> save(CreatePostDraft draft) async {
+    final prefs = await _prefs;
+    if (prefs == null) return;
     try {
-      final prefs = await _prefsFactory();
       await prefs.setString(_keyFor(draft.userId), draft.toJsonString());
     } catch (e) {
       debugPrint('[CreatePostDraftService] save failed: $e');
@@ -33,8 +59,9 @@ class CreatePostDraftService {
   /// Load the draft for [userId]. Returns null if no draft is stored, the
   /// payload is malformed, or the stored `userId` does not match.
   Future<CreatePostDraft?> load(String userId) async {
+    final prefs = await _prefs;
+    if (prefs == null) return null;
     try {
-      final prefs = await _prefsFactory();
       final raw = prefs.getString(_keyFor(userId));
       if (raw == null || raw.isEmpty) return null;
       final draft = CreatePostDraft.tryDecode(raw, expectedUserId: userId);
@@ -54,8 +81,9 @@ class CreatePostDraftService {
   /// Clear the draft for [userId]. Called on submit success, explicit
   /// discard, and logout.
   Future<void> clear(String userId) async {
+    final prefs = await _prefs;
+    if (prefs == null) return;
     try {
-      final prefs = await _prefsFactory();
       await prefs.remove(_keyFor(userId));
     } catch (e) {
       debugPrint('[CreatePostDraftService] clear failed: $e');

--- a/frontend/lib/services/create_post_draft_service.dart
+++ b/frontend/lib/services/create_post_draft_service.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/create_post_draft.dart';
+
+/// Persistence layer for [CreatePostDraft]. Stores one draft per user under
+/// the key `create_post_draft_<userId>` so a leftover draft from a previous
+/// account cannot leak across accounts on the same device — even if the
+/// logout path is bypassed (e.g. JWT expiry).
+///
+/// All exceptions are swallowed: a corrupted or unreadable draft must never
+/// block the post composer from opening.
+class CreatePostDraftService {
+  static const String _keyPrefix = 'create_post_draft_';
+
+  final Future<SharedPreferences> Function() _prefsFactory;
+
+  CreatePostDraftService({Future<SharedPreferences> Function()? prefsFactory})
+    : _prefsFactory = prefsFactory ?? SharedPreferences.getInstance;
+
+  String _keyFor(String userId) => '$_keyPrefix$userId';
+
+  /// Save (overwrite) the draft for [draft.userId].
+  Future<void> save(CreatePostDraft draft) async {
+    try {
+      final prefs = await _prefsFactory();
+      await prefs.setString(_keyFor(draft.userId), draft.toJsonString());
+    } catch (e) {
+      debugPrint('[CreatePostDraftService] save failed: $e');
+    }
+  }
+
+  /// Load the draft for [userId]. Returns null if no draft is stored, the
+  /// payload is malformed, or the stored `userId` does not match.
+  Future<CreatePostDraft?> load(String userId) async {
+    try {
+      final prefs = await _prefsFactory();
+      final raw = prefs.getString(_keyFor(userId));
+      if (raw == null || raw.isEmpty) return null;
+      final draft = CreatePostDraft.tryDecode(raw, expectedUserId: userId);
+      if (draft == null) {
+        // Corrupted or mismatched payload — proactively clear it so we
+        // don't keep trying to decode the same garbage on every open.
+        await prefs.remove(_keyFor(userId));
+        return null;
+      }
+      return draft;
+    } catch (e) {
+      debugPrint('[CreatePostDraftService] load failed: $e');
+      return null;
+    }
+  }
+
+  /// Clear the draft for [userId]. Called on submit success, explicit
+  /// discard, and logout.
+  Future<void> clear(String userId) async {
+    try {
+      final prefs = await _prefsFactory();
+      await prefs.remove(_keyFor(userId));
+    } catch (e) {
+      debugPrint('[CreatePostDraftService] clear failed: $e');
+    }
+  }
+}

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -676,14 +676,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -744,18 +736,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1013,7 +1005,7 @@ packages:
     source: hosted
     version: "0.28.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
@@ -1181,26 +1173,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   graphql_flutter: ^5.2.0-beta.7
   go_router: ^17.2.3
   flutter_secure_storage: ^10.0.0
+  shared_preferences: ^2.3.5
   collection: ^1.18.0
   google_fonts: ^8.1.0
   flutter_svg: ^2.1.0

--- a/frontend/test/models/create_post_draft_test.dart
+++ b/frontend/test/models/create_post_draft_test.dart
@@ -1,0 +1,242 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:gleisner_web/models/create_post_draft.dart';
+import 'package:gleisner_web/models/post.dart';
+
+void main() {
+  group('CreatePostDraft.toJsonString / tryDecode round-trip', () {
+    test('preserves all fields', () {
+      final original = CreatePostDraft(
+        userId: 'user-1',
+        step: 2,
+        selectedTrackId: 'track-1',
+        selectedMediaType: MediaType.article,
+        visibility: 'draft',
+        importance: 0.75,
+        articleGenre: ArticleGenre.essay,
+        externalPublish: true,
+        title: 'Hello',
+        body: 'World',
+        bodyFormat: 'delta',
+        mediaUrl: 'https://example.com/a.jpg',
+        mediaUrls: const [
+          'https://example.com/a.jpg',
+          'https://example.com/b.jpg',
+        ],
+        thumbnailUrl: 'https://example.com/thumb.jpg',
+        durationSeconds: 42,
+        eventAt: DateTime.utc(2026, 4, 1, 12),
+        savedAt: DateTime.utc(2026, 5, 16, 10),
+      );
+
+      final round = CreatePostDraft.tryDecode(
+        original.toJsonString(),
+        expectedUserId: 'user-1',
+      );
+
+      expect(round, isNotNull);
+      expect(round!.userId, 'user-1');
+      expect(round.step, 2);
+      expect(round.selectedTrackId, 'track-1');
+      expect(round.selectedMediaType, MediaType.article);
+      expect(round.visibility, 'draft');
+      expect(round.importance, 0.75);
+      expect(round.articleGenre, ArticleGenre.essay);
+      expect(round.externalPublish, true);
+      expect(round.title, 'Hello');
+      expect(round.body, 'World');
+      expect(round.bodyFormat, 'delta');
+      expect(round.mediaUrl, 'https://example.com/a.jpg');
+      expect(round.mediaUrls, [
+        'https://example.com/a.jpg',
+        'https://example.com/b.jpg',
+      ]);
+      expect(round.thumbnailUrl, 'https://example.com/thumb.jpg');
+      expect(round.durationSeconds, 42);
+      expect(round.eventAt, DateTime.utc(2026, 4, 1, 12));
+    });
+  });
+
+  group('CreatePostDraft.tryDecode security / validation', () {
+    CreatePostDraft baseline() => CreatePostDraft(
+      userId: 'user-1',
+      step: 1,
+      savedAt: DateTime.utc(2026, 5, 16),
+    );
+
+    test('rejects mismatched userId', () {
+      final draft = baseline();
+      final result = CreatePostDraft.tryDecode(
+        draft.toJsonString(),
+        expectedUserId: 'someone-else',
+      );
+      expect(result, isNull);
+    });
+
+    test('rejects payload without userId', () {
+      final raw = jsonEncode({'step': 1, 'visibility': 'public'});
+      final result = CreatePostDraft.tryDecode(raw, expectedUserId: 'user-1');
+      expect(result, isNull);
+    });
+
+    test('rejects malformed JSON', () {
+      final result = CreatePostDraft.tryDecode(
+        '{not-json',
+        expectedUserId: 'user-1',
+      );
+      expect(result, isNull);
+    });
+
+    test('rejects JSON whose root is not an object', () {
+      final result = CreatePostDraft.tryDecode('[]', expectedUserId: 'user-1');
+      expect(result, isNull);
+    });
+
+    test('falls back to "public" for unknown visibility', () {
+      final raw = jsonEncode({
+        'userId': 'user-1',
+        'visibility': 'private', // not in allow-list {public, draft}
+        'savedAt': DateTime.utc(2026, 5, 16).toIso8601String(),
+      });
+      final result = CreatePostDraft.tryDecode(raw, expectedUserId: 'user-1');
+      expect(result?.visibility, 'public');
+    });
+
+    test('falls back to "public" when visibility is not a string', () {
+      final raw = jsonEncode({
+        'userId': 'user-1',
+        'visibility': 42,
+        'savedAt': DateTime.utc(2026, 5, 16).toIso8601String(),
+      });
+      final result = CreatePostDraft.tryDecode(raw, expectedUserId: 'user-1');
+      expect(result?.visibility, 'public');
+    });
+
+    test('clamps step to 0..2', () {
+      final raw = jsonEncode({
+        'userId': 'user-1',
+        'step': 999,
+        'savedAt': DateTime.utc(2026, 5, 16).toIso8601String(),
+      });
+      final result = CreatePostDraft.tryDecode(raw, expectedUserId: 'user-1');
+      expect(result?.step, 2);
+    });
+
+    test('clamps step to 0 when value is negative', () {
+      final raw = jsonEncode({
+        'userId': 'user-1',
+        'step': -5,
+        'savedAt': DateTime.utc(2026, 5, 16).toIso8601String(),
+      });
+      final result = CreatePostDraft.tryDecode(raw, expectedUserId: 'user-1');
+      expect(result?.step, 0);
+    });
+
+    test('clamps importance to 0.0..1.0', () {
+      final raw = jsonEncode({
+        'userId': 'user-1',
+        'importance': 17.0,
+        'savedAt': DateTime.utc(2026, 5, 16).toIso8601String(),
+      });
+      final result = CreatePostDraft.tryDecode(raw, expectedUserId: 'user-1');
+      expect(result?.importance, 1.0);
+    });
+
+    test('drops unknown articleGenre rather than throwing', () {
+      final raw = jsonEncode({
+        'userId': 'user-1',
+        'articleGenre': 'not_a_real_genre',
+        'savedAt': DateTime.utc(2026, 5, 16).toIso8601String(),
+      });
+      final result = CreatePostDraft.tryDecode(raw, expectedUserId: 'user-1');
+      expect(result, isNotNull);
+      expect(result!.articleGenre, isNull);
+    });
+
+    test('drops unknown selectedMediaType rather than throwing', () {
+      final raw = jsonEncode({
+        'userId': 'user-1',
+        'selectedMediaType': 'hologram',
+        'savedAt': DateTime.utc(2026, 5, 16).toIso8601String(),
+      });
+      final result = CreatePostDraft.tryDecode(raw, expectedUserId: 'user-1');
+      expect(result, isNotNull);
+      expect(result!.selectedMediaType, isNull);
+    });
+
+    test('filters non-string entries out of mediaUrls', () {
+      final raw = jsonEncode({
+        'userId': 'user-1',
+        'mediaUrls': [
+          'https://example.com/a.jpg',
+          42,
+          null,
+          'https://example.com/b.jpg',
+        ],
+        'savedAt': DateTime.utc(2026, 5, 16).toIso8601String(),
+      });
+      final result = CreatePostDraft.tryDecode(raw, expectedUserId: 'user-1');
+      expect(result?.mediaUrls, [
+        'https://example.com/a.jpg',
+        'https://example.com/b.jpg',
+      ]);
+    });
+
+    test('returns null mediaUrls when value is not a list', () {
+      final raw = jsonEncode({
+        'userId': 'user-1',
+        'mediaUrls': 'oops',
+        'savedAt': DateTime.utc(2026, 5, 16).toIso8601String(),
+      });
+      final result = CreatePostDraft.tryDecode(raw, expectedUserId: 'user-1');
+      expect(result?.mediaUrls, isNull);
+    });
+  });
+
+  group('CreatePostDraft.hasMeaningfulInput', () {
+    CreatePostDraft empty() =>
+        CreatePostDraft(userId: 'user-1', savedAt: DateTime.utc(2026, 5, 16));
+
+    test('false for a fresh step-0 draft with no input', () {
+      expect(empty().hasMeaningfulInput, isFalse);
+    });
+
+    test('true when step has advanced', () {
+      final d = CreatePostDraft(
+        userId: 'user-1',
+        step: 1,
+        savedAt: DateTime.utc(2026, 5, 16),
+      );
+      expect(d.hasMeaningfulInput, isTrue);
+    });
+
+    test('true when a track has been selected', () {
+      final d = CreatePostDraft(
+        userId: 'user-1',
+        selectedTrackId: 'track-1',
+        savedAt: DateTime.utc(2026, 5, 16),
+      );
+      expect(d.hasMeaningfulInput, isTrue);
+    });
+
+    test('true when title is non-empty', () {
+      final d = CreatePostDraft(
+        userId: 'user-1',
+        title: 'hello',
+        savedAt: DateTime.utc(2026, 5, 16),
+      );
+      expect(d.hasMeaningfulInput, isTrue);
+    });
+
+    test('true when mediaUrls contains items', () {
+      final d = CreatePostDraft(
+        userId: 'user-1',
+        mediaUrls: const ['https://example.com/a.jpg'],
+        savedAt: DateTime.utc(2026, 5, 16),
+      );
+      expect(d.hasMeaningfulInput, isTrue);
+    });
+  });
+}

--- a/frontend/test/services/create_post_draft_service_test.dart
+++ b/frontend/test/services/create_post_draft_service_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:gleisner_web/models/create_post_draft.dart';
+import 'package:gleisner_web/models/post.dart';
+import 'package:gleisner_web/services/create_post_draft_service.dart';
+
+void main() {
+  late CreatePostDraftService service;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    service = CreatePostDraftService();
+  });
+
+  CreatePostDraft sampleDraft({String userId = 'user-1'}) => CreatePostDraft(
+    userId: userId,
+    step: 2,
+    selectedTrackId: 'track-1',
+    selectedMediaType: MediaType.thought,
+    visibility: 'public',
+    importance: 0.5,
+    title: 'hello',
+    body: 'world',
+    savedAt: DateTime.utc(2026, 5, 16),
+  );
+
+  test('save then load returns equivalent draft', () async {
+    await service.save(sampleDraft());
+
+    final loaded = await service.load('user-1');
+
+    expect(loaded, isNotNull);
+    expect(loaded!.userId, 'user-1');
+    expect(loaded.title, 'hello');
+    expect(loaded.body, 'world');
+    expect(loaded.selectedTrackId, 'track-1');
+    expect(loaded.selectedMediaType, MediaType.thought);
+  });
+
+  test('load returns null when no draft is stored', () async {
+    final loaded = await service.load('user-1');
+    expect(loaded, isNull);
+  });
+
+  test('load returns null when called with a different userId', () async {
+    await service.save(sampleDraft(userId: 'user-1'));
+
+    // shared_preferences key is user-scoped: a different userId looks at a
+    // different key entirely.
+    final loaded = await service.load('user-2');
+    expect(loaded, isNull);
+  });
+
+  test(
+    'load returns null and clears the slot when payload is corrupted',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        'create_post_draft_user-1': '{not-json',
+      });
+      final svc = CreatePostDraftService();
+
+      final loaded = await svc.load('user-1');
+      expect(loaded, isNull);
+
+      // A subsequent load should remain null (the corrupted slot was wiped).
+      final loadedAgain = await svc.load('user-1');
+      expect(loadedAgain, isNull);
+    },
+  );
+
+  test('clear removes the stored draft for that user only', () async {
+    await service.save(sampleDraft(userId: 'user-1'));
+    await service.save(sampleDraft(userId: 'user-2'));
+
+    await service.clear('user-1');
+
+    expect(await service.load('user-1'), isNull);
+    expect(await service.load('user-2'), isNotNull);
+  });
+
+  test('save overwrites the previous draft for the same user', () async {
+    await service.save(sampleDraft());
+    await service.save(
+      CreatePostDraft(
+        userId: 'user-1',
+        title: 'second',
+        savedAt: DateTime.utc(2026, 5, 16, 10),
+      ),
+    );
+
+    final loaded = await service.load('user-1');
+    expect(loaded?.title, 'second');
+  });
+}

--- a/frontend/test/services/create_post_draft_service_test.dart
+++ b/frontend/test/services/create_post_draft_service_test.dart
@@ -92,4 +92,37 @@ void main() {
     final loaded = await service.load('user-1');
     expect(loaded?.title, 'second');
   });
+
+  group('SharedPreferences unavailable (Web localStorage disabled etc.)', () {
+    // Simulates the case where `SharedPreferences.getInstance()` throws —
+    // private/incognito browsers with strict cookie blocking, embedded
+    // webviews with disabled storage, etc. The service must downgrade to
+    // a quiet no-op rather than cascading the exception into the composer.
+    late CreatePostDraftService unavailable;
+
+    setUp(() {
+      unavailable = CreatePostDraftService(
+        prefsFactory: () =>
+            Future.error(StateError('SharedPreferences unavailable for test')),
+      );
+    });
+
+    test('save does not throw when prefs are unavailable', () async {
+      await expectLater(
+        unavailable.save(
+          CreatePostDraft(userId: 'user-1', savedAt: DateTime.utc(2026, 5, 16)),
+        ),
+        completes,
+      );
+    });
+
+    test('load returns null when prefs are unavailable', () async {
+      final loaded = await unavailable.load('user-1');
+      expect(loaded, isNull);
+    });
+
+    test('clear does not throw when prefs are unavailable', () async {
+      await expectLater(unavailable.clear('user-1'), completes);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Persist in-progress posts to `shared_preferences` so an unexpected closure (crash, tab close, accidental discard) does not lose user input. Companion to #418 (which prevents the tablet/desktop dialog from dismissing on tap-outside).

This is not an explicit \"save as draft\" feature — there is no draft list UI, the user never thinks about it. It is a transparent safety net that quietly restores whatever they were typing the next time they open the composer.

## Behavior

- **Restore**: on screen open, look up the draft for the current user and rehydrate title / body / Quill delta / media URLs / track / mediaType / visibility / etc. A snackbar (\"Restored your previous draft.\" / 「前回の入力内容を復元しました」) confirms the restore.
- **Save**: on TextEditingController changes and on any \`CreatePostState\` meta change, debounced at 1.5s.
- **Clear**: on successful submit, on explicit \"Discard\", on logout (defense in depth).
- **Discard flow**: the AppBar back at step ≥ 1, the AppBar back at step 0, and the \`PopScope\` path (Android back, browser back, programmatic dialog dismiss) all converge on a \"Discard draft?\" confirmation. \"Discard\" wipes the draft and closes the composer; \"Keep editing\" returns to the form.

## Security / robustness

- **Per-user key** \`create_post_draft_<userId>\` + load-time \`userId\` check inside \`CreatePostDraft.tryDecode\`. A leftover draft from a previous account on the same device is invisible to a different account even if the explicit logout path is bypassed (e.g. JWT expiry forced logout — see \`auth_provider.dart:67-69\`).
- **Allow-list validation** in \`tryDecode\`: visibility in \`{public, draft}\`, step clamped 0..2, importance clamped 0..1, articleGenre / selectedMediaType against the enum value set, mediaUrls filtered to non-empty strings, malformed JSON returns null. Corrupted payloads are proactively removed so we don't keep attempting to decode them on every composer open.
- **Connections are NOT persisted**: they would need full \`Post\` metadata to display, and storing other users' (possibly private) post IDs in local storage is not worth the recovery convenience. The user re-selects connections after restore — accepted tradeoff for the minimum-scope design.
- **Web platform trade-off (documented for the record)**: \`shared_preferences\` writes plaintext to \`localStorage\` on Web. \`flutter_secure_storage\` does the same on Web (Keychain/Keystore only apply on native), so there is no upgrade path within the platform. If we later add features that increase XSS surface area (e.g. server-rendered OGP previews), revisit whether to opt the draft body out on Web.

## Files touched

- New: \`lib/models/create_post_draft.dart\`, \`lib/services/create_post_draft_service.dart\`, \`lib/providers/create_post_draft_provider.dart\`
- Modified: \`lib/providers/create_post_provider.dart\` (\`restoreFromDraft\` / \`persistDraft\` / \`loadDraft\` / \`clearDraft\` wrappers), \`lib/screens/create_post/create_post_screen.dart\` (init/save/load/discard wiring, PopScope), \`lib/providers/auth_provider.dart\` (clear on logout)
- l10n: 5 new keys × en/ja, regenerated AppLocalizations
- Deps: \`shared_preferences: ^2.3.5\`
- Tests: 25 new tests covering tryDecode validation paths and Service round-trips (save / load / clear / per-user scoping / corruption cleanup)

## Out of scope (deliberate)

- No widget test of the screen — high mock surface (GraphQL client + auth + l10n + Quill), reviewed manually instead. Worth adding later if the discard / restore flow regresses.
- No \"multiple drafts\" management UI. One draft per user, last-write-wins.

## Test plan

- [ ] Compose a post (text + media), close the tab, reopen → snackbar appears, fields restored
- [ ] Compose a post, submit successfully → reopen → no draft (clean state)
- [ ] Compose a post, tap back → discard dialog → \"Keep editing\" → still composing
- [ ] Compose a post, tap back → discard dialog → \"Discard\" → composer closes, reopen → no draft
- [ ] Compose a post on user A, log out, log in as user B → no draft visible to B
- [ ] Quill article: enter rich text, reopen → formatting preserved
- [ ] On a tablet/desktop dialog (after #418 lands), Android back / browser back → discard dialog (not silent close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)