### PR TITLE
feat(backend): artist activity heatmap + pulse beacon (Idea 032)

### DIFF
--- a/backend/drizzle/0017_public_mysterio.sql
+++ b/backend/drizzle/0017_public_mysterio.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "posts_author_visibility_created_idx" ON "posts" USING btree ("author_id","visibility","created_at");

--- a/backend/drizzle/meta/0017_snapshot.json
+++ b/backend/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,2024 @@
+{
+  "id": "031d3a64-5dc5-471c-801e-a2c7ac4fb36e",
+  "prevId": "54ffa868-0826-42e0-a5bf-0af706057822",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analytics_events": {
+      "name": "analytics_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analytics_event_type_created_idx": {
+          "name": "analytics_event_type_created_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_event_user_id_idx": {
+          "name": "analytics_event_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analytics_event_session_id_idx": {
+          "name": "analytics_event_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_genres": {
+      "name": "artist_genres",
+      "schema": "",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_genres_artist_id_artists_id_fk": {
+          "name": "artist_genres_artist_id_artists_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_genres_genre_id_genres_id_fk": {
+          "name": "artist_genres_genre_id_genres_id_fk",
+          "tableFrom": "artist_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_genres_artist_id_genre_id_pk": {
+          "name": "artist_genres_artist_id_genre_id_pk",
+          "columns": [
+            "artist_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_links": {
+      "name": "artist_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_category": {
+          "name": "link_category",
+          "type": "link_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_links_artist_id_artists_id_fk": {
+          "name": "artist_links_artist_id_artists_id_fk",
+          "tableFrom": "artist_links",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_milestones": {
+      "name": "artist_milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "milestone_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artist_milestones_artist_id_idx": {
+          "name": "artist_milestones_artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_milestones_artist_id_artists_id_fk": {
+          "name": "artist_milestones_artist_id_artists_id_fk",
+          "tableFrom": "artist_milestones",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_username": {
+          "name": "artist_username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_since": {
+          "name": "active_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tuned_in_count": {
+          "name": "tuned_in_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artists_featured_visibility_idx": {
+          "name": "artists_featured_visibility_idx",
+          "columns": [
+            {
+              "expression": "is_featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artists_user_id_users_id_fk": {
+          "name": "artists_user_id_users_id_fk",
+          "tableFrom": "artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artists_user_id_unique": {
+          "name": "artists_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "artists_artist_username_unique": {
+          "name": "artists_artist_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_post_id_posts_id_fk": {
+          "name": "comments_post_id_posts_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_type": {
+          "name": "connection_type",
+          "type": "connection_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_connection": {
+          "name": "unique_connection",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_source_id_posts_id_fk": {
+          "name": "connections_source_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_target_id_posts_id_fk": {
+          "name": "connections_target_id_posts_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "source_neq_target": {
+          "name": "source_neq_target",
+          "value": "\"connections\".\"source_id\" != \"connections\".\"target_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.constellations": {
+      "name": "constellations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_post_id": {
+          "name": "anchor_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "constellations_artist_id_artists_id_fk": {
+          "name": "constellations_artist_id_artists_id_fk",
+          "tableFrom": "constellations",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "constellations_anchor_post_id_posts_id_fk": {
+          "name": "constellations_anchor_post_id_posts_id_fk",
+          "tableFrom": "constellations",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "anchor_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "constellations_anchor_post_id_unique": {
+          "name": "constellations_anchor_post_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anchor_post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "name": "follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "follower_neq_following": {
+          "name": "follower_neq_following",
+          "value": "\"follows\".\"follower_id\" != \"follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_promoted": {
+          "name": "is_promoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "genres_normalized_name_unique": {
+          "name": "genres_normalized_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "normalized_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_users_id_fk": {
+          "name": "invites_created_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_used_by_users_id_fk": {
+          "name": "invites_used_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_reactions": {
+      "name": "milestone_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "milestone_reactions_milestone_id_idx": {
+          "name": "milestone_reactions_milestone_id_idx",
+          "columns": [
+            {
+              "expression": "milestone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "milestone_reactions_milestone_id_artist_milestones_id_fk": {
+          "name": "milestone_reactions_milestone_id_artist_milestones_id_fk",
+          "tableFrom": "milestone_reactions",
+          "tableTo": "artist_milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_reactions_user_id_users_id_fk": {
+          "name": "milestone_reactions_user_id_users_id_fk",
+          "tableFrom": "milestone_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_reactions_milestone_id_user_id_emoji_unique": {
+          "name": "milestone_reactions_milestone_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_media": {
+      "name": "post_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_media_post_id_position_idx": {
+          "name": "post_media_post_id_position_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_media_post_id_posts_id_fk": {
+          "name": "post_media_post_id_posts_id_fk",
+          "tableFrom": "post_media",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_format": {
+          "name": "body_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'plain'"
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importance": {
+          "name": "importance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_fetched_at": {
+          "name": "og_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_genre": {
+          "name": "article_genre",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_publish": {
+          "name": "external_publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_x": {
+          "name": "layout_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "layout_y": {
+          "name": "layout_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "posts_author_og_fetched_idx": {
+          "name": "posts_author_og_fetched_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "og_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_author_media_url_idx": {
+          "name": "posts_author_media_url_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_media_url_og_fetched_idx": {
+          "name": "posts_media_url_og_fetched_idx",
+          "columns": [
+            {
+              "expression": "media_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "og_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_author_visibility_updated_idx": {
+          "name": "posts_author_visibility_updated_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_author_visibility_created_idx": {
+          "name": "posts_author_visibility_created_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_track_id_tracks_id_fk": {
+          "name": "posts_track_id_tracks_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_post_id_idx": {
+          "name": "reactions_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_post_id_posts_id_fk": {
+          "name": "reactions_post_id_posts_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_user_id_users_id_fk": {
+          "name": "reactions_user_id_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_post_id_user_id_emoji_unique": {
+          "name": "reactions_post_id_user_id_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracks": {
+      "name": "tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_artist_track_name": {
+          "name": "unique_artist_track_name",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tracks_artist_id_artists_id_fk": {
+          "name": "tracks_artist_id_artists_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tune_ins": {
+      "name": "tune_ins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tune_ins_user_id_users_id_fk": {
+          "name": "tune_ins_user_id_users_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tune_ins_artist_id_artists_id_fk": {
+          "name": "tune_ins_artist_id_artists_id_fk",
+          "tableFrom": "tune_ins",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tune_ins_user_id_artist_id_pk": {
+          "name": "tune_ins_user_id_artist_id_pk",
+          "columns": [
+            "user_id",
+            "artist_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "did": {
+          "name": "did",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_salt": {
+          "name": "password_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_private_key": {
+          "name": "encrypted_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_salt": {
+          "name": "encryption_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_year_month": {
+          "name": "birth_year_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_id": {
+          "name": "guardian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_guardian_id_idx": {
+          "name": "users_guardian_id_idx",
+          "columns": [
+            {
+              "expression": "guardian_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_guardian_id_users_id_fk": {
+          "name": "users_guardian_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "guardian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_did_unique": {
+          "name": "users_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_type": {
+      "name": "connection_type",
+      "schema": "public",
+      "values": [
+        "reply",
+        "remix",
+        "reference",
+        "evolution"
+      ]
+    },
+    "public.link_category": {
+      "name": "link_category",
+      "schema": "public",
+      "values": [
+        "social",
+        "music",
+        "video",
+        "website",
+        "store",
+        "other"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "thought",
+        "article",
+        "image",
+        "video",
+        "audio",
+        "link"
+      ]
+    },
+    "public.milestone_category": {
+      "name": "milestone_category",
+      "schema": "public",
+      "values": [
+        "award",
+        "release",
+        "event",
+        "affiliation",
+        "education",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1778256543005,
       "tag": "0016_true_forgotten_one",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1779104974138,
+      "tag": "0017_public_mysterio",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/post.ts
+++ b/backend/src/db/schema/post.ts
@@ -91,5 +91,16 @@ export const posts = pgTable(
       table.visibility,
       table.updatedAt,
     ),
+    // Activity heatmap (Idea 032 / ADR 013 + ADR 021): per-author daily post
+    // count aggregation. Same (author_id, visibility) leading columns as the
+    // updated_at index above, but trails on created_at because the heatmap
+    // groups by created_at::date and ranges by created_at >= fromDate. The
+    // existing _updated_idx is not reusable here because GROUP BY on
+    // created_at would force a sort even after the index seek.
+    index("posts_author_visibility_created_idx").on(
+      table.authorId,
+      table.visibility,
+      table.createdAt,
+    ),
   ],
 );

--- a/backend/src/graphql/__tests__/artist-activity.test.ts
+++ b/backend/src/graphql/__tests__/artist-activity.test.ts
@@ -33,9 +33,12 @@ import {
 
 type App = Awaited<ReturnType<typeof getTestApp>>;
 
-/** Shape returned by ARTIST_ACTIVITY_QUERY — used to DRY up casts. */
+/**
+ * Shape returned by ARTIST_ACTIVITY_QUERY — used to DRY up casts. `id` is
+ * returned by the query but never asserted in this file, so it's omitted
+ * from the type to keep assertions focused on the activity surface.
+ */
 interface ArtistActivityResult {
-  id: string;
   activitySeries: Array<{ date: string; count: number }>;
   lastPostedAt: string | null;
 }

--- a/backend/src/graphql/__tests__/artist-activity.test.ts
+++ b/backend/src/graphql/__tests__/artist-activity.test.ts
@@ -33,6 +33,13 @@ import {
 
 type App = Awaited<ReturnType<typeof getTestApp>>;
 
+/** Shape returned by ARTIST_ACTIVITY_QUERY — used to DRY up casts. */
+interface ArtistActivityResult {
+  id: string;
+  activitySeries: Array<{ date: string; count: number }>;
+  lastPostedAt: string | null;
+}
+
 const UPDATE_ME_MUTATION = `
   mutation UpdateMe($profileVisibility: String) {
     updateMe(profileVisibility: $profileVisibility) { id profileVisibility }
@@ -185,10 +192,7 @@ describe("artist activity heatmap authorization (Idea 032)", () => {
         username: author.artistUsername,
       });
       expect(resp.errors).toBeUndefined();
-      const artist = resp.data!.artist as {
-        activitySeries: Array<{ date: string; count: number }>;
-        lastPostedAt: string | null;
-      };
+      const artist = resp.data!.artist as ArtistActivityResult;
       expect(artist.activitySeries).toHaveLength(1);
       expect(artist.activitySeries[0].count).toBe(2);
       expect(artist.lastPostedAt).not.toBeNull();
@@ -207,9 +211,7 @@ describe("artist activity heatmap authorization (Idea 032)", () => {
       const resp = await gql(app, ARTIST_ACTIVITY_QUERY, {
         username: author.artistUsername,
       });
-      const artist = resp.data!.artist as {
-        activitySeries: Array<{ count: number }>;
-      };
+      const artist = resp.data!.artist as ArtistActivityResult;
       expect(artist.activitySeries[0].count).toBe(1);
     });
 
@@ -229,9 +231,7 @@ describe("artist activity heatmap authorization (Idea 032)", () => {
         { username: author.artistUsername },
         author.token,
       );
-      const artist = resp.data!.artist as {
-        activitySeries: Array<{ count: number }>;
-      };
+      const artist = resp.data!.artist as ArtistActivityResult;
       expect(artist.activitySeries[0].count).toBe(2);
     });
   });
@@ -297,9 +297,7 @@ describe("artist activity heatmap authorization (Idea 032)", () => {
         { username: author.artistUsername },
         fanToken,
       );
-      const artist = resp.data!.artist as {
-        activitySeries: Array<{ count: number }>;
-      };
+      const artist = resp.data!.artist as ArtistActivityResult;
       expect(artist).not.toBeNull();
       expect(artist.activitySeries[0].count).toBe(1);
     });
@@ -319,10 +317,7 @@ describe("artist activity heatmap authorization (Idea 032)", () => {
       const resp = await gql(app, ARTIST_ACTIVITY_QUERY, {
         username: author.artistUsername,
       });
-      const artist = resp.data!.artist as {
-        activitySeries: Array<unknown>;
-        lastPostedAt: string | null;
-      };
+      const artist = resp.data!.artist as ArtistActivityResult;
       // Artist row still resolvable (artists.profileVisibility=public by default),
       // but activity is blanked because the *user* is private.
       expect(artist.activitySeries).toEqual([]);
@@ -345,10 +340,7 @@ describe("artist activity heatmap authorization (Idea 032)", () => {
         { username: author.artistUsername },
         author.token,
       );
-      const artist = resp.data!.artist as {
-        activitySeries: Array<{ count: number }>;
-        lastPostedAt: string | null;
-      };
+      const artist = resp.data!.artist as ArtistActivityResult;
       expect(artist.activitySeries[0].count).toBe(1);
       expect(artist.lastPostedAt).not.toBeNull();
     });
@@ -365,7 +357,7 @@ describe("artist activity heatmap authorization (Idea 032)", () => {
         guardianToken,
         childId,
       );
-      const artistResp = await gql(
+      await gql(
         app,
         REGISTER_ARTIST_MUTATION,
         { artistUsername: "kiddo_artist", displayName: "Kiddo Artist" },
@@ -380,21 +372,16 @@ describe("artist activity heatmap authorization (Idea 032)", () => {
       const trackId = (trackResp.data!.createTrack as { id: string }).id;
       await createPost(app, childToken, trackId, "child post");
 
-      // Even an anon viewer should see empty activity. (artist row may be
-      // unreachable depending on Tier setting, but if reachable the
-      // activity must be empty.)
-      void (artistResp.data!.registerArtist as { id: string });
+      // Anon viewer: the artist row may be unreachable depending on Tier
+      // settings, but if it is reachable the activity surface must be
+      // empty (Layer 0 hides child posts from third parties).
       const resp = await gql(app, ARTIST_ACTIVITY_QUERY, {
         username: "kiddo_artist",
       });
-      const artist = resp.data!.artist;
+      const artist = resp.data!.artist as ArtistActivityResult | null;
       if (artist !== null) {
-        const a = artist as {
-          activitySeries: unknown[];
-          lastPostedAt: string | null;
-        };
-        expect(a.activitySeries).toEqual([]);
-        expect(a.lastPostedAt).toBeNull();
+        expect(artist.activitySeries).toEqual([]);
+        expect(artist.lastPostedAt).toBeNull();
       }
     });
   });
@@ -417,10 +404,7 @@ describe("artist activity heatmap authorization (Idea 032)", () => {
         { username: author.artistUsername },
         author.token,
       );
-      const artist = resp.data!.artist as {
-        activitySeries: unknown[];
-        lastPostedAt: string | null;
-      };
+      const artist = resp.data!.artist as ArtistActivityResult;
       expect(artist.activitySeries).toEqual([]);
       expect(artist.lastPostedAt).toBeNull();
     });

--- a/backend/src/graphql/__tests__/artist-activity.test.ts
+++ b/backend/src/graphql/__tests__/artist-activity.test.ts
@@ -1,0 +1,575 @@
+/**
+ * Activity heatmap authorization matrix (Idea 032).
+ *
+ * Verifies that `Artist.activitySeries` and `Artist.lastPostedAt` enforce the
+ * exact same authorization chain as `recentPosts` / `artistPosts`. The pulse
+ * beacon and star calendar must never reveal activity that the post
+ * resolvers would hide; otherwise the timestamp / count surface becomes a
+ * side channel for private posts and child accounts (#250 sec-1 analogue).
+ *
+ * Coverage:
+ *   - Layer 1: artists.profileVisibility (public / private + tuned-in / private + non-tuned-in)
+ *   - Layer 0: users.profileVisibility (public / private)
+ *   - Post visibility: 'public' vs 'draft' — non-self viewers only see public
+ *   - Track scope: trackId IS NOT NULL (unassigned posts excluded, matches recentPosts #67)
+ *   - Deep path: myTuneIns → TuneInType.artist → activitySeries / lastPostedAt
+ *   - Discover prefetch: lastPostedAt is filtered to public + public-author + assigned
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import "dotenv/config";
+import { sql } from "drizzle-orm";
+import {
+  closeTestDb,
+  db,
+  getTestApp,
+  gql,
+  signupAndCreateChild,
+  signupAndGetTokenAndId,
+  switchToChildAndGetToken,
+  CREATE_POST_MUTATION,
+  CREATE_TRACK_MUTATION,
+  REGISTER_ARTIST_MUTATION,
+} from "./helpers.js";
+
+type App = Awaited<ReturnType<typeof getTestApp>>;
+
+const UPDATE_ME_MUTATION = `
+  mutation UpdateMe($profileVisibility: String) {
+    updateMe(profileVisibility: $profileVisibility) { id profileVisibility }
+  }
+`;
+
+const UPDATE_ARTIST_VISIBILITY_MUTATION = `
+  mutation UpdateArtist($profileVisibility: String) {
+    updateArtist(profileVisibility: $profileVisibility) { id profileVisibility }
+  }
+`;
+
+const TOGGLE_TUNE_IN_MUTATION = `
+  mutation ToggleTuneIn($artistId: String!) {
+    toggleTuneIn(artistId: $artistId) { createdAt }
+  }
+`;
+
+const ARTIST_ACTIVITY_QUERY = `
+  query ArtistActivity($username: String!) {
+    artist(username: $username) {
+      id
+      activitySeries { date count }
+      lastPostedAt
+    }
+  }
+`;
+
+const MY_TUNE_INS_ACTIVITY_QUERY = `
+  query MyTuneInsActivity {
+    myTuneIns {
+      artist {
+        id
+        artistUsername
+        activitySeries { date count }
+        lastPostedAt
+      }
+    }
+  }
+`;
+
+const DISCOVER_ARTISTS_QUERY = `
+  query DiscoverArtists {
+    discoverArtists { id artistUsername lastPostedAt }
+  }
+`;
+
+interface AuthorFixture {
+  token: string;
+  userId: string;
+  artistId: string;
+  artistUsername: string;
+  trackId: string;
+}
+
+async function createPublicArtistWithTrack(
+  app: App,
+  email: string,
+  username: string,
+  artistUsername: string,
+): Promise<AuthorFixture> {
+  const { token, userId } = await signupAndGetTokenAndId(app, email, username);
+  const artistResp = await gql(
+    app,
+    REGISTER_ARTIST_MUTATION,
+    { artistUsername, displayName: `Artist ${artistUsername}` },
+    token,
+  );
+  const artistId = (artistResp.data!.registerArtist as { id: string }).id;
+  const trackResp = await gql(
+    app,
+    CREATE_TRACK_MUTATION,
+    { name: `Track-${username}`, color: "#FF0000" },
+    token,
+  );
+  const trackId = (trackResp.data!.createTrack as { id: string }).id;
+  return { token, userId, artistId, artistUsername, trackId };
+}
+
+async function createPost(
+  app: App,
+  token: string,
+  trackId: string,
+  body: string,
+  visibility: "public" | "draft" = "public",
+): Promise<string> {
+  const resp = await gql(
+    app,
+    CREATE_POST_MUTATION,
+    { trackId, mediaType: "thought", body, visibility },
+    token,
+  );
+  if (resp.errors) {
+    throw new Error(`createPost failed: ${JSON.stringify(resp.errors)}`);
+  }
+  return (resp.data!.createPost as { id: string }).id;
+}
+
+async function setUserPrivate(app: App, token: string): Promise<void> {
+  const resp = await gql(
+    app,
+    UPDATE_ME_MUTATION,
+    { profileVisibility: "private" },
+    token,
+  );
+  if (resp.errors) {
+    throw new Error(`setUserPrivate failed: ${JSON.stringify(resp.errors)}`);
+  }
+}
+
+async function setArtistPrivate(app: App, token: string): Promise<void> {
+  const resp = await gql(
+    app,
+    UPDATE_ARTIST_VISIBILITY_MUTATION,
+    { profileVisibility: "private" },
+    token,
+  );
+  if (resp.errors) {
+    throw new Error(`setArtistPrivate failed: ${JSON.stringify(resp.errors)}`);
+  }
+}
+
+describe("artist activity heatmap authorization (Idea 032)", () => {
+  let app: App;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+  });
+
+  afterAll(async () => {
+    await closeTestDb();
+  });
+
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE users CASCADE`);
+  });
+
+  describe("public artist + public user (baseline)", () => {
+    it("anon viewer sees activitySeries and lastPostedAt for public posts", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "post one");
+      await createPost(app, author.token, author.trackId, "post two");
+
+      const resp = await gql(app, ARTIST_ACTIVITY_QUERY, {
+        username: author.artistUsername,
+      });
+      expect(resp.errors).toBeUndefined();
+      const artist = resp.data!.artist as {
+        activitySeries: Array<{ date: string; count: number }>;
+        lastPostedAt: string | null;
+      };
+      expect(artist.activitySeries).toHaveLength(1);
+      expect(artist.activitySeries[0].count).toBe(2);
+      expect(artist.lastPostedAt).not.toBeNull();
+    });
+
+    it("excludes draft posts for non-self viewers", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "public", "public");
+      await createPost(app, author.token, author.trackId, "draft", "draft");
+
+      const resp = await gql(app, ARTIST_ACTIVITY_QUERY, {
+        username: author.artistUsername,
+      });
+      const artist = resp.data!.artist as {
+        activitySeries: Array<{ count: number }>;
+      };
+      expect(artist.activitySeries[0].count).toBe(1);
+    });
+
+    it("self viewer sees draft posts in their own count", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "public", "public");
+      await createPost(app, author.token, author.trackId, "draft", "draft");
+
+      const resp = await gql(
+        app,
+        ARTIST_ACTIVITY_QUERY,
+        { username: author.artistUsername },
+        author.token,
+      );
+      const artist = resp.data!.artist as {
+        activitySeries: Array<{ count: number }>;
+      };
+      expect(artist.activitySeries[0].count).toBe(2);
+    });
+  });
+
+  describe("private artist (Layer 1)", () => {
+    it("non-tuned-in viewer cannot see activity at all", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "post one");
+      await setArtistPrivate(app, author.token);
+
+      // Anon viewer: artist query returns null entirely, so activity is unreachable
+      const respAnon = await gql(app, ARTIST_ACTIVITY_QUERY, {
+        username: author.artistUsername,
+      });
+      expect(respAnon.data!.artist).toBeNull();
+
+      // Authed third party: same — checkArtistAccess gates the artist query
+      const { token: otherToken } = await signupAndGetTokenAndId(
+        app,
+        "bob@test.com",
+        "bob",
+      );
+      const respOther = await gql(
+        app,
+        ARTIST_ACTIVITY_QUERY,
+        { username: author.artistUsername },
+        otherToken,
+      );
+      expect(respOther.data!.artist).toBeNull();
+    });
+
+    it("tuned-in viewer sees public posts only, not drafts", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "public", "public");
+      await createPost(app, author.token, author.trackId, "draft", "draft");
+      await setArtistPrivate(app, author.token);
+
+      const { token: fanToken } = await signupAndGetTokenAndId(
+        app,
+        "fan@test.com",
+        "fan",
+      );
+      await gql(
+        app,
+        TOGGLE_TUNE_IN_MUTATION,
+        { artistId: author.artistId },
+        fanToken,
+      );
+
+      const resp = await gql(
+        app,
+        ARTIST_ACTIVITY_QUERY,
+        { username: author.artistUsername },
+        fanToken,
+      );
+      const artist = resp.data!.artist as {
+        activitySeries: Array<{ count: number }>;
+      };
+      expect(artist).not.toBeNull();
+      expect(artist.activitySeries[0].count).toBe(1);
+    });
+  });
+
+  describe("private user / child author (Layer 0)", () => {
+    it("private adult author hidden from anon viewer", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "post one");
+      await setUserPrivate(app, author.token);
+
+      const resp = await gql(app, ARTIST_ACTIVITY_QUERY, {
+        username: author.artistUsername,
+      });
+      const artist = resp.data!.artist as {
+        activitySeries: Array<unknown>;
+        lastPostedAt: string | null;
+      };
+      // Artist row still resolvable (artists.profileVisibility=public by default),
+      // but activity is blanked because the *user* is private.
+      expect(artist.activitySeries).toEqual([]);
+      expect(artist.lastPostedAt).toBeNull();
+    });
+
+    it("private adult author still sees their own activity (self path)", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "post one");
+      await setUserPrivate(app, author.token);
+
+      const resp = await gql(
+        app,
+        ARTIST_ACTIVITY_QUERY,
+        { username: author.artistUsername },
+        author.token,
+      );
+      const artist = resp.data!.artist as {
+        activitySeries: Array<{ count: number }>;
+        lastPostedAt: string | null;
+      };
+      expect(artist.activitySeries[0].count).toBe(1);
+      expect(artist.lastPostedAt).not.toBeNull();
+    });
+
+    it("child author's activity hidden from third party even when artist is public", async () => {
+      const { guardianToken, childId } = await signupAndCreateChild(
+        app,
+        "guardian@test.com",
+        "guardian",
+        "kiddo",
+      );
+      const childToken = await switchToChildAndGetToken(
+        app,
+        guardianToken,
+        childId,
+      );
+      const artistResp = await gql(
+        app,
+        REGISTER_ARTIST_MUTATION,
+        { artistUsername: "kiddo_artist", displayName: "Kiddo Artist" },
+        childToken,
+      );
+      const trackResp = await gql(
+        app,
+        CREATE_TRACK_MUTATION,
+        { name: "Kiddo Track", color: "#00FF00" },
+        childToken,
+      );
+      const trackId = (trackResp.data!.createTrack as { id: string }).id;
+      await createPost(app, childToken, trackId, "child post");
+
+      // Even an anon viewer should see empty activity. (artist row may be
+      // unreachable depending on Tier setting, but if reachable the
+      // activity must be empty.)
+      void (artistResp.data!.registerArtist as { id: string });
+      const resp = await gql(app, ARTIST_ACTIVITY_QUERY, {
+        username: "kiddo_artist",
+      });
+      const artist = resp.data!.artist;
+      if (artist !== null) {
+        const a = artist as {
+          activitySeries: unknown[];
+          lastPostedAt: string | null;
+        };
+        expect(a.activitySeries).toEqual([]);
+        expect(a.lastPostedAt).toBeNull();
+      }
+    });
+  });
+
+  describe("track scope (unassigned posts excluded)", () => {
+    it("trackId=NULL posts are not counted", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "post one");
+      // Detach the post from the track by deleting the track (ON DELETE SET NULL)
+      await db.execute(sql`UPDATE posts SET track_id = NULL`);
+
+      const resp = await gql(
+        app,
+        ARTIST_ACTIVITY_QUERY,
+        { username: author.artistUsername },
+        author.token,
+      );
+      const artist = resp.data!.artist as {
+        activitySeries: unknown[];
+        lastPostedAt: string | null;
+      };
+      expect(artist.activitySeries).toEqual([]);
+      expect(artist.lastPostedAt).toBeNull();
+    });
+  });
+
+  describe("deep path (#250 sec-1 analogue)", () => {
+    it("myTuneIns → artist → activitySeries respects auth on tuned-in private artist", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "public", "public");
+      await createPost(app, author.token, author.trackId, "draft", "draft");
+      await setArtistPrivate(app, author.token);
+
+      const { token: fanToken } = await signupAndGetTokenAndId(
+        app,
+        "fan@test.com",
+        "fan",
+      );
+      await gql(
+        app,
+        TOGGLE_TUNE_IN_MUTATION,
+        { artistId: author.artistId },
+        fanToken,
+      );
+
+      const resp = await gql(app, MY_TUNE_INS_ACTIVITY_QUERY, {}, fanToken);
+      const tuneIns = resp.data!.myTuneIns as Array<{
+        artist: {
+          artistUsername: string;
+          activitySeries: Array<{ count: number }>;
+          lastPostedAt: string | null;
+        };
+      }>;
+      expect(tuneIns).toHaveLength(1);
+      // Drafts must NOT leak through the deep path either — both
+      // activitySeries.count and lastPostedAt are reached via the same
+      // `resolveActivityAccess` helper, but assert both explicitly so a
+      // future split of the helper into per-field auth paths cannot
+      // silently regress one without the other.
+      expect(tuneIns[0].artist.activitySeries[0].count).toBe(1);
+      expect(tuneIns[0].artist.lastPostedAt).not.toBeNull();
+    });
+  });
+
+  describe("discoverArtists prefetch", () => {
+    it("returns lastPostedAt filtered to public posts only", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "public", "public");
+      // A later draft must NOT advance lastPostedAt for non-self viewers.
+      await createPost(app, author.token, author.trackId, "draft", "draft");
+
+      const resp = await gql(app, DISCOVER_ARTISTS_QUERY);
+      const artistsRet = resp.data!.discoverArtists as Array<{
+        artistUsername: string;
+        lastPostedAt: string | null;
+      }>;
+      const target = artistsRet.find(
+        (a) => a.artistUsername === author.artistUsername,
+      );
+      expect(target?.lastPostedAt).not.toBeNull();
+      // The latest *public* post timestamp is what should be returned; we
+      // can't compare exact times, but lastPostedAt must match the public
+      // post (first one), not the draft. Verifying via the per-artist
+      // resolver from a third-party viewer should yield the same value.
+      const { token: otherToken } = await signupAndGetTokenAndId(
+        app,
+        "carol@test.com",
+        "carol",
+      );
+      const detail = await gql(
+        app,
+        ARTIST_ACTIVITY_QUERY,
+        { username: author.artistUsername },
+        otherToken,
+      );
+      const detailArtist = detail.data!.artist as { lastPostedAt: string };
+      expect(target!.lastPostedAt).toBe(detailArtist.lastPostedAt);
+    });
+
+    it("returns null lastPostedAt when author has only drafts", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "draft", "draft");
+
+      const resp = await gql(app, DISCOVER_ARTISTS_QUERY);
+      const artistsRet = resp.data!.discoverArtists as Array<{
+        artistUsername: string;
+        lastPostedAt: string | null;
+      }>;
+      const target = artistsRet.find(
+        (a) => a.artistUsername === author.artistUsername,
+      );
+      expect(target?.lastPostedAt).toBeNull();
+    });
+
+    it("does not list private artists at all (no row, no prefetch)", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "post one");
+      await setArtistPrivate(app, author.token);
+
+      const resp = await gql(app, DISCOVER_ARTISTS_QUERY);
+      const artistsRet = resp.data!.discoverArtists as Array<{
+        artistUsername: string;
+      }>;
+      // The whole row is omitted from discoverArtists — pulse beacon can
+      // never be rendered for a private artist because the artist isn't
+      // listed in the first place.
+      expect(
+        artistsRet.find((a) => a.artistUsername === author.artistUsername),
+      ).toBeUndefined();
+    });
+
+    it("does not leak private user activity via prefetch", async () => {
+      const author = await createPublicArtistWithTrack(
+        app,
+        "alice@test.com",
+        "alice",
+        "alice_artist",
+      );
+      await createPost(app, author.token, author.trackId, "post one");
+      await setUserPrivate(app, author.token);
+
+      const resp = await gql(app, DISCOVER_ARTISTS_QUERY);
+      const artistsRet = resp.data!.discoverArtists as Array<{
+        artistUsername: string;
+        lastPostedAt: string | null;
+      }>;
+      const target = artistsRet.find(
+        (a) => a.artistUsername === author.artistUsername,
+      );
+      expect(target?.lastPostedAt).toBeNull();
+    });
+  });
+});

--- a/backend/src/graphql/builder.ts
+++ b/backend/src/graphql/builder.ts
@@ -1,4 +1,5 @@
 import SchemaBuilder from "@pothos/core";
+import type { SQL } from "drizzle-orm";
 import type { AuthUser } from "../auth/middleware.js";
 import type { artists } from "../db/schema/index.js";
 // `import type` erases at compile time, so this does not create a runtime
@@ -43,6 +44,15 @@ export interface GraphQLContext {
    * `publicUserColumns` shape here.
    */
   tuneInUserCache?: Map<string, PublicUserShape>;
+  /**
+   * Per-request cache for `Artist.activitySeries` / `Artist.lastPostedAt`
+   * authorization checks (Idea 032). Both fields run the same
+   * `checkArtistAccess` + Layer-0 author lookup; without this cache, a
+   * client querying both fields on N artists fires 4N round-trips. Key
+   * is `${artistId}:${viewerUserId ?? "anon"}`. Stores `null` for
+   * authorization denials so we don't re-prove them on the second field.
+   */
+  activityAccessCache?: Map<string, { baseConditions: SQL[] } | null>;
 }
 
 export const builder = new SchemaBuilder<{

--- a/backend/src/graphql/builder.ts
+++ b/backend/src/graphql/builder.ts
@@ -48,9 +48,12 @@ export interface GraphQLContext {
    * Per-request cache for `Artist.activitySeries` / `Artist.lastPostedAt`
    * authorization checks (Idea 032). Both fields run the same
    * `checkArtistAccess` + Layer-0 author lookup; without this cache, a
-   * client querying both fields on N artists fires 4N round-trips. Key
-   * is `${artistId}:${viewerUserId ?? "anon"}`. Stores `null` for
-   * authorization denials so we don't re-prove them on the second field.
+   * client querying both fields on N artists (where N = the number of
+   * `Artist` rows resolved in the request, typically 1 for an artist
+   * page or up to `discoverArtists.limit` for the Discover list) fires
+   * 4N round-trips. Key is `${artistId}:${viewerUserId ?? "anon"}`.
+   * Stores `null` for authorization denials so we don't re-prove them
+   * on the second field.
    */
   activityAccessCache?: Map<string, { baseConditions: SQL[] } | null>;
 }

--- a/backend/src/graphql/types/artist-activity.ts
+++ b/backend/src/graphql/types/artist-activity.ts
@@ -1,0 +1,194 @@
+/**
+ * Activity heatmap fields on `Artist` (Idea 032).
+ *
+ * Exposes two read-only derived metrics that drive the artist page's "star
+ * calendar" heatmap and the discover card's pulse beacon:
+ *
+ * - `activitySeries: [ActivityDay!]!` — daily post count from the artist's
+ *   registration date (or `today - 365d`, whichever is later) up to today.
+ *   Only days with at least one matching post are returned.
+ * - `lastPostedAt: String` — ISO 8601 timestamp of the most recent matching
+ *   post, or null if none.
+ *
+ * Authorization mirrors `recentPosts` exactly so that activity counts cannot
+ * leak information that the post resolvers would hide:
+ *   1. `checkArtistAccess` (Layer 1: `artists.profileVisibility`) — re-run
+ *      inside the field resolver even on deep paths (see #250 sec-1).
+ *   2. `isAuthorVisibleToViewer` (Layer 0: `users.profileVisibility`) — child
+ *      / non-public author rows are hidden from non-self viewers.
+ *   3. `posts.visibility = 'public'` — for non-self viewers (incl. tuned-in
+ *      followers, matching `recentPosts` / `artistPosts` behaviour).
+ *   4. `posts.trackId IS NOT NULL` — unassigned posts are excluded so the
+ *      heatmap reflects the same scope as the artist's track timeline (#67).
+ *
+ * The 365-day window is hardcoded; clients trim further if the artist is
+ * newer. Future `periodDays` argument should be clamped with
+ * `Math.max(1, Math.min(args.periodDays ?? 365, 365))` to prevent DoS.
+ */
+import { builder, type GraphQLContext } from "../builder.js";
+import { db } from "../../db/index.js";
+import { posts, users } from "../../db/schema/index.js";
+import { and, eq, gte, sql, type SQL } from "drizzle-orm";
+import { ArtistType } from "./artist.js";
+import { checkArtistAccess, isAuthorVisibleToViewer } from "../access.js";
+
+const ACTIVITY_PERIOD_DAYS = 365;
+
+/** Internal shape used for the GROUP BY result. */
+interface ActivityDayShape {
+  date: string;
+  count: number;
+}
+
+export const ActivityDayType = builder
+  .objectRef<ActivityDayShape>("ActivityDay")
+  .implement({
+    description:
+      "A single day of artist posting activity. `date` is the UTC date " +
+      "portion in ISO 8601 short form (YYYY-MM-DD). `count` includes only " +
+      "posts the viewer is permitted to see (Idea 032).",
+    fields: (t) => ({
+      date: t.exposeString("date"),
+      count: t.exposeInt("count"),
+    }),
+  });
+
+/**
+ * Resolve the viewer's authorization view of an artist's activity.
+ *
+ * Returns `null` when the viewer is forbidden from seeing any activity at
+ * all (private artist + non-tuned-in, or Layer-0 hidden author). Returns
+ * the `(isSelf, baseConditions)` pair otherwise — `baseConditions` is an
+ * array of `SQL` predicates already including the visibility gate when
+ * applicable. Callers spread it into `and(...)` alongside their own
+ * conditions, avoiding the `and(undefined)` pattern (relies on a Drizzle
+ * implementation detail and degrades gracefully but silently if it ever
+ * changes). Same authorization chain as `recentPosts`.
+ */
+async function resolveActivityAccess(
+  artistId: string,
+  artistUserId: string,
+  authUser: GraphQLContext["authUser"],
+): Promise<{
+  isSelf: boolean;
+  baseConditions: SQL[];
+} | null> {
+  const access = await checkArtistAccess(artistId, authUser);
+  if (!access.accessible) return null;
+
+  // Layer 0: hide child / non-public-user authors from non-self viewers.
+  // checkArtistAccess only inspects `artists.profileVisibility` (Layer 1) so
+  // an explicit users-row lookup is required here.
+  const [author] = await db
+    .select({
+      userId: users.id,
+      guardianId: users.guardianId,
+      profileVisibility: users.profileVisibility,
+    })
+    .from(users)
+    .where(eq(users.id, artistUserId))
+    .limit(1);
+  if (!author) return null;
+  if (!isAuthorVisibleToViewer(author, authUser?.userId ?? null)) return null;
+
+  const baseConditions: SQL[] = [eq(posts.authorId, artistUserId)];
+  if (!access.isSelf) {
+    baseConditions.push(eq(posts.visibility, "public"));
+  }
+  return { isSelf: access.isSelf, baseConditions };
+}
+
+builder.objectFields(ArtistType, (t) => ({
+  activitySeries: t.field({
+    type: [ActivityDayType],
+    description:
+      "Daily post counts for the activity heatmap (Idea 032). Returns " +
+      "only days with at least one matching post, from the later of " +
+      "`artist.createdAt` or 365 days ago to today.",
+    resolve: async (artist, _args, ctx) => {
+      const access = await resolveActivityAccess(
+        artist.id,
+        artist.userId,
+        ctx.authUser,
+      );
+      if (!access) return [];
+
+      const horizon = new Date(Date.now() - ACTIVITY_PERIOD_DAYS * 86_400_000);
+      const fromDate =
+        artist.createdAt.getTime() > horizon.getTime()
+          ? artist.createdAt
+          : horizon;
+
+      // Bucket key is reused in SELECT / GROUP BY / ORDER BY — define once
+      // as a SELECT alias and reference the alias to avoid silent drift if
+      // the expression ever changes (matches tune-in.ts MAX(updatedAt)
+      // alias pattern).
+      const bucketExpr = sql<string>`to_char((${posts.createdAt} AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD')`;
+      const rows = await db
+        .select({
+          date: bucketExpr.as("activity_date"),
+          count: sql<number>`count(*)::int`,
+        })
+        .from(posts)
+        .where(
+          and(
+            ...access.baseConditions,
+            sql`${posts.trackId} IS NOT NULL`,
+            gte(posts.createdAt, fromDate),
+          ),
+        )
+        .groupBy(sql`activity_date`)
+        .orderBy(sql`activity_date`);
+
+      return rows;
+    },
+  }),
+
+  lastPostedAt: t.string({
+    nullable: true,
+    description:
+      "ISO 8601 timestamp of the most recent post visible to the viewer " +
+      "(Idea 032). Drives the discover-card pulse beacon. Prefetched by " +
+      "`discoverArtists` to avoid N+1; falls back to a per-artist query " +
+      "on other Artist paths. Intentionally NOT clamped to the 365-day " +
+      "heatmap window — the pulse should still surface artists who " +
+      "posted >1y ago, even when the heatmap shows nothing.",
+    resolve: async (artist, _args, ctx) => {
+      // Discover prefetch path: `_lastPostedAt` is already filtered to
+      // public posts + non-null trackId + public author + public artist.
+      // Even when the viewer is the artist owner, the discover surface
+      // clamps the pulse to public posts on purpose — the beacon should
+      // mean the same thing to everyone, and drafts belong on the artist
+      // page heatmap (where `resolveActivityAccess` adds the self
+      // exemption). `null` is a legitimate prefetch result (no matching
+      // posts), so we check for `undefined` rather than truthy.
+      if (artist._lastPostedAt !== undefined) {
+        return artist._lastPostedAt
+          ? new Date(artist._lastPostedAt).toISOString()
+          : null;
+      }
+
+      const access = await resolveActivityAccess(
+        artist.id,
+        artist.userId,
+        ctx.authUser,
+      );
+      if (!access) return null;
+
+      // postgres.js does not auto-parse aggregate (MAX) results to Date;
+      // keep the raw `string | null` and normalize via `new Date(...)`.
+      const [row] = await db
+        .select({
+          lastPostedAt: sql<string | null>`MAX(${posts.createdAt})`,
+        })
+        .from(posts)
+        .where(
+          and(...access.baseConditions, sql`${posts.trackId} IS NOT NULL`),
+        );
+
+      return row?.lastPostedAt
+        ? new Date(row.lastPostedAt).toISOString()
+        : null;
+    },
+  }),
+}));

--- a/backend/src/graphql/types/artist-activity.ts
+++ b/backend/src/graphql/types/artist-activity.ts
@@ -190,9 +190,10 @@ builder.objectFields(ArtistType, (t) => ({
 
       // Fallback path (artist / myArtist / featuredArtist / TuneInType.artist).
       // No 365-day clamp here — see field description. The
-      // `posts_author_visibility_created_idx` makes `MAX(created_at)` an
-      // index-only seek per author, so a full-time scan is constant-cost
-      // even on long-lived artists.
+      // `posts_author_visibility_created_idx` covers most of the WHERE
+      // clause; `trackId IS NOT NULL` still costs a heap fetch per
+      // candidate row, which is bounded by posts-per-author. Issue #430
+      // tracks switching to a partial index that drops the heap fetch.
       //
       // postgres.js does not auto-parse aggregate (MAX) results to Date;
       // keep the raw `string | null` and normalize via `new Date(...)`.

--- a/backend/src/graphql/types/artist-activity.ts
+++ b/backend/src/graphql/types/artist-activity.ts
@@ -32,6 +32,7 @@ import { and, eq, gte, sql, type SQL } from "drizzle-orm";
 import { ArtistType } from "./artist.js";
 import { checkArtistAccess, isAuthorVisibleToViewer } from "../access.js";
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const ACTIVITY_PERIOD_DAYS = 365;
 
 /** Internal shape used for the GROUP BY result. */
@@ -58,27 +59,35 @@ export const ActivityDayType = builder
  *
  * Returns `null` when the viewer is forbidden from seeing any activity at
  * all (private artist + non-tuned-in, or Layer-0 hidden author). Returns
- * the `(isSelf, baseConditions)` pair otherwise — `baseConditions` is an
- * array of `SQL` predicates already including the visibility gate when
- * applicable. Callers spread it into `and(...)` alongside their own
- * conditions, avoiding the `and(undefined)` pattern (relies on a Drizzle
- * implementation detail and degrades gracefully but silently if it ever
- * changes). Same authorization chain as `recentPosts`.
+ * `{ baseConditions }` — an array of `SQL` predicates already including the
+ * visibility gate when applicable — otherwise. Callers spread it into
+ * `and(...)` alongside their own conditions, avoiding `and(undefined)`
+ * (Drizzle implementation detail). Same authorization chain as
+ * `recentPosts`.
+ *
+ * Cached per-request on `ctx.activityAccessCache` so the two activity
+ * fields don't double the auth round-trips on the same artist. Cache
+ * stores `null` for denials so a second field on the same artist doesn't
+ * re-prove access.
  */
 async function resolveActivityAccess(
-  artistId: string,
-  artistUserId: string,
-  authUser: GraphQLContext["authUser"],
-): Promise<{
-  isSelf: boolean;
-  baseConditions: SQL[];
-} | null> {
-  const access = await checkArtistAccess(artistId, authUser);
-  if (!access.accessible) return null;
+  artist: { id: string; userId: string },
+  ctx: GraphQLContext,
+): Promise<{ baseConditions: SQL[] } | null> {
+  ctx.activityAccessCache ??= new Map();
+  const cacheKey = `${artist.id}:${ctx.authUser?.userId ?? "anon"}`;
+  const cached = ctx.activityAccessCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const access = await checkArtistAccess(artist.id, ctx.authUser);
+  if (!access.accessible) {
+    ctx.activityAccessCache.set(cacheKey, null);
+    return null;
+  }
 
   // Layer 0: hide child / non-public-user authors from non-self viewers.
-  // checkArtistAccess only inspects `artists.profileVisibility` (Layer 1) so
-  // an explicit users-row lookup is required here.
+  // checkArtistAccess only inspects `artists.profileVisibility` (Layer 1)
+  // so an explicit users-row lookup is required here.
   const [author] = await db
     .select({
       userId: users.id,
@@ -86,16 +95,23 @@ async function resolveActivityAccess(
       profileVisibility: users.profileVisibility,
     })
     .from(users)
-    .where(eq(users.id, artistUserId))
+    .where(eq(users.id, artist.userId))
     .limit(1);
-  if (!author) return null;
-  if (!isAuthorVisibleToViewer(author, authUser?.userId ?? null)) return null;
+  if (
+    !author ||
+    !isAuthorVisibleToViewer(author, ctx.authUser?.userId ?? null)
+  ) {
+    ctx.activityAccessCache.set(cacheKey, null);
+    return null;
+  }
 
-  const baseConditions: SQL[] = [eq(posts.authorId, artistUserId)];
+  const baseConditions: SQL[] = [eq(posts.authorId, artist.userId)];
   if (!access.isSelf) {
     baseConditions.push(eq(posts.visibility, "public"));
   }
-  return { isSelf: access.isSelf, baseConditions };
+  const result = { baseConditions };
+  ctx.activityAccessCache.set(cacheKey, result);
+  return result;
 }
 
 builder.objectFields(ArtistType, (t) => ({
@@ -106,23 +122,18 @@ builder.objectFields(ArtistType, (t) => ({
       "only days with at least one matching post, from the later of " +
       "`artist.createdAt` or 365 days ago to today.",
     resolve: async (artist, _args, ctx) => {
-      const access = await resolveActivityAccess(
-        artist.id,
-        artist.userId,
-        ctx.authUser,
-      );
+      const access = await resolveActivityAccess(artist, ctx);
       if (!access) return [];
 
-      const horizon = new Date(Date.now() - ACTIVITY_PERIOD_DAYS * 86_400_000);
+      const horizon = new Date(Date.now() - ACTIVITY_PERIOD_DAYS * MS_PER_DAY);
       const fromDate =
         artist.createdAt.getTime() > horizon.getTime()
           ? artist.createdAt
           : horizon;
 
-      // Bucket key is reused in SELECT / GROUP BY / ORDER BY — define once
-      // as a SELECT alias and reference the alias to avoid silent drift if
-      // the expression ever changes (matches tune-in.ts MAX(updatedAt)
-      // alias pattern).
+      // Bucket key is reused across SELECT / GROUP BY / ORDER BY — define
+      // once as a SELECT alias to keep the three call sites in sync
+      // (tune-in.ts MAX(updatedAt) pattern).
       const bucketExpr = sql<string>`to_char((${posts.createdAt} AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD')`;
       const rows = await db
         .select({
@@ -154,27 +165,35 @@ builder.objectFields(ArtistType, (t) => ({
       "heatmap window — the pulse should still surface artists who " +
       "posted >1y ago, even when the heatmap shows nothing.",
     resolve: async (artist, _args, ctx) => {
-      // Discover prefetch path: `_lastPostedAt` is already filtered to
-      // public posts + non-null trackId + public author + public artist.
-      // Even when the viewer is the artist owner, the discover surface
-      // clamps the pulse to public posts on purpose — the beacon should
-      // mean the same thing to everyone, and drafts belong on the artist
-      // page heatmap (where `resolveActivityAccess` adds the self
-      // exemption). `null` is a legitimate prefetch result (no matching
-      // posts), so we check for `undefined` rather than truthy.
+      // Run authorization first — even when `_lastPostedAt` is prefetched
+      // — so any caller who attaches the prefetch field on a different
+      // Artist path (e.g. a future TuneInType.artist that JOINs the same
+      // aggregate) cannot bypass Layer 0/1 checks. The auth result is
+      // cached per request, so this stays cheap when `activitySeries`
+      // also queried.
+      const access = await resolveActivityAccess(artist, ctx);
+      if (!access) return null;
+
+      // Discover prefetch path: `_lastPostedAt` is filtered inside the
+      // outer query to public posts + non-null trackId + public author +
+      // public artist. The same value is the right answer for non-self
+      // and self viewers on Discover by design — the beacon should mean
+      // the same thing to everyone, and drafts belong on the artist
+      // page heatmap (where the fallback below + auth-side baseConditions
+      // add the self exemption). `null` is a legitimate prefetch result,
+      // so we check `undefined`.
       if (artist._lastPostedAt !== undefined) {
         return artist._lastPostedAt
           ? new Date(artist._lastPostedAt).toISOString()
           : null;
       }
 
-      const access = await resolveActivityAccess(
-        artist.id,
-        artist.userId,
-        ctx.authUser,
-      );
-      if (!access) return null;
-
+      // Fallback path (artist / myArtist / featuredArtist / TuneInType.artist).
+      // No 365-day clamp here — see field description. The
+      // `posts_author_visibility_created_idx` makes `MAX(created_at)` an
+      // index-only seek per author, so a full-time scan is constant-cost
+      // even on long-lived artists.
+      //
       // postgres.js does not auto-parse aggregate (MAX) results to Date;
       // keep the raw `string | null` and normalize via `new Date(...)`.
       const [row] = await db

--- a/backend/src/graphql/types/artist.ts
+++ b/backend/src/graphql/types/artist.ts
@@ -393,6 +393,11 @@ builder.queryFields((t) => ({
       // stays correct even if a future refactor relaxes the outer filter.
       // The extra INNER JOIN is also a perf win — it caps the GROUP BY to
       // users who actually have an artist row.
+      //
+      // Note: the sub-query aggregates across all matching posts on every
+      // `discoverArtists` call. Issue #431 tracks materialising
+      // `artists.last_posted_at` so the GROUP BY can be replaced with a
+      // direct column read once Phase 1 scale demands it.
       const lastPostSq = db
         .select({
           authorId: posts.authorId,

--- a/backend/src/graphql/types/artist.ts
+++ b/backend/src/graphql/types/artist.ts
@@ -1,7 +1,7 @@
 import { GraphQLError } from "graphql";
 import { builder } from "../builder.js";
 import { db } from "../../db/index.js";
-import { artists, artistGenres } from "../../db/schema/index.js";
+import { artists, artistGenres, posts, users } from "../../db/schema/index.js";
 import { and, eq, desc, asc, sql } from "drizzle-orm";
 import {
   validateProfileVisibility,
@@ -26,6 +26,17 @@ export const ArtistType = builder.objectRef<{
   tunedInCount: number;
   createdAt: Date;
   updatedAt: Date;
+  // Prefetched by `discoverArtists` to avoid N+1 on the pulse beacon. Only
+  // present on the Discover list path; field resolver falls back to a
+  // per-artist MAX query when undefined. Layer-0/Layer-1/visibility filters
+  // are applied inside the JOIN so this value already represents the
+  // viewer-safe public timestamp (Idea 032).
+  //
+  // Typed as `string` because postgres.js does NOT auto-parse aggregate
+  // (MAX/MIN) results to Date — only declared `timestamp` columns. The
+  // field resolver normalizes via `new Date(...).toISOString()` so wire
+  // output stays ISO 8601 regardless of driver quirks.
+  _lastPostedAt?: string | null;
 }>("Artist");
 
 ArtistType.implement({
@@ -370,6 +381,60 @@ builder.queryFields((t) => ({
 
       const publicOnly = eq(artists.profileVisibility, "public");
 
+      // Pulse beacon prefetch (Idea 032): MAX(created_at) per author, with
+      // the same Layer-0 / Layer-1 / visibility / track filters used by
+      // `recentPosts` so the pulse can never reveal activity that the post
+      // resolvers would hide. Applied to all 3 discover paths to avoid N+1
+      // on `Artist.lastPostedAt`.
+      //
+      // Defense in depth: the outer query already gates by
+      // `artists.profileVisibility = 'public'` (publicOnly below), but the
+      // subquery joins `artists` and filters again so the prefetched value
+      // stays correct even if a future refactor relaxes the outer filter.
+      // The extra INNER JOIN is also a perf win — it caps the GROUP BY to
+      // users who actually have an artist row.
+      const lastPostSq = db
+        .select({
+          authorId: posts.authorId,
+          // postgres.js does not auto-parse aggregate results to Date —
+          // keep raw `string | null` and let the field resolver normalize
+          // (see _lastPostedAt typing on ArtistType).
+          lastPostedAt: sql<string | null>`MAX(${posts.createdAt})`.as(
+            "last_posted_at",
+          ),
+        })
+        .from(posts)
+        .innerJoin(users, eq(users.id, posts.authorId))
+        .innerJoin(artists, eq(artists.userId, posts.authorId))
+        .where(
+          and(
+            eq(posts.visibility, "public"),
+            eq(users.profileVisibility, "public"),
+            eq(artists.profileVisibility, "public"),
+            sql`${posts.trackId} IS NOT NULL`,
+          ),
+        )
+        .groupBy(posts.authorId)
+        .as("last_post_sq");
+
+      const artistCols = {
+        id: artists.id,
+        userId: artists.userId,
+        artistUsername: artists.artistUsername,
+        displayName: artists.displayName,
+        bio: artists.bio,
+        tagline: artists.tagline,
+        location: artists.location,
+        activeSince: artists.activeSince,
+        avatarUrl: artists.avatarUrl,
+        coverImageUrl: artists.coverImageUrl,
+        profileVisibility: artists.profileVisibility,
+        tunedInCount: artists.tunedInCount,
+        createdAt: artists.createdAt,
+        updatedAt: artists.updatedAt,
+        _lastPostedAt: lastPostSq.lastPostedAt,
+      } as const;
+
       // Genre filter: single JOIN query instead of 2-query split
       if (args.genreId) {
         const textFilter = pattern
@@ -377,27 +442,13 @@ builder.queryFields((t) => ({
           : sql``;
 
         return db
-          .select({
-            id: artists.id,
-            userId: artists.userId,
-            artistUsername: artists.artistUsername,
-            displayName: artists.displayName,
-            bio: artists.bio,
-            tagline: artists.tagline,
-            location: artists.location,
-            activeSince: artists.activeSince,
-            avatarUrl: artists.avatarUrl,
-            coverImageUrl: artists.coverImageUrl,
-            profileVisibility: artists.profileVisibility,
-            tunedInCount: artists.tunedInCount,
-            createdAt: artists.createdAt,
-            updatedAt: artists.updatedAt,
-          })
+          .select(artistCols)
           .from(artists)
           .innerJoin(
             artistGenres,
             sql`${artistGenres.artistId} = ${artists.id} AND ${artistGenres.genreId} = ${args.genreId}`,
           )
+          .leftJoin(lastPostSq, eq(lastPostSq.authorId, artists.userId))
           .where(sql`${artists.profileVisibility} = 'public'${textFilter}`)
           .orderBy(desc(artists.tunedInCount))
           .limit(limit)
@@ -407,8 +458,9 @@ builder.queryFields((t) => ({
       // Text search only
       if (pattern) {
         return db
-          .select()
+          .select(artistCols)
           .from(artists)
+          .leftJoin(lastPostSq, eq(lastPostSq.authorId, artists.userId))
           .where(
             and(
               publicOnly,
@@ -422,8 +474,9 @@ builder.queryFields((t) => ({
 
       // No filters — all public artists by popularity
       return db
-        .select()
+        .select(artistCols)
         .from(artists)
+        .leftJoin(lastPostSq, eq(lastPostSq.authorId, artists.userId))
         .where(publicOnly)
         .orderBy(desc(artists.tunedInCount))
         .limit(limit)

--- a/backend/src/graphql/types/index.ts
+++ b/backend/src/graphql/types/index.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { UserType, userColumns } from "./user.js";
 import "./auth.js";
 import "./artist.js";
+import "./artist-activity.js";
 import "./track.js";
 import "./post.js";
 import "./reaction.js";

--- a/docs/ideas/032-activity-heatmap-and-pulse.md
+++ b/docs/ideas/032-activity-heatmap-and-pulse.md
@@ -1,0 +1,74 @@
+# Idea 032: Star Calendar Heatmap & Pulse Beacon
+
+**Status:** Validated
+**Priority:** Phase 0.x (immediate)
+**Date:** 2026-05-18
+
+## Summary
+
+Visualize per-artist daily posting activity using two complementary components themed around Gleisner's "artist's universe" metaphor: (1) a **star calendar** heatmap on the artist page (GitHub-style contribution grid reinterpreted as a night sky), and (2) a **pulse beacon** dot on discovery cards indicating recency of activity. The goal is to make daily posting feel visibly rewarded and to surface "alive" artists in discovery, reinforcing posting motivation among the current ~4 active artists.
+
+## Notes
+
+### Component 1: Star calendar (artist page)
+
+- Placed directly below the Tune In button on the artist page
+- Grid: 7 rows × N weeks (N = weeks since registration, capped at 52; horizontal scroll for older artists)
+- Cell shape: **circles**, not squares — more cosmic, less industrial; row spacing slightly looser than GitHub
+- Background per cell: deep space color (`#0A0E1A`-ish), optional faint star dust noise
+- Active cells map post count to star brightness:
+  - 1 post: faint small star (low-opacity white)
+  - 2–3: brighter star with mild glow
+  - 4–6: bright star + halo
+  - 7+: cluster / nebula — largest glow, accent tint (cyan or violet)
+- Optional sparse twinkle animation (performance-budgeted)
+- Tooltip on hover/tap: `YYYY/MM/DD · N 件の投稿` (empty days show just date)
+- Empty-state copy for brand-new artists: 「これから星が灯ります」 (or English equivalent in i18n)
+- Naming candidates for the section header: 星暦 (せいれき) / 光跡 (こうせき) / "Star Calendar"
+
+### Component 2: Pulse beacon (discovery cards)
+
+- Position: top-right of the artist card cover image, 8–12px dot
+- Maps last-posted recency to a beacon state:
+  - Within 24h: bright cyan/white, fast breathing pulse (~1.2s cycle)
+  - Within 7d: warm white, slower pulse (~2s)
+  - Within 30d: dim static glow (no animation)
+  - >30d: hidden — silence is a meaningful state
+- Animation drives **opacity only**, never scale/transform — keeps GPU cost flat across many cards
+- Optional long-press / hover: textual recency ("3 日前にアクティブ")
+
+### Backend
+
+- New endpoint, e.g., `GET /artists/:id/activity` returning:
+  - `series: { date: ISODate, count: int }[]` for the calendar (registration → today, capped at 365 entries)
+  - `lastPostedAt: ISODate | null` for the beacon
+- Daily aggregate is cheap; cache per-day (or compute on demand and HTTP-cache 1h)
+- For the discovery list, `lastPostedAt` may be inlined into the artist list response to avoid N+1 fetches
+
+### Frontend (Flutter)
+
+- `CustomPainter` for the calendar grid — paint cells in one pass, avoid per-cell widgets
+- `AnimationController` for the pulse, with a single controller per visible card; consider a shared ticker if many cards animate
+- Wrap discovery cards in `RepaintBoundary` to localize repaints (see [[project_constellation_performance.md]])
+- Respect reduced-motion preferences: disable twinkle and pulse animation when set
+
+### Phase considerations
+
+- Star calendar works in Phase 0 context too — the "family lifelog" framing ("our child's activity sky") is a natural fit
+- Pulse beacon depends on Discovery being visible; ship together if Discovery is already exposed to current users
+- This idea is greenlit for immediate implementation despite Phase 0 timing because the 4 active artists' visible reward loop directly affects retention
+
+### Open questions
+
+- Does the heatmap count **all** posts or only public/timeline-visible posts? (Affects how private/draft activity is reflected.) Default: count all posts the viewer is permitted to see — i.e., apply existing visibility filter at aggregation time.
+- For an artist with <7 days of registration, should the calendar render at all or wait until there's enough horizontal width? Suggestion: always render, padded left so the first week aligns to "today" column.
+- Privacy: should an artist be able to opt out of showing the heatmap or pulse? Probably yes longer-term; not required for v1.
+
+### Related
+
+- ADR 006 (Constellation visual design — star/space metaphor source)
+- ADR 008 (Artist mode / Fan mode — affects who sees what)
+- ADR 009 (Discover tab — host surface for the pulse beacon)
+- ADR 013 (Profile and artist page — host surface for the calendar)
+- Idea 005 (Synapse timeline — adjacent universe-themed visualization)
+- Idea 015 (View count display — adjacent activity-metric display)


### PR DESCRIPTION
## Summary

Idea 032 のバックエンド実装。アーティストの daily 投稿活動を集計する 2 つの GraphQL フィールドを `Artist` に追加。

- `Artist.activitySeries: [ActivityDay!]!` — 直近 365 日（or 登録日以降）の daily 投稿カウント。star calendar ヒートマップを駆動
- `Artist.lastPostedAt: String` — 最新の可視 post の ISO 8601 timestamp。discover カードの pulse beacon を駆動。N+1 回避のため `discoverArtists` で MAX prefetch

## 認可

`recentPosts` / `artistPosts` / `TrackType.posts` と完全パリティ:

1. **Layer 1** (`artists.profileVisibility`) — `checkArtistAccess` で fan は tune-in 必須
2. **Layer 0** (`users.profileVisibility`) — `isAuthorVisibleToViewer` で child / non-public author を第三者から隠す
3. **post.visibility** — 非 self viewer（tuned-in fan 含む）には `'public'` のみ。draft は不可視
4. **trackId IS NOT NULL** — unassigned posts を除外（`recentPosts` #67 のスコープに揃える）

`discoverArtists` の MAX(created_at) prefetch sub-query は outer の `publicOnly` に加え `users.profileVisibility / artists.profileVisibility / posts.visibility / trackId` の 4 層を sub-query 内で再適用（防御多層化、refactor 耐性）。

deep path (`myTuneIns → artist → activitySeries/lastPostedAt`) でも field resolver 内で `checkArtistAccess` を再実行し、親オブジェクトのプリフェッチ状態に依存しない設計（#250 sec-1 教訓）。

## マイグレーション

`0017_public_mysterio.sql`: `posts(author_id, visibility, created_at)` の compound index 追加のみ。破壊的変更なし。本番デプロイ後に `pnpm db:migrate` の実行を確認。

## テスト

`backend/src/graphql/__tests__/artist-activity.test.ts` に 14 件追加（674 / 675 全件パス、1 skipped は既存の意図的スキップ）:

- public artist baseline (anon / non-self / self の draft 可視性)
- Layer 1 private artist (non-tuned-in / tuned-in × draft 除外)
- Layer 0 private user / child author
- track scope (`trackId IS NULL` 除外)
- deep path (`myTuneIns → artist` で `activitySeries.count` / `lastPostedAt` 両方を assert)
- `discoverArtists` prefetch (private artist 非掲載 / private user の `lastPostedAt = null` / draft で advance しない)

## 関連 ADR / Idea

- Idea 032 (Star Calendar Heatmap & Pulse Beacon)
- ADR 006 (constellation visual design — 星 / 宇宙メタファ)
- ADR 008 (Artist mode / Fan mode)
- ADR 009 (Discover tab)
- ADR 013 (Profile and artist page)
- ADR 019 §"Phase 0 Amendment"（child author visibility = `users.profileVisibility` sole gate）
- ADR 021 (`users.profileVisibility` Layer 0)

## レビューフロー

事前に security-reviewer + graphql-reviewer + synthesis-reviewer で 3 段レビュー実施。合計 10 件の指摘から 7 件を反映、3 件は ADR 019 Phase 0 amendment 等との整合性により却下（PR-A / #363 の意図的な `guardianId IS NULL` 除去ロジックを尊重）。

## ⚠️ Phase 0 post-launch — skip 不可カテゴリ

DB マイグレーション + GraphQL 認可レイヤーを含むため、ローンチ圧モードでも skip 不可。通常レビュー必須・48h バッチに頼らない。

## Test plan

- [ ] CI: build + lint + format:check + 全テスト green
- [ ] 本番デプロイ後に `pnpm db:migrate` で index が適用されたこと（`\d posts` で `posts_author_visibility_created_idx` を確認）
- [ ] フロント PR 2 (StarCalendar) で artist page を開き、activitySeries が正しく描画されること
- [ ] フロント PR 3 (PulseBeacon) で discover カードに lastPostedAt 由来の pulse が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)