### PR TITLE
fix(activity-grid): align week-column count to join day's ISO week

### DIFF
--- a/frontend/lib/widgets/artist/activity_grid.dart
+++ b/frontend/lib/widgets/artist/activity_grid.dart
@@ -792,9 +792,20 @@ class ActivityGridPainter extends CustomPainter {
   /// midnight at the start of that Monday. Used by the widget to
   /// align grid columns to whole calendar weeks (Mon–Sun) and by
   /// tests to pin the expected leftmost column of the grid.
+  ///
+  /// Accepts either a local or UTC [d]; only the `year` / `month` /
+  /// `day` fields are read, so the time-of-day and the timezone tag
+  /// don't matter. The result is always a UTC midnight DateTime so
+  /// callers can compare with other `mondayOf` results or with
+  /// `DateTime.utc(...)` values without timezone drift.
   static DateTime mondayOf(DateTime d) {
     final day = DateTime.utc(d.year, d.month, d.day);
-    return day.subtract(Duration(days: d.weekday - 1));
+    // Use the normalized `day`'s weekday rather than `d.weekday` so
+    // the calculation stays internally consistent if a future
+    // refactor changes how `d` is constructed. Both yield the same
+    // weekday today (proleptic Gregorian calendar gives a single
+    // weekday per y/m/d), but reading from `day` makes that explicit.
+    return day.subtract(Duration(days: day.weekday - 1));
   }
 
   /// Number of week columns the grid needs to cover the span from
@@ -817,11 +828,16 @@ class ActivityGridPainter extends CustomPainter {
   /// Clamped to [1, maxWeeks]. Returns 1 defensively when
   /// [joinedDay] is after [today] (callers gate this case via
   /// `canRenderGrid`).
+  ///
+  /// [maxWeeks] must be ≥ 1 — a grid with zero columns is undefined
+  /// (the painter would paint nothing while the header still claims
+  /// "activity, N posts"). The assert encodes that contract.
   static int weeksToCoverJoin({
     required DateTime today,
     required DateTime joinedDay,
     required int maxWeeks,
   }) {
+    assert(maxWeeks >= 1, 'maxWeeks must be >= 1, got $maxWeeks');
     if (joinedDay.isAfter(today)) return 1;
     final weekDiff =
         mondayOf(today).difference(mondayOf(joinedDay)).inDays ~/ 7;

--- a/frontend/lib/widgets/artist/activity_grid.dart
+++ b/frontend/lib/widgets/artist/activity_grid.dart
@@ -143,9 +143,16 @@ class _ActivityGridState extends State<ActivityGrid>
     final canRenderGrid = joinedDay != null && !joinedDay.isAfter(today);
     int weeks = 0;
     if (canRenderGrid) {
-      final daysSinceJoin = today.difference(joinedDay).inDays + 1;
-      final clampedDays = daysSinceJoin.clamp(1, _maxWeeks * 7);
-      weeks = (clampedDays / 7).ceil();
+      // Each grid column is a Monday–Sunday week, right-aligned with
+      // today. The leftmost column must reach the join day's own
+      // week — `ceil(daysSinceJoin / 7)` doesn't do that when today's
+      // weekday is earlier than the join day's, so we instead diff
+      // the two weeks' Mondays. See `ActivityGridPainter.weeksToCoverJoin`.
+      weeks = ActivityGridPainter.weeksToCoverJoin(
+        today: today,
+        joinedDay: joinedDay,
+        maxWeeks: _maxWeeks,
+      );
     }
 
     final reduced = MediaQuery.disableAnimationsOf(context);
@@ -779,6 +786,46 @@ class ActivityGridPainter extends CustomPainter {
     final m = d.month.toString().padLeft(2, '0');
     final day = d.day.toString().padLeft(2, '0');
     return '$y-$m-$day';
+  }
+
+  /// Return the UTC Monday of the ISO week that contains [d] — the
+  /// midnight at the start of that Monday. Used by the widget to
+  /// align grid columns to whole calendar weeks (Mon–Sun) and by
+  /// tests to pin the expected leftmost column of the grid.
+  static DateTime mondayOf(DateTime d) {
+    final day = DateTime.utc(d.year, d.month, d.day);
+    return day.subtract(Duration(days: d.weekday - 1));
+  }
+
+  /// Number of week columns the grid needs to cover the span from
+  /// [joinedDay] through [today] inclusive, given that each column
+  /// represents one Monday–Sunday week and the grid is right-aligned
+  /// with today (so the join day's column is the leftmost).
+  ///
+  /// The naïve `ceil(daysSinceJoin / 7)` is wrong because it assumes
+  /// the leftmost column starts `weeks * 7` days before today —
+  /// whereas the painter's leftmost cell is actually
+  /// `(weeks - 1) * 7 + (todayWeekday - 1)` days before today
+  /// (see `ActivityGridPainter.paint`). When today's weekday is
+  /// earlier in the week than the join day's, that off-by-one
+  /// silently drops the join day and the few days following it out
+  /// of the rendered grid even though the backend returned them.
+  ///
+  /// Computing the difference between the two weeks' Mondays makes
+  /// the alignment explicit and matches what the painter actually
+  /// draws, so the leftmost column is always the join day's week.
+  /// Clamped to [1, maxWeeks]. Returns 1 defensively when
+  /// [joinedDay] is after [today] (callers gate this case via
+  /// `canRenderGrid`).
+  static int weeksToCoverJoin({
+    required DateTime today,
+    required DateTime joinedDay,
+    required int maxWeeks,
+  }) {
+    if (joinedDay.isAfter(today)) return 1;
+    final weekDiff =
+        mondayOf(today).difference(mondayOf(joinedDay)).inDays ~/ 7;
+    return (weekDiff + 1).clamp(1, maxWeeks);
   }
 
   @override

--- a/frontend/test/widgets/activity_grid_test.dart
+++ b/frontend/test/widgets/activity_grid_test.dart
@@ -253,6 +253,181 @@ void main() {
     });
   });
 
+  group('ActivityGridPainter.mondayOf', () {
+    test('returns the same date for a Monday', () {
+      // 2026-05-18 is a Monday (weekday == 1).
+      final mon = DateTime.utc(2026, 5, 18);
+      expect(ActivityGridPainter.mondayOf(mon), mon);
+    });
+
+    test('rolls a mid-week date back to its Monday', () {
+      // 2026-05-21 is a Thursday → Monday is 2026-05-18.
+      final thu = DateTime.utc(2026, 5, 21);
+      expect(ActivityGridPainter.mondayOf(thu), DateTime.utc(2026, 5, 18));
+    });
+
+    test('rolls a Sunday back six days, not forward to the next Monday', () {
+      // 2026-05-17 is a Sunday (weekday == 7) — same week as 2026-05-11.
+      // Without ISO-week semantics, naively snapping to the *next* Monday
+      // would land on 2026-05-18 and visually shove Sunday cells into
+      // the wrong column.
+      final sun = DateTime.utc(2026, 5, 17);
+      expect(ActivityGridPainter.mondayOf(sun), DateTime.utc(2026, 5, 11));
+    });
+
+    test('discards the time-of-day portion (returns UTC midnight)', () {
+      // Late-evening UTC timestamp on a Wednesday must still collapse
+      // to that week's Monday midnight, so the helper composes safely
+      // with `formatYYYYMMDD` and the painter's date arithmetic.
+      final wedAfternoon = DateTime.utc(2026, 5, 20, 18, 30);
+      expect(
+        ActivityGridPainter.mondayOf(wedAfternoon),
+        DateTime.utc(2026, 5, 18),
+      );
+    });
+  });
+
+  group('ActivityGridPainter.weeksToCoverJoin', () {
+    test('returns 1 when today equals the join day', () {
+      final today = DateTime.utc(2026, 5, 19);
+      expect(
+        ActivityGridPainter.weeksToCoverJoin(
+          today: today,
+          joinedDay: today,
+          maxWeeks: 52,
+        ),
+        1,
+      );
+    });
+
+    test('returns 1 when both fall in the same ISO week', () {
+      // today = Tue 2026-05-19, join = Mon 2026-05-18 → same week.
+      expect(
+        ActivityGridPainter.weeksToCoverJoin(
+          today: DateTime.utc(2026, 5, 19),
+          joinedDay: DateTime.utc(2026, 5, 18),
+          maxWeeks: 52,
+        ),
+        1,
+      );
+    });
+
+    test('returns 2 when the join falls in the previous ISO week', () {
+      // today = Tue 2026-05-19 (week of 5/18), join = Sun 2026-05-17
+      // (week of 5/11). The Sunday cell lives in column 0 row 6, so
+      // the grid needs exactly two columns to keep it visible.
+      expect(
+        ActivityGridPainter.weeksToCoverJoin(
+          today: DateTime.utc(2026, 5, 19),
+          joinedDay: DateTime.utc(2026, 5, 17),
+          maxWeeks: 52,
+        ),
+        2,
+      );
+    });
+
+    test(
+      'returns 3 for the Phase 0 launch scenario (today Tue, join Wed 13d ago)',
+      () {
+        // Regression for the bug this PR fixes: an artist registered on
+        // the Phase 0 launch day (2026-05-06, Wed) viewed on
+        // 2026-05-19 (Tue) used to compute weeks = ceil(14/7) = 2,
+        // which made the leftmost cell 2026-05-11 and dropped
+        // 2026-05-06..2026-05-10 out of the grid entirely. The
+        // Monday-aligned formula returns 3 so the leftmost column is
+        // the join day's week (2026-05-04 .. 2026-05-10).
+        expect(
+          ActivityGridPainter.weeksToCoverJoin(
+            today: DateTime.utc(2026, 5, 19),
+            joinedDay: DateTime.utc(2026, 5, 6),
+            maxWeeks: 52,
+          ),
+          3,
+        );
+      },
+    );
+
+    test('counts whole calendar weeks regardless of weekday combo', () {
+      // 5 calendar weeks apart on the Monday axis: join 2026-04-15
+      // (Wed, week of 4/13), today 2026-05-19 (Tue, week of 5/18).
+      // Monday distance = (5/18 - 4/13) / 7 = 35/7 = 5 → weeks = 6.
+      expect(
+        ActivityGridPainter.weeksToCoverJoin(
+          today: DateTime.utc(2026, 5, 19),
+          joinedDay: DateTime.utc(2026, 4, 15),
+          maxWeeks: 52,
+        ),
+        6,
+      );
+    });
+
+    test('clamps to maxWeeks when the artist is older than the window', () {
+      // Two-year-old artist viewed today: way past 52 weeks.
+      expect(
+        ActivityGridPainter.weeksToCoverJoin(
+          today: DateTime.utc(2026, 5, 19),
+          joinedDay: DateTime.utc(2024, 1, 1),
+          maxWeeks: 52,
+        ),
+        52,
+      );
+    });
+
+    test('falls back to 1 if joinedDay is in the future (defensive)', () {
+      // Callers gate this case via `canRenderGrid`, but the helper
+      // stays correct in isolation so it can be reused without that
+      // outer guard.
+      expect(
+        ActivityGridPainter.weeksToCoverJoin(
+          today: DateTime.utc(2026, 5, 19),
+          joinedDay: DateTime.utc(2026, 5, 20),
+          maxWeeks: 52,
+        ),
+        1,
+      );
+    });
+
+    test(
+      "leftmost column reaches the join day's week for every weekday combo",
+      () {
+        // Painter formula: leftmost cell (col=0, row=0) is
+        //   today - ((weeks - 1) * 7 + (todayWeekday - 1))
+        // i.e. the Monday of today's leftmost rendered week. The grid
+        // is correct iff that Monday is on-or-before the join day's
+        // Monday. Sweep every (today-weekday, join-weekday) pair.
+        for (int todayOffset = 0; todayOffset < 7; todayOffset++) {
+          // Anchor a Monday and walk forward to land on each weekday.
+          final today = DateTime.utc(
+            2026,
+            5,
+            18,
+          ).add(Duration(days: todayOffset));
+          for (int daysBack = 0; daysBack < 40; daysBack++) {
+            final joinedDay = today.subtract(Duration(days: daysBack));
+            final weeks = ActivityGridPainter.weeksToCoverJoin(
+              today: today,
+              joinedDay: joinedDay,
+              maxWeeks: 52,
+            );
+            final leftmostMondayDays = (weeks - 1) * 7 + (today.weekday - 1);
+            final leftmostMonday = today.subtract(
+              Duration(days: leftmostMondayDays),
+            );
+            final joinMonday = ActivityGridPainter.mondayOf(joinedDay);
+            expect(
+              leftmostMonday.isAtSameMomentAs(joinMonday) ||
+                  leftmostMonday.isBefore(joinMonday),
+              isTrue,
+              reason:
+                  'today=$today joinedDay=$joinedDay weeks=$weeks '
+                  'leftmostMonday=$leftmostMonday joinMonday=$joinMonday',
+            );
+          }
+        }
+      },
+    );
+  });
+
   group('ActivityGridPainter.tierForCount', () {
     test('maps counts to the 5-tier ramp', () {
       expect(ActivityGridPainter.tierForCount(0), 0);

--- a/frontend/test/widgets/activity_grid_test.dart
+++ b/frontend/test/widgets/activity_grid_test.dart
@@ -267,7 +267,8 @@ void main() {
     });
 
     test('rolls a Sunday back six days, not forward to the next Monday', () {
-      // 2026-05-17 is a Sunday (weekday == 7) — same week as 2026-05-11.
+      // 2026-05-17 is a Sunday (weekday == 7). Its ISO week starts on
+      // Monday 2026-05-11, so `mondayOf` must roll back six days.
       // Without ISO-week semantics, naively snapping to the *next* Monday
       // would land on 2026-05-18 and visually shove Sunday cells into
       // the wrong column.
@@ -387,6 +388,33 @@ void main() {
       );
     });
 
+    test('today on Monday is its own ISO week (edge case)', () {
+      // Boundary check: when `todayWeekday == 1`, the offset term
+      // `(todayWeekday - 1)` drops to zero, so the leftmost-Monday
+      // formula collapses to `(weeks - 1) * 7`. Make sure the helper
+      // doesn't over- or under-allocate columns in that case.
+      // today = Mon 2026-05-18, join = previous Wed 2026-05-13
+      // (week of 5/11). Distance between Mondays = 7 → weeks = 2.
+      expect(
+        ActivityGridPainter.weeksToCoverJoin(
+          today: DateTime.utc(2026, 5, 18),
+          joinedDay: DateTime.utc(2026, 5, 13),
+          maxWeeks: 52,
+        ),
+        2,
+      );
+      // And join = today (Mon) collapses to a single column with no
+      // off-by-one creeping in.
+      expect(
+        ActivityGridPainter.weeksToCoverJoin(
+          today: DateTime.utc(2026, 5, 18),
+          joinedDay: DateTime.utc(2026, 5, 18),
+          maxWeeks: 52,
+        ),
+        1,
+      );
+    });
+
     test(
       "leftmost column reaches the join day's week for every weekday combo",
       () {
@@ -409,6 +437,10 @@ void main() {
               joinedDay: joinedDay,
               maxWeeks: 52,
             );
+            // Mirror the painter's `daysFromToday` math for (col=0, row=0):
+            //   daysFromToday = (weeks - 1) * 7 + (todayWeekday - 1)
+            // → leftmost rendered cell sits this many days before today.
+            // Subtracting it gives the Monday at the top of column 0.
             final leftmostMondayDays = (weeks - 1) * 7 + (today.weekday - 1);
             final leftmostMonday = today.subtract(
               Duration(days: leftmostMondayDays),


### PR DESCRIPTION
## Summary

- **バグ**: アクティビティカレンダーで join 日とその直後数日が描画から落ちることがあった。今日が火曜・Phase 0 ローンチ（2026-05-06 水）にアーティスト登録したケースでは、2026-05-06〜2026-05-10 の 5 日分が見えなかった（バックエンドは正しく返している）
- **原因**: `weeks = ceil(daysSinceJoin / 7)` がグリッドの右寄せ（最左セル = `today − ((weeks-1)*7 + (todayWeekday-1))`）を考慮しておらず、今日の曜日が join 日の曜日より早い週で 1 週分足りなくなっていた
- **修正**: 各カラムが Mon–Sun の 1 週間という事実に合わせ、`today` と `joinedDay` それぞれの月曜の差で `weeks` を導出する Monday-aligned 式に切り替え。`mondayOf` / `weeksToCoverJoin` を `ActivityGridPainter` の static helper として公開（既存の `formatYYYYMMDD` / `hitTestCell` と同じパターン）し、ユニットテストを追加

### 検算（今日 = 2026-05-19 火）

| Join | 旧 weeks | 旧最左セル | 新 weeks | 新最左セル |
|---|---|---|---|---|
| 2026-05-19 (Tue, 今日) | 1 | 2026-05-18 | 1 | 2026-05-18 |
| 2026-05-18 (Mon, 昨日) | 1 | 2026-05-18 | 1 | 2026-05-18 |
| 2026-05-17 (Sun) | 1 | 2026-05-18 ⚠ | 2 | 2026-05-11 |
| 2026-05-06 (Wed, Phase 0 launch) | 2 | 2026-05-11 ⚠ | 3 | 2026-05-04 |
| 2024-01-01 (≥2y) | 52 (clamp) | — | 52 (clamp) | — |

## Test plan

- [x] `mise run lint`（dart analyze / dart format） — `lib/widgets/artist/activity_grid.dart` および `test/widgets/activity_grid_test.dart` 共に 0 issues
- [x] `flutter test --platform chrome test/widgets/activity_grid_test.dart` — 40/40 pass（既存 28 + 新規 12: `mondayOf` × 4, `weeksToCoverJoin` × 8）
- [x] 既存 `dart analyze lib/` の warning は `rich_text_editor.dart` の experimental API のみで本 PR と無関係
- [ ] 本番でアーティストプロフィールを開き、Phase 0 ローンチ日近辺で登録したアーティストの 5/10 以前のデータが star calendar に表示されること
- [ ] スクロール / 選択リング / hit-test（タップ → day-posts 表示）が壊れていないこと

## Notes

- 添付テストのスイープ（`leftmost column reaches the join day's week for every weekday combo`）が今後の painter 側の式変更時にも安全網として機能します
- `_maxWeeks = 52` の挙動は変更なし（GitHub-grass 互換、backend の 365 日窓と整合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)