### PR TITLE
fix(railpack): pin pnpm via railpack.json (Railway redeploy)

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.railpack.com",
+  "packages": {
+    "pnpm": "10.32.1"
+  }
+}


### PR DESCRIPTION
## Summary
Third attempt at unblocking Railway. PRs #421 and #422 both modified \`mise.toml\` but Railway kept resolving \`mise pnpm@11.0.3\` from the aqua registry and failing on the new asset layout. Per Railpack docs ([config/file](https://railpack.com/config/file), [languages/node](https://railpack.com/languages/node)), the canonical place to override package versions in the generated build plan is \`railpack.json\`, not the project's \`mise.toml\`.

## Why mise.toml didn't take effect
Railpack-builder writes its own \`/etc/mise/config.toml\` from its generated plan (the \`create mise config\` line in build logs). The project's \`mise.toml\` is copied into the image (\`copy mise.toml\`) but the plan is generated **before** that copy, so the pnpm version the build resolves comes from the plan, not from our file. We have no example of the plan ingesting \`mise.toml\` tool versions for the pnpm key.

## Fix
Add a minimal \`railpack.json\` at the repo root:

\`\`\`json
{
  "\$schema": "https://schema.railpack.com",
  "packages": { "pnpm": "10.32.1" }
}
\`\`\`

This is exactly the path the Railpack docs prescribe (\`packages\` map). The existing \`mise.toml\` line stays as-is for local-dev parity.

## Test plan
- [ ] CI green
- [ ] Railway redeploys successfully (currently 11+ consecutive FAILED)

## Note
If this still doesn't fix it, the next hypothesis would be that the Railway service has its **Root Directory** set somewhere other than the repo root, in which case \`railpack.json\` may need to be placed under that directory instead.