### PR TITLE
fix(docker): drop npm i -g corepack to avoid yarn EEXIST

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,11 +3,13 @@ FROM node:25.9-bookworm-slim
 
 WORKDIR /app
 
-# Runtime native deps + corepack for pnpm
+# Runtime native deps + enable Node-bundled corepack for pnpm.
+# Note: we intentionally do NOT `npm i -g corepack@latest` here because
+# node:25.9-bookworm-slim already ships corepack along with a yarn shim,
+# and `npm i -g` would EEXIST-fail when re-installing the yarn shim.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends libatomic1 \
   && rm -rf /var/lib/apt/lists/* \
-  && npm i -g corepack@latest \
   && corepack enable
 
 # Install dependencies. pnpm version is resolved from package.json's


### PR DESCRIPTION
## Summary
First Dockerfile-builder deploy (after #424) failed at step 3/7:

\`\`\`
npm error EEXIST: file already exists
npm error File exists: /usr/local/bin/yarn
\`\`\`

The good news: Railway **did** switch to the Dockerfile builder (\`load build definition from backend/Dockerfile\`). The bad news: the Dockerfile itself had a latent issue.

## Root cause
\`node:25.9-bookworm-slim\` already ships:
- \`corepack\` (version sufficient for pnpm 10.x)
- a \`yarn\` shim at \`/usr/local/bin/yarn\`

\`npm i -g corepack@latest\` tries to (re)install the yarn shim and EEXIST-fails. It also produced an EBADENGINE warning because corepack 0.35 requires Node ≥26.

## Fix
Skip \`npm i -g corepack@latest\`; just call \`corepack enable\` directly. The bundled corepack can already \`corepack prepare --activate\` for \`pnpm@10.32.1\` (from \`package.json#packageManager\`).

## Test plan
- [ ] CI green
- [ ] Railway redeploys past step 3/7 → pnpm install, pnpm build, Healthcheck succeeded