### PR TITLE
fix(mise): switch pnpm key from npm:pnpm to pnpm (Railway redeploy)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ experimental_monorepo_root = true
 [tools]
 flutter = { version = "3.38.10", platforms = { linux-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_{{ version }}-stable.tar.xz" }, macos-arm64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_{{ version }}-stable.zip" }, macos-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_{{ version }}-stable.zip" }, windows-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_{{ version }}-stable.zip" } }, version_expr = 'fromJSON(body).releases | filter({ #.channel == "stable" }) | map({ replace(#.version, "-stable", "") }) | sortVersions()', version_list_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json" }
 node = "latest"
-"npm:pnpm" = "10.32.1"
+pnpm = "10.32.1"
 
 [monorepo]
 config_roots = [


### PR DESCRIPTION
## Summary
PR #421 didn't actually fix Railway deploys. The same error keeps reproducing:

```
mise pnpm@11.0.3     [1/2] install
mise ERROR Failed to install aqua:pnpm/pnpm@latest: no asset found: pnpm-linux-x64
```

### Root cause (corrected)
mise has **two independent keys** for pnpm:
- `"npm:pnpm"` — installs pnpm via the npm registry
- `"pnpm"` — installs pnpm via the core/aqua registry

Railway's `railpack-builder` generates a build plan that uses the **`pnpm`** key (aqua route), but our `mise.toml` only pinned `"npm:pnpm"`. The aqua-route install therefore kept falling back to `latest`, which now resolves to pnpm 11.x — whose Linux asset (`pnpm-linux-x64.tar.gz`) the bundled aqua registry doesn't yet know how to handle (it still expects the pre-11 `pnpm-linux-x64` binary).

### Fix
Rename the key:

```diff
-"npm:pnpm" = "10.32.1"
+pnpm = "10.32.1"
```

Verified locally — `mise ls --current` now reports:

```
pnpm  10.32.1 (missing)  ~/projects/yatima/gleisner/mise.toml  10.32.1
```

## Test plan
- [ ] CI green
- [ ] Railway redeploys successfully after merge (currently 10+ consecutive FAILED)

## Note
Leaving #421 as-is in the history; this PR continues the chain (no revert needed — `"npm:pnpm"` line is being replaced, not stacked).