### PR TITLE
fix(railway): switch to Dockerfile builder (bypass mise pnpm aqua bug)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.env
+.env.local
+.env.*.local
+*.log
+.git
+.vscode
+.idea

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+FROM node:25.9-bookworm-slim
+
+WORKDIR /app
+
+# Runtime native deps + corepack for pnpm
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends libatomic1 \
+  && rm -rf /var/lib/apt/lists/* \
+  && npm i -g corepack@latest \
+  && corepack enable
+
+# Install dependencies. pnpm version is resolved from package.json's
+# `packageManager` field via corepack, so we avoid mise / aqua-registry
+# entirely (which has been broken upstream for pnpm 11.x asset naming).
+COPY package.json pnpm-lock.yaml ./
+RUN corepack prepare --activate \
+  && pnpm install --frozen-lockfile --prefer-offline
+
+# Build (tsc -> dist/)
+COPY . .
+RUN pnpm build
+
+ENV NODE_ENV=production
+EXPOSE 4000
+CMD ["node", "dist/index.js"]

--- a/backend/railway.json
+++ b/backend/railway.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "RAILPACK",
-    "buildCommand": "pnpm install --frozen-lockfile && pnpm build"
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
   },
   "deploy": {
     "startCommand": "node dist/index.js",

--- a/railpack.json
+++ b/railpack.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://schema.railpack.com",
-  "packages": {
-    "pnpm": "10.32.1"
-  }
-}


### PR DESCRIPTION
## Summary
Recovery PR for Railway. PRs #421 / #422 / #423 each tried to fix the symptom inside Railpack's mise plan but none of those config surfaces actually feed into the broken step.

### Root cause (final)
Two stacked upstream issues:

1. **mise aqua-registry doesn't understand pnpm 11.x asset layout**
   pnpm 11.x ships `pnpm-linux-x64.tar.gz`; the bundled aqua-registry inside `railpack-builder:mise-2026.3.17` expects the pre-11 binary asset `pnpm-linux-x64`.
   → [mise discussion #9624](https://github.com/jdx/mise/discussions/9624)
2. **Railpack generates its own mise config**
   Build logs show `create mise config` — Railpack writes \`/etc/mise/config.toml\` from its build plan. Project-level \`mise.toml\` tool versions and \`railpack.json#packages\` are both ignored for this aqua-route \`mise install pnpm@latest\` step. There is no documented override path.

### Evidence from build logs

\`\`\`
# 2026-05-11 (last success)
mise pnpm@10.33.2  download pnpm-linux-x64   <- old layout, works

# 2026-05-16 onwards (10+ consecutive failures)
mise pnpm@11.0.3   no asset found: pnpm-linux-x64
\`\`\`

\`latest\` rolled from 10.33.2 to 11.x and broke. We can't pin it because Railpack regenerates the mise config.

## Fix
Move off Railpack entirely. Use a plain Dockerfile that installs pnpm via Corepack from the existing \`packageManager: \"pnpm@10.32.1\"\` field — no mise, no aqua.

### Changes
- **Add** \`backend/Dockerfile\` (node:25.9-bookworm-slim + corepack)
- **Add** \`backend/.dockerignore\`
- **Switch** \`backend/railway.json\` builder \`RAILPACK\` → \`DOCKERFILE\` + \`dockerfilePath: \"Dockerfile\"\`
- **Remove** root \`railpack.json\` (from #423, no longer relevant)

\`mise.toml\` is left as-is — still useful for local dev / CI; only the Railway runtime is moved off mise.

## Post-merge verification
1. After merge, Railway will trigger a new deploy automatically.
2. In the Railway dashboard, confirm the service's **Builder Type** now shows **Dockerfile** (railway.json should switch it on next deploy; if not, set it explicitly under Service Settings → Build).
3. Healthcheck path (\`/health\`) and timeout are preserved from the previous railway.json.

## Test plan
- [ ] CI green (lint / format / test / build / Cloudflare Pages preview)
- [ ] Railway deploys successfully (\`Healthcheck succeeded\` in build log)
- [ ] /health responds 200
- [ ] /graphql responds normally (smoke test)