### PR TITLE
feat(timeline): render multi-image posts as a scattered polaroid pile

### DIFF
--- a/frontend/lib/theme/gleisner_tokens.dart
+++ b/frontend/lib/theme/gleisner_tokens.dart
@@ -39,6 +39,18 @@ const colorAccentGold = Color(0xFFd4af37);
 /// Fallback
 const colorTrackFallback = Color(0xFF808080);
 
+/// Warm off-white "paper" color used for polaroid-style photo frames in the
+/// multi-image timeline pile (fresh / newer polaroid tone).
+const colorPaperWhite = Color(0xFFf5f0e2);
+
+/// Yellowed paper tone for aged polaroid frames. Per-tile lerp between
+/// [colorPaperWhite] and this gives each photo in the pile its own age.
+const colorPaperAged = Color(0xFFe8d3a8);
+
+/// Base color for the sepia / haze overlay laid on top of polaroid images
+/// (applied at low alpha to simulate fading and dustiness).
+const colorPaperAgingTint = Color(0xFF8b6e3f);
+
 // ---------------------------------------------------------------------------
 // Typography — Font sizes (6-step scale)
 // ---------------------------------------------------------------------------

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../models/post.dart';
@@ -9,6 +10,12 @@ import '../../utils/constellation_layout.dart';
 import '../../utils/reading_time.dart';
 import 'post_detail_sheet.dart';
 import 'seed_art_painter.dart';
+
+/// Presentation-only flag: an image post that should render as a scattered
+/// polaroid pile instead of a single full-bleed thumbnail.
+extension _PostPilePresentation on Post {
+  bool get isPhotoPile => mediaType == MediaType.image && imageUrls.length > 1;
+}
 
 /// Border radius by media type.
 BorderRadius _borderForType(MediaType type) {
@@ -111,8 +118,7 @@ class _NodeCardState extends State<NodeCard>
     // Multi-image image posts render as a free-floating photo pile — no
     // surrounding frame, fill, or hard clip so individual photos can extend
     // past the rectangular node bounds for a casual "tossed photos" feel.
-    final isPhotoPile =
-        post.mediaType == MediaType.image && post.imageUrls.length > 1;
+    final isPhotoPile = post.isPhotoPile;
 
     Widget card = GestureDetector(
       onTap: widget.onTap ?? () => showPostDetailSheet(context, post),
@@ -523,7 +529,7 @@ class _ImageContent extends StatelessWidget {
     final totalH = node.mediaHeight + (showInfo ? 30 : 0);
     final hasTitle = post.title != null && post.title!.isNotEmpty;
 
-    final isPhotoPile = hasImage && imageCount > 1;
+    final isPhotoPile = post.isPhotoPile;
 
     // The image fills the entire node — text overlays on top.
     // For photo piles, allow tiles to extend slightly past the node bounds.
@@ -644,7 +650,11 @@ class _ImageContent extends StatelessWidget {
 /// Up to [_maxLayers] photos are rendered back-to-front with deterministic
 /// rotation and offset derived from [seed], so layout is stable across rebuilds.
 /// urls[0] is the top photo (least rotated, near-centered).
-class _ScatteredPhotos extends StatelessWidget {
+///
+/// Stateful so the per-tile scatter (angle/offset) is computed once on
+/// init/didUpdate rather than on every parent rebuild — the timeline can
+/// rebuild this widget on every constellation pan/zoom frame.
+class _ScatteredPhotos extends StatefulWidget {
   final List<String> urls;
   final double width;
   final double height;
@@ -668,24 +678,52 @@ class _ScatteredPhotos extends StatelessWidget {
   static const int _maxLayers = 4;
 
   @override
-  Widget build(BuildContext context) {
-    final visible = urls.length > _maxLayers
-        ? urls.take(_maxLayers).toList()
-        : urls;
+  State<_ScatteredPhotos> createState() => _ScatteredPhotosState();
+}
+
+class _ScatteredPhotosState extends State<_ScatteredPhotos> {
+  /// Photo tile size as a fraction of the node's width/height. Smaller than
+  /// the node so each tile reads as a discrete photograph and the scatter
+  /// has room to extend past the node bounds.
+  static const double _tileScale = 0.82;
+
+  late List<_TileLayout> _layouts;
+  late double _photoW;
+  late double _photoH;
+  late int _cacheW;
+  late int _cacheH;
+
+  @override
+  void initState() {
+    super.initState();
+    _recompute();
+  }
+
+  @override
+  void didUpdateWidget(_ScatteredPhotos old) {
+    super.didUpdateWidget(old);
+    if (old.seed != widget.seed ||
+        old.width != widget.width ||
+        old.height != widget.height ||
+        !listEquals(old.urls, widget.urls)) {
+      _recompute();
+    }
+  }
+
+  void _recompute() {
+    final visible = widget.urls.take(_ScatteredPhotos._maxLayers).toList();
     final count = visible.length;
+    _photoW = widget.width * _tileScale;
+    _photoH = widget.height * _tileScale;
+    _cacheW = (_photoW * 2).toInt();
+    _cacheH = (_photoH * 2).toInt();
 
-    // Photo size — smaller than node so each tile reads as a distinct
-    // photograph rather than a full-bleed slice.
-    final photoW = width * 0.82;
-    final photoH = height * 0.82;
-    final cacheW = (photoW * 2).toInt();
-
-    final layers = <Widget>[];
+    final layouts = <_TileLayout>[];
     // i=0 → front (urls[0], on top). i=count-1 → back. Add back first so
     // Stack paint order places urls[0] last (= on top).
     for (int i = count - 1; i >= 0; i--) {
       final depth = count > 1 ? i / (count - 1) : 0.0;
-      final r = Random('$seed#$i'.hashCode);
+      final r = Random('${widget.seed}#$i'.hashCode);
 
       // Rotation grows with depth: ~±2.5° front, ~±10° back.
       final angleSign = r.nextBool() ? 1.0 : -1.0;
@@ -698,42 +736,75 @@ class _ScatteredPhotos extends StatelessWidget {
       final dySign = r.nextBool() ? 1.0 : -1.0;
       final dx =
           dxSign *
-          (width * 0.03 + width * 0.13 * depth) *
+          (widget.width * 0.03 + widget.width * 0.13 * depth) *
           (0.65 + r.nextDouble() * 0.35);
       final dy =
           dySign *
-          (height * 0.025 + height * 0.10 * depth) *
+          (widget.height * 0.025 + widget.height * 0.10 * depth) *
           (0.65 + r.nextDouble() * 0.35);
 
-      layers.add(
-        Center(
-          child: Transform.translate(
-            offset: Offset(dx, dy),
-            child: Transform.rotate(
-              angle: angle,
-              child: _PhotoTile(
-                url: visible[i],
-                width: photoW,
-                height: photoH,
-                cacheWidth: cacheW,
-                isFront: i == 0,
-                depth: depth,
-                importance: importance,
-                trackColor: trackColor,
-                fallbackSeed: fallbackSeed,
-              ),
-            ),
-          ),
+      layouts.add(
+        _TileLayout(
+          url: visible[i],
+          angle: angle,
+          dx: dx,
+          dy: dy,
+          depth: depth,
         ),
       );
     }
+    _layouts = layouts;
+  }
 
+  @override
+  Widget build(BuildContext context) {
     return Stack(
       fit: StackFit.expand,
       clipBehavior: Clip.none,
-      children: layers,
+      children: [
+        for (final layout in _layouts)
+          Center(
+            child: Transform.translate(
+              offset: Offset(layout.dx, layout.dy),
+              child: Transform.rotate(
+                angle: layout.angle,
+                child: _PhotoTile(
+                  url: layout.url,
+                  width: _photoW,
+                  height: _photoH,
+                  cacheWidth: _cacheW,
+                  cacheHeight: _cacheH,
+                  isFront: layout.depth == 0.0,
+                  depth: layout.depth,
+                  importance: widget.importance,
+                  trackColor: widget.trackColor,
+                  fallbackSeed: widget.fallbackSeed,
+                ),
+              ),
+            ),
+          ),
+      ],
     );
   }
+}
+
+/// Cached transform + identity for a single tile in [_ScatteredPhotos].
+class _TileLayout {
+  final String url;
+  final double angle;
+  final double dx;
+  final double dy;
+
+  /// 0.0 = front (on top), 1.0 = back.
+  final double depth;
+
+  const _TileLayout({
+    required this.url,
+    required this.angle,
+    required this.dx,
+    required this.dy,
+    required this.depth,
+  });
 }
 
 /// A single tile in [_ScatteredPhotos]. Renders as a polaroid-style frame:
@@ -748,6 +819,7 @@ class _PhotoTile extends StatelessWidget {
   final double width;
   final double height;
   final int cacheWidth;
+  final int cacheHeight;
   final bool isFront;
   final double depth; // 0.0 = front, 1.0 = back
   final double importance;
@@ -759,6 +831,7 @@ class _PhotoTile extends StatelessWidget {
     required this.width,
     required this.height,
     required this.cacheWidth,
+    required this.cacheHeight,
     required this.isFront,
     required this.depth,
     required this.importance,
@@ -789,58 +862,64 @@ class _PhotoTile extends StatelessWidget {
     final dropAlpha = isFront ? 0.55 : 0.4;
     final dropDy = isFront ? 4.0 : 2.0;
 
-    return Container(
-      width: width,
-      height: height,
-      padding: EdgeInsets.all(borderThickness),
-      decoration: BoxDecoration(
-        color: paperColor,
-        borderRadius: BorderRadius.circular(radiusSm),
-        boxShadow: [
-          // Track-color halo behind the tile.
-          BoxShadow(
-            color: trackColor.withValues(alpha: glowAlpha),
-            blurRadius: glowBlur,
-            spreadRadius: glowSpread,
-          ),
-          // Black drop shadow for elevation.
-          BoxShadow(
-            color: Colors.black.withValues(alpha: dropAlpha),
-            blurRadius: dropBlur,
-            offset: Offset(0, dropDy),
-          ),
-        ],
-      ),
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          Image.network(
-            url,
-            fit: BoxFit.cover,
-            cacheWidth: cacheWidth,
-            loadingBuilder: (context, child, loadingProgress) {
-              if (loadingProgress == null) return child;
-              return Container(color: colorSurface2);
-            },
-            errorBuilder: (_, _, _) => SeedArtCanvas(
-              width: width - borderThickness * 2,
-              height: height - borderThickness * 2,
-              trackColor: trackColor,
-              seed: fallbackSeed,
-              mediaType: MediaType.image,
+    // RepaintBoundary cuts the repaint chain so timeline-wide rebuilds (pan,
+    // hover, neighbor reactions) don't traverse Transform.translate +
+    // Transform.rotate + the wear painter on every frame.
+    return RepaintBoundary(
+      child: Container(
+        width: width,
+        height: height,
+        padding: EdgeInsets.all(borderThickness),
+        decoration: BoxDecoration(
+          color: paperColor,
+          borderRadius: BorderRadius.circular(radiusSm),
+          boxShadow: [
+            // Track-color halo behind the tile.
+            BoxShadow(
+              color: trackColor.withValues(alpha: glowAlpha),
+              blurRadius: glowBlur,
+              spreadRadius: glowSpread,
             ),
-          ),
-          // Sepia / dustiness wash over the image — alpha varies per tile.
-          IgnorePointer(
-            child: Container(
-              color: colorPaperAgingTint.withValues(alpha: tintAlpha),
+            // Black drop shadow for elevation.
+            BoxShadow(
+              color: Colors.black.withValues(alpha: dropAlpha),
+              blurRadius: dropBlur,
+              offset: Offset(0, dropDy),
             ),
-          ),
-          // Faint crease + vignette baked from a per-tile seed.
-          IgnorePointer(
-            child: CustomPaint(painter: _PaperWearPainter(seed: url)),
-          ),
-        ],
+          ],
+        ),
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            Image.network(
+              url,
+              fit: BoxFit.cover,
+              cacheWidth: cacheWidth,
+              cacheHeight: cacheHeight,
+              loadingBuilder: (context, child, loadingProgress) {
+                if (loadingProgress == null) return child;
+                return Container(color: colorSurface2);
+              },
+              errorBuilder: (_, _, _) => SeedArtCanvas(
+                width: width - borderThickness * 2,
+                height: height - borderThickness * 2,
+                trackColor: trackColor,
+                seed: fallbackSeed,
+                mediaType: MediaType.image,
+              ),
+            ),
+            // Sepia / dustiness wash over the image — alpha varies per tile.
+            IgnorePointer(
+              child: Container(
+                color: colorPaperAgingTint.withValues(alpha: tintAlpha),
+              ),
+            ),
+            // Faint crease + vignette baked from a per-tile seed.
+            IgnorePointer(
+              child: CustomPaint(painter: _PaperWearPainter(seed: url)),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -849,10 +928,15 @@ class _PhotoTile extends StatelessWidget {
 /// Subtle wear overlay for [_PhotoTile]: 1–2 faint crease lines and a soft
 /// vignette at the corners. Stable per [seed] so the wear is the same across
 /// rebuilds for a given photo.
+///
+/// ⚠ When adding fields here, also extend the constructor and
+/// [shouldRepaint] to compare them — otherwise tiles may render with stale
+/// wear after a rebuild. See `frontend-implementation.md` —
+/// "CustomPainter フィールド追加チェックリスト".
 class _PaperWearPainter extends CustomPainter {
   final String seed;
 
-  _PaperWearPainter({required this.seed});
+  const _PaperWearPainter({required this.seed});
 
   @override
   void paint(Canvas canvas, Size size) {

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -108,25 +108,38 @@ class _NodeCardState extends State<NodeCard>
     final glowBlur = 8.0 + importance * 16;
     final glowOpacity = 0.15 + importance * 0.25;
 
+    // Multi-image image posts render as a free-floating photo pile — no
+    // surrounding frame, fill, or hard clip so individual photos can extend
+    // past the rectangular node bounds for a casual "tossed photos" feel.
+    final isPhotoPile =
+        post.mediaType == MediaType.image && post.imageUrls.length > 1;
+
     Widget card = GestureDetector(
       onTap: widget.onTap ?? () => showPostDetailSheet(context, post),
       child: Container(
         decoration: BoxDecoration(
           borderRadius: borderRadius,
-          boxShadow: [
-            BoxShadow(
-              color: trackColor.withValues(alpha: glowOpacity),
-              blurRadius: glowBlur,
-              spreadRadius: glowSpread,
-            ),
-          ],
-          border: Border.all(
-            color: trackColor.withValues(alpha: opacityBorder),
-            width: 1,
-          ),
-          color: colorSurface1,
+          // Photo piles supply their own track-color glow per tile so the
+          // halo follows the scattered shape; non-pile nodes keep the
+          // rectangular importance glow.
+          boxShadow: isPhotoPile
+              ? const []
+              : [
+                  BoxShadow(
+                    color: trackColor.withValues(alpha: glowOpacity),
+                    blurRadius: glowBlur,
+                    spreadRadius: glowSpread,
+                  ),
+                ],
+          border: isPhotoPile
+              ? null
+              : Border.all(
+                  color: trackColor.withValues(alpha: opacityBorder),
+                  width: 1,
+                ),
+          color: isPhotoPile ? Colors.transparent : colorSurface1,
         ),
-        clipBehavior: Clip.antiAlias,
+        clipBehavior: isPhotoPile ? Clip.none : Clip.antiAlias,
         child: _buildContent(node, trackColor),
       ),
     );
@@ -510,15 +523,29 @@ class _ImageContent extends StatelessWidget {
     final totalH = node.mediaHeight + (showInfo ? 30 : 0);
     final hasTitle = post.title != null && post.title!.isNotEmpty;
 
-    // The image fills the entire node — text overlays on top
+    final isPhotoPile = hasImage && imageCount > 1;
+
+    // The image fills the entire node — text overlays on top.
+    // For photo piles, allow tiles to extend slightly past the node bounds.
     return SizedBox(
       width: node.width,
       height: totalH,
       child: Stack(
         fit: StackFit.expand,
+        clipBehavior: isPhotoPile ? Clip.none : Clip.hardEdge,
         children: [
-          // Background: first image or seed art
-          if (hasImage)
+          // Background: scattered photo pile (multi) / single image / seed art
+          if (isPhotoPile)
+            _ScatteredPhotos(
+              urls: urls,
+              width: node.width,
+              height: totalH,
+              seed: post.id,
+              trackColor: trackColor,
+              fallbackSeed: seed,
+              importance: post.importance,
+            )
+          else if (hasImage)
             Image.network(
               urls.first,
               width: node.width,
@@ -611,6 +638,271 @@ class _ImageContent extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Multiple images stacked like a casually dropped photo pile.
+/// Up to [_maxLayers] photos are rendered back-to-front with deterministic
+/// rotation and offset derived from [seed], so layout is stable across rebuilds.
+/// urls[0] is the top photo (least rotated, near-centered).
+class _ScatteredPhotos extends StatelessWidget {
+  final List<String> urls;
+  final double width;
+  final double height;
+  final String seed;
+  final Color trackColor;
+  final String fallbackSeed;
+  final double importance;
+
+  const _ScatteredPhotos({
+    required this.urls,
+    required this.width,
+    required this.height,
+    required this.seed,
+    required this.trackColor,
+    required this.fallbackSeed,
+    required this.importance,
+  });
+
+  /// Cap visible layers — beyond this, the pile reads as "many" anyway and
+  /// rendering extra Image.network widgets just costs memory.
+  static const int _maxLayers = 4;
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = urls.length > _maxLayers
+        ? urls.take(_maxLayers).toList()
+        : urls;
+    final count = visible.length;
+
+    // Photo size — smaller than node so each tile reads as a distinct
+    // photograph rather than a full-bleed slice.
+    final photoW = width * 0.82;
+    final photoH = height * 0.82;
+    final cacheW = (photoW * 2).toInt();
+
+    final layers = <Widget>[];
+    // i=0 → front (urls[0], on top). i=count-1 → back. Add back first so
+    // Stack paint order places urls[0] last (= on top).
+    for (int i = count - 1; i >= 0; i--) {
+      final depth = count > 1 ? i / (count - 1) : 0.0;
+      final r = Random('$seed#$i'.hashCode);
+
+      // Rotation grows with depth: ~±2.5° front, ~±10° back.
+      final angleSign = r.nextBool() ? 1.0 : -1.0;
+      final angle =
+          angleSign * (0.04 + depth * 0.14) * (0.7 + r.nextDouble() * 0.3);
+
+      // Offset grows with depth: front near center, back scattered far enough
+      // to extend past the node bounds.
+      final dxSign = r.nextBool() ? 1.0 : -1.0;
+      final dySign = r.nextBool() ? 1.0 : -1.0;
+      final dx =
+          dxSign *
+          (width * 0.03 + width * 0.13 * depth) *
+          (0.65 + r.nextDouble() * 0.35);
+      final dy =
+          dySign *
+          (height * 0.025 + height * 0.10 * depth) *
+          (0.65 + r.nextDouble() * 0.35);
+
+      layers.add(
+        Center(
+          child: Transform.translate(
+            offset: Offset(dx, dy),
+            child: Transform.rotate(
+              angle: angle,
+              child: _PhotoTile(
+                url: visible[i],
+                width: photoW,
+                height: photoH,
+                cacheWidth: cacheW,
+                isFront: i == 0,
+                depth: depth,
+                importance: importance,
+                trackColor: trackColor,
+                fallbackSeed: fallbackSeed,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Stack(
+      fit: StackFit.expand,
+      clipBehavior: Clip.none,
+      children: layers,
+    );
+  }
+}
+
+/// A single tile in [_ScatteredPhotos]. Renders as a polaroid-style frame:
+/// off-white paper border around the image, with both a black drop shadow
+/// (depth) and a track-colored halo (importance signal). The halo replaces
+/// the rectangular boxShadow that normally lives on the parent NodeCard so
+/// the importance glow follows the scattered pile rather than the node rect.
+/// Each tile has per-photo aging — varied paper yellowing, a sepia tint, and
+/// a faint crease + vignette via [_PaperWearPainter].
+class _PhotoTile extends StatelessWidget {
+  final String url;
+  final double width;
+  final double height;
+  final int cacheWidth;
+  final bool isFront;
+  final double depth; // 0.0 = front, 1.0 = back
+  final double importance;
+  final Color trackColor;
+  final String fallbackSeed;
+
+  const _PhotoTile({
+    required this.url,
+    required this.width,
+    required this.height,
+    required this.cacheWidth,
+    required this.isFront,
+    required this.depth,
+    required this.importance,
+    required this.trackColor,
+    required this.fallbackSeed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // Polaroid paper border thickness — scales with photo size, min 4 px.
+    final borderThickness = max(4.0, width * 0.045);
+
+    // Per-photo aging factor from a stable hash of the URL. Some tiles look
+    // fresh, others heavily yellowed.
+    final agingT = ((url.hashCode & 0xFF) / 255.0);
+    final paperColor = Color.lerp(colorPaperWhite, colorPaperAged, agingT)!;
+    final tintAlpha = 0.04 + agingT * 0.10;
+
+    // Track-color halo: brightest on the front tile, fades with depth so the
+    // collective halo concentrates near the top of the pile.
+    final glowStrength = 1.0 - depth * 0.6;
+    final glowSpread = (3.0 + importance * 12.0) * glowStrength;
+    final glowBlur = (10.0 + importance * 18.0) * glowStrength;
+    final glowAlpha = (0.20 + importance * 0.30) * glowStrength;
+
+    // Black depth shadow: front tile floats higher off the canvas.
+    final dropBlur = isFront ? 18.0 : 10.0;
+    final dropAlpha = isFront ? 0.55 : 0.4;
+    final dropDy = isFront ? 4.0 : 2.0;
+
+    return Container(
+      width: width,
+      height: height,
+      padding: EdgeInsets.all(borderThickness),
+      decoration: BoxDecoration(
+        color: paperColor,
+        borderRadius: BorderRadius.circular(radiusSm),
+        boxShadow: [
+          // Track-color halo behind the tile.
+          BoxShadow(
+            color: trackColor.withValues(alpha: glowAlpha),
+            blurRadius: glowBlur,
+            spreadRadius: glowSpread,
+          ),
+          // Black drop shadow for elevation.
+          BoxShadow(
+            color: Colors.black.withValues(alpha: dropAlpha),
+            blurRadius: dropBlur,
+            offset: Offset(0, dropDy),
+          ),
+        ],
+      ),
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          Image.network(
+            url,
+            fit: BoxFit.cover,
+            cacheWidth: cacheWidth,
+            loadingBuilder: (context, child, loadingProgress) {
+              if (loadingProgress == null) return child;
+              return Container(color: colorSurface2);
+            },
+            errorBuilder: (_, _, _) => SeedArtCanvas(
+              width: width - borderThickness * 2,
+              height: height - borderThickness * 2,
+              trackColor: trackColor,
+              seed: fallbackSeed,
+              mediaType: MediaType.image,
+            ),
+          ),
+          // Sepia / dustiness wash over the image — alpha varies per tile.
+          IgnorePointer(
+            child: Container(
+              color: colorPaperAgingTint.withValues(alpha: tintAlpha),
+            ),
+          ),
+          // Faint crease + vignette baked from a per-tile seed.
+          IgnorePointer(
+            child: CustomPaint(painter: _PaperWearPainter(seed: url)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Subtle wear overlay for [_PhotoTile]: 1–2 faint crease lines and a soft
+/// vignette at the corners. Stable per [seed] so the wear is the same across
+/// rebuilds for a given photo.
+class _PaperWearPainter extends CustomPainter {
+  final String seed;
+
+  _PaperWearPainter({required this.seed});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final r = Random(seed.hashCode);
+    final rect = Offset.zero & size;
+
+    // Vignette — soft darkening towards the corners.
+    final vignette = Paint()
+      ..shader = RadialGradient(
+        center: Alignment.center,
+        radius: 0.85,
+        colors: const [Color(0x00000000), Color(0x26000000)],
+        stops: const [0.55, 1.0],
+      ).createShader(rect);
+    canvas.drawRect(rect, vignette);
+
+    // Primary crease: long thin highlight at a random angle.
+    final p1 = Offset(
+      r.nextDouble() * size.width,
+      r.nextDouble() * size.height,
+    );
+    final angle = r.nextDouble() * 2 * pi;
+    final len =
+        (size.width + size.height) * 0.4 + r.nextDouble() * size.width * 0.3;
+    final p2 = Offset(p1.dx + cos(angle) * len, p1.dy + sin(angle) * len);
+    final creasePaint = Paint()
+      ..color = Colors.white.withValues(alpha: 0.08)
+      ..strokeWidth = 0.7 + r.nextDouble() * 0.4
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(p1, p2, creasePaint);
+
+    // Occasional shorter dark companion crease for a real fold feel.
+    if (r.nextDouble() > 0.5) {
+      final p3 = Offset(
+        r.nextDouble() * size.width,
+        r.nextDouble() * size.height,
+      );
+      final angle2 = angle + pi / 2 + (r.nextDouble() * 0.5 - 0.25);
+      final len2 = size.width * 0.35 + r.nextDouble() * size.width * 0.2;
+      final p4 = Offset(p3.dx + cos(angle2) * len2, p3.dy + sin(angle2) * len2);
+      final paint2 = Paint()
+        ..color = Colors.black.withValues(alpha: 0.07)
+        ..strokeWidth = 0.5 + r.nextDouble() * 0.3
+        ..strokeCap = StrokeCap.round;
+      canvas.drawLine(p3, p4, paint2);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_PaperWearPainter old) => old.seed != seed;
 }
 
 // --- Video: thumbnail fills node, play button + duration + overlay info ---

--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -690,8 +690,6 @@ class _ScatteredPhotosState extends State<_ScatteredPhotos> {
   late List<_TileLayout> _layouts;
   late double _photoW;
   late double _photoH;
-  late int _cacheW;
-  late int _cacheH;
 
   @override
   void initState() {
@@ -715,8 +713,6 @@ class _ScatteredPhotosState extends State<_ScatteredPhotos> {
     final count = visible.length;
     _photoW = widget.width * _tileScale;
     _photoH = widget.height * _tileScale;
-    _cacheW = (_photoW * 2).toInt();
-    _cacheH = (_photoH * 2).toInt();
 
     final layouts = <_TileLayout>[];
     // i=0 → front (urls[0], on top). i=count-1 → back. Add back first so
@@ -758,6 +754,15 @@ class _ScatteredPhotosState extends State<_ScatteredPhotos> {
 
   @override
   Widget build(BuildContext context) {
+    // cacheWidth/cacheHeight are derived from the runtime device pixel ratio
+    // (rather than a fixed 2x) so Retina-class displays get sharp tiles and
+    // DPR=1 displays don't pay for over-decoded buffers. They live in build()
+    // rather than _recompute() because DPR can change without seed/url/size
+    // changes (e.g., window dragged between monitors).
+    final dpr = MediaQuery.devicePixelRatioOf(context);
+    final cacheW = (_photoW * dpr).ceil();
+    final cacheH = (_photoH * dpr).ceil();
+
     return Stack(
       fit: StackFit.expand,
       clipBehavior: Clip.none,
@@ -772,8 +777,8 @@ class _ScatteredPhotosState extends State<_ScatteredPhotos> {
                   url: layout.url,
                   width: _photoW,
                   height: _photoH,
-                  cacheWidth: _cacheW,
-                  cacheHeight: _cacheH,
+                  cacheWidth: cacheW,
+                  cacheHeight: cacheH,
                   isFront: layout.depth == 0.0,
                   depth: layout.depth,
                   importance: widget.importance,

--- a/frontend/test/widgets/timeline/node_card_photo_pile_test.dart
+++ b/frontend/test/widgets/timeline/node_card_photo_pile_test.dart
@@ -1,7 +1,8 @@
 // Regression tests for the multi-image photo-pile rendering path in
 // NodeCard. Single-image image posts must still render a single full-bleed
-// thumbnail, multi-image posts must render one tile per image, and the
-// `_maxLayers = 4` cap must hold for posts with more than four images.
+// thumbnail, multi-image posts must render one tile per image, the
+// `_maxLayers` cap must hold for posts with more than that many images, and
+// the importance boundaries must not throw.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,11 +14,21 @@ import 'package:gleisner_web/widgets/timeline/node_card.dart';
 
 PostAuthor _author() => const PostAuthor(id: 'u1', username: 'test_user');
 
-Post _imagePost({String id = 'p1', required int imageCount}) {
+/// Mirrors the private `_ScatteredPhotos._maxLayers` cap used by the
+/// production widget. Kept here so the truncation assertion below names
+/// the constraint instead of an opaque literal — keep these two in sync if
+/// `_maxLayers` changes.
+const int _expectedMaxLayers = 4;
+
+Post _imagePost({
+  String id = 'p1',
+  required int imageCount,
+  double importance = 0.4,
+}) {
   return Post(
     id: id,
     mediaType: MediaType.image,
-    importance: 0.4,
+    importance: importance,
     createdAt: DateTime.utc(2026, 1, 1),
     updatedAt: DateTime.utc(2026, 1, 1),
     author: _author(),
@@ -72,14 +83,31 @@ void main() {
       expect(find.byType(Image), findsNWidgets(3));
     });
 
-    testWidgets('multi-image post (6) is capped at _maxLayers (4) tiles', (
+    testWidgets('multi-image post is capped at _maxLayers tiles', (
       tester,
     ) async {
-      final post = _imagePost(imageCount: 6);
+      final post = _imagePost(imageCount: _expectedMaxLayers + 2);
       await tester.pumpWidget(_host(NodeCard(node: _nodeFor(post), index: 0)));
       await tester.pump();
 
-      expect(find.byType(Image), findsNWidgets(4));
+      expect(find.byType(Image), findsNWidgets(_expectedMaxLayers));
+    });
+
+    // Boundary check: the glow / drop-shadow math in _PhotoTile scales with
+    // `importance`. Exercise the 0.0 / 1.0 edges to catch regressions where
+    // a coefficient flips negative or trips an alpha-out-of-range assertion.
+    testWidgets('renders without crashing at importance boundaries', (
+      tester,
+    ) async {
+      for (final imp in const [0.0, 1.0]) {
+        final post = _imagePost(id: 'imp-$imp', imageCount: 3, importance: imp);
+        await tester.pumpWidget(
+          _host(NodeCard(node: _nodeFor(post), index: 0)),
+        );
+        await tester.pump();
+
+        expect(find.byType(Image), findsNWidgets(3));
+      }
     });
   });
 }

--- a/frontend/test/widgets/timeline/node_card_photo_pile_test.dart
+++ b/frontend/test/widgets/timeline/node_card_photo_pile_test.dart
@@ -1,0 +1,85 @@
+// Regression tests for the multi-image photo-pile rendering path in
+// NodeCard. Single-image image posts must still render a single full-bleed
+// thumbnail, multi-image posts must render one tile per image, and the
+// `_maxLayers = 4` cap must hold for posts with more than four images.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gleisner_web/models/post.dart';
+import 'package:gleisner_web/models/timeline_item.dart';
+import 'package:gleisner_web/utils/constellation_layout.dart';
+import 'package:gleisner_web/widgets/timeline/node_card.dart';
+
+PostAuthor _author() => const PostAuthor(id: 'u1', username: 'test_user');
+
+Post _imagePost({String id = 'p1', required int imageCount}) {
+  return Post(
+    id: id,
+    mediaType: MediaType.image,
+    importance: 0.4,
+    createdAt: DateTime.utc(2026, 1, 1),
+    updatedAt: DateTime.utc(2026, 1, 1),
+    author: _author(),
+    trackColor: '#FF8B7355',
+    media: List.generate(
+      imageCount,
+      (i) => PostMedia(
+        id: 'm$i',
+        mediaUrl: 'https://example.invalid/$id-$i.jpg',
+        position: i,
+      ),
+    ),
+  );
+}
+
+PlacedNode _nodeFor(Post post) => PlacedNode(
+  item: PostItem(post),
+  x: 0,
+  y: 0,
+  width: 160,
+  height: 200,
+  nodeSize: 160,
+  mediaHeight: 140,
+  showInfo: false,
+);
+
+Widget _host(Widget child) {
+  return ProviderScope(
+    child: MaterialApp(
+      home: Scaffold(body: Center(child: child)),
+    ),
+  );
+}
+
+void main() {
+  group('NodeCard photo pile rendering', () {
+    testWidgets('single-image post renders exactly one Image', (tester) async {
+      final post = _imagePost(imageCount: 1);
+      await tester.pumpWidget(_host(NodeCard(node: _nodeFor(post), index: 0)));
+      await tester.pump();
+
+      expect(find.byType(Image), findsOneWidget);
+    });
+
+    testWidgets('multi-image post (3) renders one tile per image', (
+      tester,
+    ) async {
+      final post = _imagePost(imageCount: 3);
+      await tester.pumpWidget(_host(NodeCard(node: _nodeFor(post), index: 0)));
+      await tester.pump();
+
+      expect(find.byType(Image), findsNWidgets(3));
+    });
+
+    testWidgets('multi-image post (6) is capped at _maxLayers (4) tiles', (
+      tester,
+    ) async {
+      final post = _imagePost(imageCount: 6);
+      await tester.pumpWidget(_host(NodeCard(node: _nodeFor(post), index: 0)));
+      await tester.pump();
+
+      expect(find.byType(Image), findsNWidgets(4));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Multi-image posts now render up to 4 photos as a casually-tossed polaroid pile in the timeline, instead of showing only the first image with a +N badge.
- Each tile gets a per-photo polaroid border, deterministic rotation/offset from `post.id`, and stable subtle aging (paper yellowing, sepia wash, vignette, faint crease) via `_PaperWearPainter`.
- The track-color importance halo moves from the rectangular parent NodeCard onto each tile (front tile brightest, back tiles fade), so the halo follows the scattered shape rather than outlining the hidden node rectangle.

## Visual behavior

- **Single-image image posts**: unchanged.
- **Multi-image image posts** (`imageUrls.length > 1`):
  - Parent NodeCard drops border, surface fill, boxShadow, and clip (`Clip.none`) so photos can extend slightly past the rectangular bounds.
  - Up to `_maxLayers = 4` photos render back-to-front with `Transform.translate` + `Transform.rotate`; `urls[0]` sits near-centered on top.
  - Each photo: off-white paper border (~4–8 px, scaled), seeded paper yellowing, low-alpha sepia tint, painter-based vignette + crease, two-layer shadow (track halo + black drop).

## Layout safety

`constellation_layout.dart` / `timeline_provider.dart` are untouched. `Transform.translate` only affects paint, not layout, so each NodeCard still occupies `node.width × totalH`. Position math is unchanged — the only visible difference is that paint can spill slightly past the node rectangle.

## Files

- `frontend/lib/widgets/timeline/node_card.dart` — new `_ScatteredPhotos`, `_PhotoTile`, `_PaperWearPainter`; `_NodeCardState.build` conditional on `isPhotoPile`; `_ImageContent` branches to the pile.
- `frontend/lib/theme/gleisner_tokens.dart` — adds `colorPaperWhite`, `colorPaperAged`, `colorPaperAgingTint`.

## Test plan

- [ ] Open the timeline for a user with a multi-image post (>= 2 images) and confirm tiles appear as a scattered polaroid pile.
- [ ] Confirm single-image image posts still render full-bleed with the original framed look.
- [ ] Confirm the track-color halo radiates from the photos themselves (no dark rectangular halo behind them).
- [ ] Confirm node positions / connections in the constellation look unchanged vs. main.
- [ ] Reload the same post a few times and confirm each photo's rotation, offset, paper tone, and wear pattern are stable.
- [ ] `cd frontend && dart analyze lib/ && dart format --set-exit-if-changed lib/widgets/timeline/node_card.dart lib/theme/gleisner_tokens.dart && flutter test --platform chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)