### PR TITLE
fix(mise): pin pnpm to 10.32.1 to unblock Railway builds

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ experimental_monorepo_root = true
 [tools]
 flutter = { version = "3.38.10", platforms = { linux-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_{{ version }}-stable.tar.xz" }, macos-arm64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_{{ version }}-stable.zip" }, macos-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_{{ version }}-stable.zip" }, windows-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_{{ version }}-stable.zip" } }, version_expr = 'fromJSON(body).releases | filter({ #.channel == "stable" }) | map({ replace(#.version, "-stable", "") }) | sortVersions()', version_list_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json" }
 node = "latest"
-"npm:pnpm" = "latest"
+"npm:pnpm" = "10.32.1"
 
 [monorepo]
 config_roots = [


### PR DESCRIPTION
## Summary
- Railway production deploys have been failing since 2026-05-16 22:29 JST.
- Build log shows mise failing to install pnpm:
  ```
  mise ERROR Failed to install aqua:pnpm/pnpm@latest: no asset found: pnpm-linux-x64
  ```
- pnpm 11.x (released 2026-05-05〜) changed Linux asset naming from `pnpm-linux-x64` to `pnpm-linux-x64.tar.gz`; the aqua registry pinned inside the Railway build image (`railpack-builder:mise-2026.3.17`) still expects the pre-11 naming.
- `mise.toml` had `"npm:pnpm" = "latest"`, so each rebuild has been picking up the broken 11.x release.

## Fix
Pin pnpm to **10.32.1**, matching `backend/package.json#packageManager`. This keeps mise on the working aqua asset layout until the upstream registry catches up with pnpm 11.

## Scope
- Single line in `mise.toml`. No app code touched.
- Not related to today's Dependabot batch (those PRs landed cleanly; this is a latent issue from `latest` floating across pnpm major bump).

## Test plan
- [ ] CI green (build / test / format / lint / Cloudflare Pages preview)
- [ ] After merge: confirm Railway redeploys successfully (currently 9 consecutive failed deploys)

## Follow-up (out of scope)
- Consider also pinning `node = "latest"` for the same reason — leaving as-is for now to minimize blast radius. Track separately if desired.