### PR TITLE
fix(timeline): preserve source aspect ratio for photo-pile tiles

### DIFF
--- a/frontend/lib/widgets/timeline/node_card.dart
+++ b/frontend/lib/widgets/timeline/node_card.dart
@@ -896,9 +896,14 @@ class _PhotoTile extends StatelessWidget {
         child: Stack(
           fit: StackFit.expand,
           children: [
+            // BoxFit.contain preserves the source aspect ratio so the photo
+            // is shown whole — any unused tile area becomes additional paper
+            // border, the same way a real polaroid frames an off-aspect print.
+            // The downstream sepia / wear overlays still cover the full tile,
+            // which reads as "the paper is aged too", not as misalignment.
             Image.network(
               url,
-              fit: BoxFit.cover,
+              fit: BoxFit.contain,
               cacheWidth: cacheWidth,
               cacheHeight: cacheHeight,
               loadingBuilder: (context, child, loadingProgress) {


### PR DESCRIPTION
## Summary

Follow-up to #427. `_PhotoTile` was rendering each photo with `BoxFit.cover`, which crops to fill the tile rectangle whenever the node's aspect ratio doesn't match the source photo's. The visible thumbnail then no longer matches the original shape — users reported their photos appearing in the wrong proportions.

Switch the tile image to `BoxFit.contain` so the full photo is shown at its native aspect ratio; any leftover tile area becomes additional paper border, matching how a real polaroid frames an off-aspect print.

## Why this is OK with the existing wear effects

The sepia / vignette / crease overlays still cover the full tile (not just the image rectangle). This is intentional — paper aging visually extends into the empty paper margins too, which reads as "the paper itself is aged" rather than as misalignment. Aged paper tiles get a slightly stronger combined tone, which is consistent with the polaroid aesthetic.

## Files

- `frontend/lib/widgets/timeline/node_card.dart` — `_PhotoTile` image fit + explanatory comment.

## Test plan

- [ ] Multi-image post with mixed portrait + landscape photos: each tile shows the full photo at native aspect, with paper border filling unused area.
- [ ] Single-image image post still renders full-bleed (unchanged code path).
- [ ] Sepia / vignette / crease overlays still apply uniformly across the tile.
- [ ] `dart analyze lib/ && dart format --set-exit-if-changed lib/widgets/timeline/node_card.dart && flutter test --platform chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)