### PR TITLE
feat(timeline): marquee track rail with activity highlights

### DIFF
--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -251,6 +251,8 @@
   "constellationPostCount": "Constellation \u00b7 {count, plural, =1{1 post} other{{count} posts}}",
   "@constellationPostCount": { "placeholders": { "count": { "type": "int" } } },
   "all": "All",
+  "trackRailExpandHint": "Tap to see all tracks",
+  "@trackRailExpandHint": { "description": "Tooltip / semantic label on the auto-scrolling track marquee. Tapping the marquee expands it into a static multi-row view where individual tracks can be tapped to toggle the timeline filter." },
   "noPostsYet": "No posts yet",
   "yourTimeline": "Your Timeline",
   "noPostsFromArtist": "No posts from this artist yet",

--- a/frontend/lib/l10n/app_ja.arb
+++ b/frontend/lib/l10n/app_ja.arb
@@ -225,6 +225,7 @@
   "discoverMoreArtists": "もっとアーティストを探す",
   "constellationPostCount": "コンステレーション · {count} 投稿",
   "all": "すべて",
+  "trackRailExpandHint": "タップして全トラックを表示",
   "noPostsYet": "まだ投稿がありません",
   "yourTimeline": "マイタイムライン",
   "noPostsFromArtist": "このアーティストの投稿はまだありません",

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -1316,6 +1316,12 @@ abstract class AppLocalizations {
   /// **'All'**
   String get all;
 
+  /// Tooltip / semantic label on the auto-scrolling track marquee. Tapping the marquee expands it into a static multi-row view where individual tracks can be tapped to toggle the timeline filter.
+  ///
+  /// In en, this message translates to:
+  /// **'Tap to see all tracks'**
+  String get trackRailExpandHint;
+
   /// No description provided for @noPostsYet.
   ///
   /// In en, this message translates to:

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -685,6 +685,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get all => 'All';
 
   @override
+  String get trackRailExpandHint => 'Tap to see all tracks';
+
+  @override
   String get noPostsYet => 'No posts yet';
 
   @override

--- a/frontend/lib/l10n/app_localizations_ja.dart
+++ b/frontend/lib/l10n/app_localizations_ja.dart
@@ -667,6 +667,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get all => 'すべて';
 
   @override
+  String get trackRailExpandHint => 'タップして全トラックを表示';
+
+  @override
   String get noPostsYet => 'まだ投稿がありません';
 
   @override

--- a/frontend/lib/providers/public_timeline_provider.dart
+++ b/frontend/lib/providers/public_timeline_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
@@ -72,6 +74,7 @@ class PublicTimelineNotifier extends Notifier<TimelineState>
         artist: artist,
         selectedTrackIds: allIds,
         isLoading: artist.tracks.isNotEmpty,
+        shuffleSeed: _newPublicShuffleSeed(),
       );
 
       if (artist.tracks.isNotEmpty) {
@@ -129,7 +132,15 @@ class PublicTimelineNotifier extends Notifier<TimelineState>
   }
 
   Future<void> refresh() async {
+    state = state.copyWith(shuffleSeed: _newPublicShuffleSeed());
     await _loadSelectedPosts();
+  }
+
+  /// See `TimelineNotifier.reshuffleTracks` — the public timeline mirrors
+  /// the rail-foreground / pull-to-refresh hook with identical semantics
+  /// (no backend mutation, local state-only).
+  void reshuffleTracks() {
+    state = state.copyWith(shuffleSeed: _newPublicShuffleSeed());
   }
 
   Future<void> _loadSelectedPosts() async {
@@ -208,6 +219,13 @@ class PublicTimelineNotifier extends Notifier<TimelineState>
     }
     state = state.copyWith(layout: result);
   }
+}
+
+int _newPublicShuffleSeed() {
+  // See `_newShuffleSeed` in timeline_provider.dart — `0x7FFFFFFF` is
+  // the dart2js-safe upper bound for `Random.nextInt`.
+  final raw = Random().nextInt(0x7FFFFFFF);
+  return raw == 0 ? 1 : raw;
 }
 
 /// Auto-disposed when no screen is watching. Navigating away from the public

--- a/frontend/lib/providers/timeline_provider.dart
+++ b/frontend/lib/providers/timeline_provider.dart
@@ -33,6 +33,15 @@ class TimelineState {
   final String? highlightPostId;
   final Set<String>? constellationPostIds;
 
+  /// Seed for the marquee track rail's per-load random order.
+  ///
+  /// Bumped on `refresh()`, `loadArtist()`, and explicit `reshuffleTracks()`
+  /// calls (e.g. from the rail's app-foreground / pull-to-refresh hooks).
+  /// 0 is the "not yet seeded" sentinel — `MarqueeTrackRail` falls back to
+  /// the source order when seed is 0, which keeps widget tests deterministic
+  /// without forcing every test setup to inject a seed.
+  final int shuffleSeed;
+
   const TimelineState({
     this.artist,
     this.selectedTrackIds = const {},
@@ -42,6 +51,7 @@ class TimelineState {
     this.layout,
     this.highlightPostId,
     this.constellationPostIds,
+    this.shuffleSeed = 0,
   });
 
   bool get allSelected =>
@@ -60,6 +70,7 @@ class TimelineState {
     Object? layout = sentinel,
     Object? highlightPostId = sentinel,
     Object? constellationPostIds = sentinel,
+    int? shuffleSeed,
   }) {
     return TimelineState(
       artist: artist == sentinel ? this.artist : artist as Artist?,
@@ -74,8 +85,19 @@ class TimelineState {
       constellationPostIds: constellationPostIds == sentinel
           ? this.constellationPostIds
           : constellationPostIds as Set<String>?,
+      shuffleSeed: shuffleSeed ?? this.shuffleSeed,
     );
   }
+}
+
+/// Generate a fresh non-zero seed for the marquee track rail.
+///
+/// `0x7FFFFFFF` (signed-int max) is the safe upper bound that works on
+/// both the Dart VM and dart2js — `1 << 32` evaluates to `0` under
+/// JavaScript's 32-bit bitwise semantics and breaks `Random.nextInt`.
+int _newShuffleSeed() {
+  final raw = Random().nextInt(0x7FFFFFFF);
+  return raw == 0 ? 1 : raw;
 }
 
 class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
@@ -165,6 +187,7 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
         artist: artist,
         selectedTrackIds: allIds,
         isLoading: artist.tracks.isNotEmpty,
+        shuffleSeed: _newShuffleSeed(),
       );
 
       if (artist.tracks.isNotEmpty) {
@@ -212,6 +235,7 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
         artist: artist,
         selectedTrackIds: allIds,
         isLoading: artist.tracks.isNotEmpty,
+        shuffleSeed: _newShuffleSeed(),
       );
 
       if (artist.tracks.isNotEmpty) {
@@ -998,7 +1022,17 @@ class TimelineNotifier extends Notifier<TimelineState> with DisposableNotifier {
   }
 
   Future<void> refresh() async {
+    state = state.copyWith(shuffleSeed: _newShuffleSeed());
     await _loadSelectedPosts();
+  }
+
+  /// Bump the marquee track rail's `shuffleSeed` without re-fetching posts.
+  ///
+  /// Wired into the rail's app-foreground hook so returning to the app
+  /// rotates the order even when the network slice is unchanged. Does not
+  /// touch any other state field.
+  void reshuffleTracks() {
+    state = state.copyWith(shuffleSeed: _newShuffleSeed());
   }
 }
 

--- a/frontend/lib/screens/timeline/public_timeline_screen.dart
+++ b/frontend/lib/screens/timeline/public_timeline_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import '../../models/timeline_item.dart';
-import '../../models/track.dart';
 import '../../providers/analytics_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/public_timeline_provider.dart';
@@ -15,6 +14,7 @@ import '../../utils/constellation_layout.dart';
 import '../../widgets/timeline/constellation_painter.dart';
 import '../../widgets/timeline/milestone_detail_sheet.dart';
 import '../../widgets/timeline/milestone_node_card.dart';
+import '../../widgets/timeline/marquee_track_rail.dart';
 import '../../widgets/timeline/node_card.dart';
 import '../../widgets/timeline/post_detail_sheet.dart';
 import '../../theme/gleisner_assets.dart';
@@ -156,15 +156,19 @@ class _PublicTimelineScreenState extends ConsumerState<PublicTimelineScreen>
       body: Column(
         children: [
           if (timeline.artist != null && timeline.artist!.tracks.isNotEmpty)
-            _TrackSelector(
+            MarqueeTrackRail(
               tracks: timeline.artist!.tracks,
+              posts: timeline.posts,
               selectedTrackIds: timeline.selectedTrackIds,
               allSelected: timeline.allSelected,
+              shuffleSeed: timeline.shuffleSeed,
               onToggleTrack: (trackId) => ref
                   .read(publicTimelineProvider.notifier)
                   .toggleTrack(trackId),
               onToggleAll: () =>
                   ref.read(publicTimelineProvider.notifier).toggleAll(),
+              onReshuffle: () =>
+                  ref.read(publicTimelineProvider.notifier).reshuffleTracks(),
             ),
           if (timeline.error != null)
             Padding(
@@ -775,80 +779,6 @@ class _TuneInButton extends StatelessWidget {
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class _TrackSelector extends StatelessWidget {
-  final List<Track> tracks;
-  final Set<String> selectedTrackIds;
-  final bool allSelected;
-  final ValueChanged<String> onToggleTrack;
-  final VoidCallback onToggleAll;
-
-  const _TrackSelector({
-    required this.tracks,
-    required this.selectedTrackIds,
-    required this.allSelected,
-    required this.onToggleTrack,
-    required this.onToggleAll,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      child: Wrap(
-        spacing: 4,
-        runSpacing: 2,
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: _chip(
-              label: context.l10n.all,
-              selected: allSelected,
-              onTap: onToggleAll,
-              selectedColor: colorInteractive,
-              borderRadius: BorderRadius.circular(4),
-            ),
-          ),
-          for (final track in tracks)
-            _chip(
-              label: track.name,
-              selected: selectedTrackIds.contains(track.id),
-              onTap: () => onToggleTrack(track.id),
-              selectedColor: track.displayColor,
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _chip({
-    required String label,
-    required bool selected,
-    required VoidCallback onTap,
-    required Color selectedColor,
-    BorderRadius? borderRadius,
-  }) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-        decoration: BoxDecoration(
-          borderRadius: borderRadius ?? BorderRadius.circular(10),
-          color: selected ? selectedColor.withValues(alpha: 0.2) : null,
-          border: Border.all(color: selected ? selectedColor : colorBorder),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 11,
-            color: selected ? selectedColor : colorInteractive,
-            fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
-          ),
         ),
       ),
     );

--- a/frontend/lib/screens/timeline/timeline_screen.dart
+++ b/frontend/lib/screens/timeline/timeline_screen.dart
@@ -5,13 +5,13 @@ import 'package:go_router/go_router.dart';
 import '../../models/artist.dart';
 import '../../models/post.dart';
 import '../../models/timeline_item.dart';
-import '../../models/track.dart';
 import '../../providers/my_artist_provider.dart';
 import '../../providers/pending_artist_provider.dart';
 import '../../providers/timeline_provider.dart';
 import '../../providers/tune_in_provider.dart';
 import '../../utils/constellation_layout.dart';
 import '../../widgets/timeline/avatar_rail.dart';
+import '../../widgets/timeline/marquee_track_rail.dart';
 import '../../l10n/l10n.dart';
 import '../../utils/month_names.dart';
 import '../../widgets/timeline/constellation_painter.dart';
@@ -459,15 +459,20 @@ class _TimelineScreenState extends ConsumerState<TimelineScreen>
                   children: [
                     if (timeline.artist != null &&
                         timeline.artist!.tracks.isNotEmpty)
-                      _TrackSelector(
+                      MarqueeTrackRail(
                         tracks: timeline.artist!.tracks,
+                        posts: timeline.posts,
                         selectedTrackIds: timeline.selectedTrackIds,
                         allSelected: timeline.allSelected,
+                        shuffleSeed: timeline.shuffleSeed,
                         onToggleTrack: (trackId) => ref
                             .read(timelineProvider.notifier)
                             .toggleTrack(trackId),
                         onToggleAll: () =>
                             ref.read(timelineProvider.notifier).toggleAll(),
+                        onReshuffle: () => ref
+                            .read(timelineProvider.notifier)
+                            .reshuffleTracks(),
                       ),
                     // Avatar rail — always visible (not inside scroll)
                     if (tuneIn.tunedInArtists.isNotEmpty ||
@@ -1316,80 +1321,6 @@ class _DateLabel extends StatelessWidget {
               ),
             ),
         ],
-      ),
-    );
-  }
-}
-
-class _TrackSelector extends StatelessWidget {
-  final List<Track> tracks;
-  final Set<String> selectedTrackIds;
-  final bool allSelected;
-  final ValueChanged<String> onToggleTrack;
-  final VoidCallback onToggleAll;
-
-  const _TrackSelector({
-    required this.tracks,
-    required this.selectedTrackIds,
-    required this.allSelected,
-    required this.onToggleTrack,
-    required this.onToggleAll,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      child: Wrap(
-        spacing: 4,
-        runSpacing: 2,
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: _chip(
-              label: context.l10n.all,
-              selected: allSelected,
-              onTap: onToggleAll,
-              selectedColor: colorInteractive,
-              borderRadius: BorderRadius.circular(4),
-            ),
-          ),
-          for (final track in tracks)
-            _chip(
-              label: track.name,
-              selected: selectedTrackIds.contains(track.id),
-              onTap: () => onToggleTrack(track.id),
-              selectedColor: track.displayColor,
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _chip({
-    required String label,
-    required bool selected,
-    required VoidCallback onTap,
-    required Color selectedColor,
-    BorderRadius? borderRadius,
-  }) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-        decoration: BoxDecoration(
-          borderRadius: borderRadius ?? BorderRadius.circular(10),
-          color: selected ? selectedColor.withValues(alpha: 0.2) : null,
-          border: Border.all(color: selected ? selectedColor : colorBorder),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 11,
-            color: selected ? selectedColor : colorInteractive,
-            fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
-          ),
-        ),
       ),
     );
   }

--- a/frontend/lib/theme/gleisner_tokens.dart
+++ b/frontend/lib/theme/gleisner_tokens.dart
@@ -231,11 +231,12 @@ const motionPulsePeriod = Duration(milliseconds: 1800);
 /// Marquee scroll speed in logical pixels per second. Tuned for "reads
 /// without effort" at 11 dp chip text; raise to dial up urgency, lower
 /// to dial down attention draw.
-const motionMarqueeSpeedDp = 50.0;
+const motionMarqueeSpeedDp = 40.0;
 
 /// Idle duration before the expanded track rail collapses back to its
-/// marquee state. Chip selection bypasses the timer (immediate collapse).
-const motionRailExpandedIdleTimeout = Duration(seconds: 10);
+/// marquee state. Reset by any chip tap so users can pick multiple
+/// tracks in one expanded session.
+const motionRailExpandedIdleTimeout = Duration(seconds: 5);
 
 // ---------------------------------------------------------------------------
 // Highlight — Track activity glow used by `MarqueeTrackRail`.
@@ -248,26 +249,30 @@ const motionRailExpandedIdleTimeout = Duration(seconds: 10);
 /// Blur radius (in logical pixels) for the white pulse applied to tracks
 /// that have at least one post in the last 24h. Pulses between
 /// [highlightFreshBlurMin] and this value over `motionPulsePeriod`.
-const highlightFreshBlurMax = 10.0;
+/// Sized to fit inside the marquee viewport (~7 px above + 7 px below
+/// the chip) so the glow never gets clipped at its peak.
+const highlightFreshBlurMax = 8.0;
 
 /// Floor of the fresh-pulse blur. Even at the lowest point of the pulse
 /// the glow is still visible so reduced-motion users see the highlight
 /// clearly without any animation.
 const highlightFreshBlurMin = 4.0;
 
-/// Peak alpha of the fresh-track white pulse. Kept below 0.55 so the
-/// glow reads as a halo, not a flashbulb.
-const highlightFreshAlphaMax = 0.5;
-const highlightFreshAlphaMin = 0.22;
+/// Peak alpha of the fresh-track white pulse. Picked high enough that
+/// the highlighted chip clearly outshines the unhighlighted neighbors
+/// at the pulse peak, while still feeling like a glow rather than a
+/// solid fill.
+const highlightFreshAlphaMax = 0.95;
+const highlightFreshAlphaMin = 0.5;
 
 /// Steady-state blur of the colored halo applied to tracks with >= 5
 /// posts in the last week. Does not pulse — the color halo is a
 /// persistent activity signal, the pulse is reserved for freshness.
-const highlightActiveHaloBlur = 6.0;
+const highlightActiveHaloBlur = 7.0;
 
-/// Alpha for the track-colored halo. Capped so the halo is unmistakable
-/// without overwhelming the chip's own border + text.
-const highlightActiveHaloAlpha = 0.35;
+/// Alpha for the track-colored halo. Strong enough to read as
+/// "this track is busy" against the chip's own border + text.
+const highlightActiveHaloAlpha = 0.85;
 
 // ---------------------------------------------------------------------------
 // Common text styles (convenience)

--- a/frontend/lib/theme/gleisner_tokens.dart
+++ b/frontend/lib/theme/gleisner_tokens.dart
@@ -217,6 +217,59 @@ const opacitySubtle = 0.12;
 const opacityBorder = 0.3;
 
 // ---------------------------------------------------------------------------
+// Motion — Periods and speeds used by infinite/repeating animations.
+//
+// All durations follow `prefers-reduced-motion` (`MediaQuery.disableAnimationsOf`):
+// callers are expected to gate the animation start, not just the period.
+// ---------------------------------------------------------------------------
+
+/// Breathing-pulse period used by the `MarqueeTrackRail` highlight.
+/// Faster than the FAB pulse (2400 ms) because tracks read as a rhythm of
+/// many small stars rather than one focal accent.
+const motionPulsePeriod = Duration(milliseconds: 1800);
+
+/// Marquee scroll speed in logical pixels per second. Tuned for "reads
+/// without effort" at 11 dp chip text; raise to dial up urgency, lower
+/// to dial down attention draw.
+const motionMarqueeSpeedDp = 50.0;
+
+/// Idle duration before the expanded track rail collapses back to its
+/// marquee state. Chip selection bypasses the timer (immediate collapse).
+const motionRailExpandedIdleTimeout = Duration(seconds: 10);
+
+// ---------------------------------------------------------------------------
+// Highlight — Track activity glow used by `MarqueeTrackRail`.
+//
+// Tuned so non-highlighted chips never read as "muted" / "disabled" — the
+// pulse is additive (adds a glow on top of the normal chip), never
+// subtractive.
+// ---------------------------------------------------------------------------
+
+/// Blur radius (in logical pixels) for the white pulse applied to tracks
+/// that have at least one post in the last 24h. Pulses between
+/// [highlightFreshBlurMin] and this value over `motionPulsePeriod`.
+const highlightFreshBlurMax = 10.0;
+
+/// Floor of the fresh-pulse blur. Even at the lowest point of the pulse
+/// the glow is still visible so reduced-motion users see the highlight
+/// clearly without any animation.
+const highlightFreshBlurMin = 4.0;
+
+/// Peak alpha of the fresh-track white pulse. Kept below 0.55 so the
+/// glow reads as a halo, not a flashbulb.
+const highlightFreshAlphaMax = 0.5;
+const highlightFreshAlphaMin = 0.22;
+
+/// Steady-state blur of the colored halo applied to tracks with >= 5
+/// posts in the last week. Does not pulse — the color halo is a
+/// persistent activity signal, the pulse is reserved for freshness.
+const highlightActiveHaloBlur = 6.0;
+
+/// Alpha for the track-colored halo. Capped so the halo is unmistakable
+/// without overwhelming the chip's own border + text.
+const highlightActiveHaloAlpha = 0.35;
+
+// ---------------------------------------------------------------------------
 // Common text styles (convenience)
 // ---------------------------------------------------------------------------
 

--- a/frontend/lib/utils/track_activity.dart
+++ b/frontend/lib/utils/track_activity.dart
@@ -1,0 +1,98 @@
+import 'dart:math';
+
+import '../models/post.dart';
+import '../models/track.dart';
+
+/// Per-track activity statistics derived from a slice of recent posts.
+///
+/// Used by `MarqueeTrackRail` to drive the highlight pulse / halo and
+/// the week-activity-descending sort order of the expanded view.
+class TrackActivity {
+  /// True when the track has at least one post in the last 24 hours.
+  /// Drives the "fresh" white-pulse highlight.
+  final bool isFresh;
+
+  /// Number of posts attributed to this track within the last 7 days.
+  /// Tracks with [weekPostCount] >= 5 receive the colored halo.
+  final int weekPostCount;
+
+  const TrackActivity({required this.isFresh, required this.weekPostCount});
+
+  bool get isActive => weekPostCount >= 5;
+
+  static const empty = TrackActivity(isFresh: false, weekPostCount: 0);
+}
+
+/// Compute per-track activity from the currently loaded slice of posts.
+///
+/// Returns a map keyed by `trackId`. Tracks with no posts in the lookback
+/// window are absent from the map (callers should treat absence as
+/// [TrackActivity.empty]).
+///
+/// `now` defaults to [DateTime.now] — tests inject a fixed reference time.
+///
+/// TODO(phase-1): the input `posts` is the paginated slice currently held
+/// by `TimelineState`. With Phase 0 data volume (tens of posts per
+/// artist) this is acceptable. When `fetchMore` lands or the timeline
+/// starts trimming aggressively, callers should switch to a dedicated
+/// activity query so the highlight does not depend on scroll position.
+Map<String, TrackActivity> computeTrackActivity(
+  List<Post> posts, {
+  DateTime? now,
+}) {
+  final reference = now ?? DateTime.now();
+  final freshThreshold = reference.subtract(const Duration(hours: 24));
+  final weekThreshold = reference.subtract(const Duration(days: 7));
+
+  final freshTrackIds = <String>{};
+  final weekCounts = <String, int>{};
+
+  for (final post in posts) {
+    final trackId = post.trackId;
+    if (trackId == null) continue;
+    final date = post.createdAt;
+    if (!date.isAfter(weekThreshold)) continue;
+    weekCounts[trackId] = (weekCounts[trackId] ?? 0) + 1;
+    if (date.isAfter(freshThreshold)) freshTrackIds.add(trackId);
+  }
+
+  return {
+    for (final entry in weekCounts.entries)
+      entry.key: TrackActivity(
+        isFresh: freshTrackIds.contains(entry.key),
+        weekPostCount: entry.value,
+      ),
+  };
+}
+
+/// Return a new list with [tracks] shuffled deterministically by [seed].
+///
+/// Used to vary the marquee order each time the timeline is reloaded
+/// (`pull-to-refresh`, foreground resume) without losing the ability to
+/// regenerate the exact same order in widget tests.
+List<Track> shuffleTracks(List<Track> tracks, int seed) {
+  if (tracks.isEmpty) return const [];
+  final result = List<Track>.from(tracks);
+  result.shuffle(Random(seed));
+  return result;
+}
+
+/// Return a new list with [tracks] sorted by descending weekly post count.
+///
+/// Tracks with no activity entry fall to the end. Name comparison is the
+/// stable tiebreaker so the expanded view never reshuffles between
+/// rebuilds when activity counts are unchanged.
+List<Track> sortByWeekActivity(
+  List<Track> tracks,
+  Map<String, TrackActivity> activity,
+) {
+  if (tracks.isEmpty) return const [];
+  final result = List<Track>.from(tracks);
+  result.sort((a, b) {
+    final aCount = activity[a.id]?.weekPostCount ?? 0;
+    final bCount = activity[b.id]?.weekPostCount ?? 0;
+    if (bCount != aCount) return bCount.compareTo(aCount);
+    return a.name.compareTo(b.name);
+  });
+  return result;
+}

--- a/frontend/lib/utils/track_activity.dart
+++ b/frontend/lib/utils/track_activity.dart
@@ -5,8 +5,8 @@ import '../models/track.dart';
 
 /// Per-track activity statistics derived from a slice of recent posts.
 ///
-/// Used by `MarqueeTrackRail` to drive the highlight pulse / halo and
-/// the week-activity-descending sort order of the expanded view.
+/// Used by `MarqueeTrackRail` to drive the highlight pulse (fresh) and
+/// halo (active) cues.
 class TrackActivity {
   /// True when the track has at least one post in the last 24 hours.
   /// Drives the "fresh" white-pulse highlight.
@@ -69,30 +69,15 @@ Map<String, TrackActivity> computeTrackActivity(
 ///
 /// Used to vary the marquee order each time the timeline is reloaded
 /// (`pull-to-refresh`, foreground resume) without losing the ability to
-/// regenerate the exact same order in widget tests.
+/// regenerate the exact same order in widget tests. The expanded view
+/// reuses the same shuffled order so chips do not reflow when the user
+/// swaps between marquee and expanded modes — original design also
+/// shipped a `sortByWeekActivity` helper for an activity-descending
+/// expanded view, but manual QA showed the reflow was distracting and
+/// the helper was retired (see PR #444 discussion).
 List<Track> shuffleTracks(List<Track> tracks, int seed) {
   if (tracks.isEmpty) return const [];
   final result = List<Track>.from(tracks);
   result.shuffle(Random(seed));
-  return result;
-}
-
-/// Return a new list with [tracks] sorted by descending weekly post count.
-///
-/// Tracks with no activity entry fall to the end. Name comparison is the
-/// stable tiebreaker so the expanded view never reshuffles between
-/// rebuilds when activity counts are unchanged.
-List<Track> sortByWeekActivity(
-  List<Track> tracks,
-  Map<String, TrackActivity> activity,
-) {
-  if (tracks.isEmpty) return const [];
-  final result = List<Track>.from(tracks);
-  result.sort((a, b) {
-    final aCount = activity[a.id]?.weekPostCount ?? 0;
-    final bCount = activity[b.id]?.weekPostCount ?? 0;
-    if (bCount != aCount) return bCount.compareTo(aCount);
-    return a.name.compareTo(b.name);
-  });
   return result;
 }

--- a/frontend/lib/widgets/timeline/marquee_track_rail.dart
+++ b/frontend/lib/widgets/timeline/marquee_track_rail.dart
@@ -150,8 +150,7 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
     final pausedAt = _lastPausedAt;
     _lastPausedAt = null;
     if (pausedAt == null ||
-        DateTime.now().difference(pausedAt) <
-            const Duration(seconds: 60)) {
+        DateTime.now().difference(pausedAt) < const Duration(seconds: 60)) {
       return;
     }
     // Defer to next frame: didChangeAppLifecycleState fires outside the
@@ -343,9 +342,7 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
     final disableAnimations = MediaQuery.disableAnimationsOf(context);
     final l10n = context.l10n;
     final activity = computeTrackActivity(widget.posts);
-    final hasAnyHighlight = activity.values.any(
-      (a) => a.isFresh || a.isActive,
-    );
+    final hasAnyHighlight = activity.values.any((a) => a.isFresh || a.isActive);
     _schedulePulse(
       disableAnimations: disableAnimations,
       hasAnyHighlight: hasAnyHighlight,

--- a/frontend/lib/widgets/timeline/marquee_track_rail.dart
+++ b/frontend/lib/widgets/timeline/marquee_track_rail.dart
@@ -18,6 +18,12 @@ import '../../utils/track_activity.dart';
 /// for selection.
 enum _RailMode { automatic, expanded }
 
+/// Pixel height reserved for the marquee viewport. Sized to give the
+/// chip (~22 dp) plus ~7 dp on each side of headroom for the highlight
+/// glow's blur so the pulse is visible without the `ClipRect` shaving
+/// it off. Still ~10 dp shorter than the original two-row Wrap.
+const double _marqueeViewportHeight = 36;
+
 /// Replacement for the original `_TrackSelector` that stops the chip list
 /// from eating two or more rows of the timeline.
 ///
@@ -69,6 +75,23 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
   /// Memoized chip-width estimates keyed by label text. Rebuilt only when
   /// the label set changes between builds.
   Map<String, double> _chipWidthCache = const {};
+
+  /// Attached to the leading marquee chip-row so we can read its actual
+  /// laid-out width after the first frame. The text estimate is used to
+  /// pick "marquee vs static" before the real measurement is available,
+  /// but the marquee animation distance is the measured value — under-
+  /// estimating made the two copies overlap; over-estimating left a
+  /// visible blank gap at the wrap point.
+  final GlobalKey _measureKey = GlobalKey();
+
+  /// Most recent measured width of one chip-row, or `null` until the
+  /// first frame has been laid out.
+  double? _measuredChipRowWidth;
+
+  /// Most recent measured height of one chip-row. Used to center the
+  /// marquee chips inside the (taller) viewport so they align with the
+  /// pinned "All" chip on the same row.
+  double? _measuredChipRowHeight;
 
   // Snapshot of the last marquee parameters we asked the controller to
   // run with — used to avoid restarting the animation on every build.
@@ -130,6 +153,11 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
     if (_mode != _RailMode.expanded) return;
     _expandTimer?.cancel();
     _expandTimer = null;
+    // Clear any leftover hover-paused flag — the pointer state from
+    // before entering expanded mode would otherwise keep the marquee
+    // stopped after the timer fires (especially in DevTools mobile
+    // emulation where `onExit` does not fire on touch end).
+    _hoverPaused = false;
     setState(() => _mode = _RailMode.automatic);
   }
 
@@ -142,12 +170,14 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
 
   void _onChipTap(String trackId) {
     widget.onToggleTrack(trackId);
-    if (_mode == _RailMode.expanded) _exitExpanded();
+    // Stay in expanded mode so the user can keep toggling multiple
+    // tracks; just restart the idle timer.
+    if (_mode == _RailMode.expanded) _restartExpandTimer();
   }
 
   void _onAllChipTap() {
     widget.onToggleAll();
-    if (_mode == _RailMode.expanded) _exitExpanded();
+    if (_mode == _RailMode.expanded) _restartExpandTimer();
   }
 
   void _onHoverEnter() {
@@ -167,15 +197,55 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
   double _estimateChipWidth(String label, TextStyle style) {
     final cached = _chipWidthCache[label];
     if (cached != null) return cached;
+    // Measure with bold weight (FontWeight.w600). The selected chip
+    // renders bold, which is meaningfully wider than the unselected
+    // (w400) baseline — under-measuring made the two marquee copies
+    // overlap because the wrapping copy started before the first one
+    // visually ended.
     final tp = TextPainter(
-      text: TextSpan(text: label, style: style),
+      text: TextSpan(
+        text: label,
+        style: style.copyWith(fontWeight: FontWeight.w600),
+      ),
       textDirection: TextDirection.ltr,
       maxLines: 1,
     )..layout();
-    // Match _chip's horizontal padding (8 px each side) + border allowance.
-    final width = tp.width + 18;
+    // Chip horizontal padding (8 px each side) + 1 px border each side
+    // = 18 px geometric overhead. Extra slack (10 px) absorbs font
+    // metric differences between `TextPainter` and the rendered `Text`
+    // widget under CanvasKit / Flutter web, plus the halo blur radius
+    // when highlighted chips wrap past the end of the strip.
+    final width = tp.width + 28;
     _chipWidthCache[label] = width;
     return width;
+  }
+
+  /// Read the leading chip-row's actual laid-out size and, if it has
+  /// changed by more than 0.5 px, store it and request a rebuild so the
+  /// marquee animation cycle distance matches reality (no gap, no
+  /// overlap at the wrap point) and the chips stay vertically aligned
+  /// with the pinned "All" chip.
+  void _scheduleMeasureChipRow() {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final box = _measureKey.currentContext?.findRenderObject() as RenderBox?;
+      if (box == null || !box.hasSize) return;
+      final measuredWidth = box.size.width;
+      final measuredHeight = box.size.height;
+      if (measuredWidth <= 0 || measuredHeight <= 0) return;
+      final widthChanged =
+          _measuredChipRowWidth == null ||
+          (_measuredChipRowWidth! - measuredWidth).abs() > 0.5;
+      final heightChanged =
+          _measuredChipRowHeight == null ||
+          (_measuredChipRowHeight! - measuredHeight).abs() > 0.5;
+      if (widthChanged || heightChanged) {
+        setState(() {
+          _measuredChipRowWidth = measuredWidth;
+          _measuredChipRowHeight = measuredHeight;
+        });
+      }
+    });
   }
 
   void _schedulePulse(bool disableAnimations) {
@@ -185,7 +255,11 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
         if (_pulseController.isAnimating) _pulseController.stop();
       } else {
         if (!_pulseController.isAnimating) {
-          _pulseController.repeat(reverse: true);
+          // Plain sawtooth, not `reverse: true`. Each chip computes
+          // its own triangular pulse from the raw controller value +
+          // a per-chip phase offset so neighboring highlighted chips
+          // do not synchronize and visually merge into one block.
+          _pulseController.repeat();
         }
       }
     });
@@ -214,6 +288,12 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
       final durationMs = (scrollDistance / motionMarqueeSpeedDp * 1000)
           .round()
           .clamp(1000, 120000);
+      // Fully reset before repeat — when the controller had been
+      // stopped mid-cycle (expand → idle 10s → marquee), repeat from
+      // the leftover value caused the visual scroll to start at the
+      // wrong offset and could appear frozen until the wrap copy
+      // caught up.
+      _marqueeController.reset();
       _marqueeController.duration = Duration(milliseconds: durationMs);
       _marqueeController.repeat();
     });
@@ -265,16 +345,22 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
             return _buildStatic(activity, chipStyle);
           }
 
+          // Prefer the measured chip-row width if we have one — the
+          // text-painter estimate ends up off by ~10 px on real Web
+          // builds, which is enough to either cover or expose the
+          // wrap-point between marquee copies.
+          final effectiveScrollDistance = _measuredChipRowWidth ?? tracksWidth;
           _scheduleMarquee(
             wantsMarquee: true,
-            scrollDistance: tracksWidth,
+            scrollDistance: effectiveScrollDistance,
             disableAnimations: disableAnimations,
           );
+          _scheduleMeasureChipRow();
           return _buildMarquee(
             activity,
             chipStyle,
             allChipWidth: allChipWidth,
-            scrollDistance: tracksWidth,
+            scrollDistance: effectiveScrollDistance,
             disableAnimations: disableAnimations,
           );
         },
@@ -328,7 +414,8 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
         ? widget.tracks
         : shuffleTracks(widget.tracks, widget.shuffleSeed);
 
-    Widget chipRow() => Row(
+    Widget chipRow({Key? key}) => Row(
+      key: key,
       mainAxisSize: MainAxisSize.min,
       children: [
         for (final track in shuffled)
@@ -339,37 +426,64 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
       ],
     );
 
-    final marqueeContent = LayoutBuilder(
-      builder: (context, marqueeConstraints) {
-        final viewportWidth = marqueeConstraints.maxWidth;
-        return ClipRect(
-          child: AnimatedBuilder(
-            animation: _marqueeController,
-            builder: (context, _) {
-              final progress = disableAnimations
-                  ? 0.0
-                  : _marqueeController.value;
-              final offset = -progress * scrollDistance;
-              return SizedBox(
-                width: viewportWidth,
-                child: Stack(
-                  clipBehavior: Clip.none,
-                  children: [
-                    Positioned(left: offset, top: 0, child: chipRow()),
-                    // Wrapping copy keeps the strip seamless past the
-                    // viewport edge for any scroll distance.
-                    Positioned(
-                      left: offset + scrollDistance,
-                      top: 0,
-                      child: chipRow(),
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
-        );
-      },
+    // Marquee viewport:
+    //   - `SizedBox(height: ...)` gives the Stack a finite height. A
+    //     Stack with only `Positioned` children otherwise inherits
+    //     `maxHeight: infinity` from the column above us and the
+    //     parent layout collapses the rail to 0 px — was visible as
+    //     the chips disappearing on narrow viewports (first round).
+    //   - `ClipRect` crops the painting horizontally so the chip-row
+    //     copies render only inside the viewport.
+    //   - Each chip-row copy is `Positioned(left, top)`. With only the
+    //     two coordinates set the child receives loose constraints,
+    //     so the `Row` lays out at its natural width without tripping
+    //     the parent's bounded-width constraint (no RenderFlex stripe).
+    //   - `IgnorePointer` swallows chip-level taps during the marquee
+    //     so the outer `GestureDetector` always wins and expands the
+    //     rail (otherwise the underlying chip would toggle its
+    //     selection without ever opening the expand view).
+    // Vertically center the chips inside the viewport so they line up
+    // with the pinned "All" chip (which the parent `Row` centers in
+    // the same available height). Falls back to top:0 on the very
+    // first frame before measurement lands; the next frame snaps
+    // into place.
+    final double chipTop = _measuredChipRowHeight == null
+        ? 0
+        : ((_marqueeViewportHeight - _measuredChipRowHeight!) / 2).clamp(
+            0.0,
+            _marqueeViewportHeight,
+          );
+
+    Widget marqueeChip(double translateX, {Key? key}) {
+      return Positioned(
+        left: translateX,
+        top: chipTop,
+        child: IgnorePointer(child: chipRow(key: key)),
+      );
+    }
+
+    final marqueeContent = SizedBox(
+      height: _marqueeViewportHeight,
+      child: ClipRect(
+        child: AnimatedBuilder(
+          animation: _marqueeController,
+          builder: (context, _) {
+            final progress = disableAnimations ? 0.0 : _marqueeController.value;
+            final offset = -progress * scrollDistance;
+            return Stack(
+              clipBehavior: Clip.none,
+              children: [
+                // Leading copy carries the measurement key so the next
+                // post-frame can read its real width.
+                marqueeChip(offset, key: _measureKey),
+                // Wrapping copy keeps the strip seamless past the
+                // viewport edge for any scroll distance.
+                marqueeChip(offset + scrollDistance),
+              ],
+            );
+          },
+        ),
+      ),
     );
 
     Widget marqueeArea = GestureDetector(
@@ -402,7 +516,13 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
     Map<String, TrackActivity> activity,
     TextStyle chipStyle,
   ) {
-    final sorted = sortByWeekActivity(widget.tracks, activity);
+    // Expanded uses the same shuffled order as the marquee so swapping
+    // between modes does not visually rearrange the chips under the
+    // user's finger. Activity-descending sort felt like a stronger
+    // signal in theory but read as a jarring reflow in practice.
+    final ordered = widget.shuffleSeed == 0
+        ? widget.tracks
+        : shuffleTracks(widget.tracks, widget.shuffleSeed);
     return Wrap(
       spacing: spaceXs,
       runSpacing: spaceXxs,
@@ -411,7 +531,8 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
           padding: const EdgeInsets.only(right: spaceSm),
           child: _buildAllChip(chipStyle),
         ),
-        for (final track in sorted) _buildTrackChip(track, activity, chipStyle),
+        for (final track in ordered)
+          _buildTrackChip(track, activity, chipStyle),
       ],
     );
   }
@@ -434,11 +555,17 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
   ) {
     final stats = activity[track.id] ?? TrackActivity.empty;
     final selected = widget.selectedTrackIds.contains(track.id);
+    // Deterministic phase offset in [0, 1) keyed on track id so the
+    // pulse never lands on the same beat for two chips at once. Using
+    // the hash mod-100 gives 100 distinct phases, well beyond what
+    // the eye can tell apart on a short rail.
+    final phaseOffset = (track.id.hashCode % 100).abs() / 100.0;
     return _HighlightedChip(
       pulseAnimation: _pulseController,
       disableAnimations: _lastDisableAnimations,
       activity: stats,
       trackColor: track.displayColor,
+      phaseOffset: phaseOffset,
       child: _Chip(
         label: track.name,
         selected: selected,
@@ -504,6 +631,7 @@ class _HighlightedChip extends StatelessWidget {
   final bool disableAnimations;
   final TrackActivity activity;
   final Color trackColor;
+  final double phaseOffset;
   final Widget child;
 
   const _HighlightedChip({
@@ -511,6 +639,7 @@ class _HighlightedChip extends StatelessWidget {
     required this.disableAnimations,
     required this.activity,
     required this.trackColor,
+    required this.phaseOffset,
     required this.child,
   });
 
@@ -523,9 +652,26 @@ class _HighlightedChip extends StatelessWidget {
     return AnimatedBuilder(
       animation: pulseAnimation,
       builder: (context, _) {
-        // Reduced-motion: settle on the midpoint of the pulse so the
-        // glow is visible without animating.
-        final t = disableAnimations ? 0.5 : pulseAnimation.value;
+        // The shared controller runs as a sawtooth 0 → 1. Each chip
+        // converts that to its own triangular pulse (0 → 1 → 0) using
+        // a per-chip `phaseOffset`, so highlighted neighbors never
+        // peak simultaneously and never blur into one big glow.
+        //
+        // Reduced-motion: settle on the midpoint so the glow is
+        // visible without animating.
+        final double t;
+        if (disableAnimations) {
+          t = 0.5;
+        } else {
+          final phase = (pulseAnimation.value + phaseOffset) % 1.0;
+          t = phase < 0.5 ? phase * 2 : (1 - phase) * 2;
+        }
+
+        // Highlight is only an outer glow. The shadow is painted on a
+        // backing plate that is the **same opaque color as the page
+        // surface** so the bloom never bleeds through the chip's
+        // transparent (unselected) interior — that bleed was the
+        // "white text background" the user kept seeing.
         final shadows = <BoxShadow>[
           if (isActive)
             BoxShadow(
@@ -543,14 +689,27 @@ class _HighlightedChip extends StatelessWidget {
               blurRadius:
                   highlightFreshBlurMin +
                   (highlightFreshBlurMax - highlightFreshBlurMin) * t,
+              spreadRadius: 0.5,
             ),
         ];
-        return DecoratedBox(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(10),
-            boxShadow: shadows,
-          ),
-          child: child,
+
+        return Stack(
+          clipBehavior: Clip.none,
+          children: [
+            Positioned.fill(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  // Opaque plate that occludes the inner half of the
+                  // shadow. Matches the timeline canvas surface so it
+                  // is invisible against the page bg.
+                  color: colorSurface0,
+                  boxShadow: shadows,
+                ),
+              ),
+            ),
+            child,
+          ],
         );
       },
     );

--- a/frontend/lib/widgets/timeline/marquee_track_rail.dart
+++ b/frontend/lib/widgets/timeline/marquee_track_rail.dart
@@ -1,0 +1,558 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart' show SchedulerBinding;
+
+import '../../l10n/l10n.dart';
+import '../../models/post.dart';
+import '../../models/track.dart';
+import '../../theme/gleisner_tokens.dart';
+import '../../utils/track_activity.dart';
+
+/// Layout mode for the track rail.
+///
+/// `automatic` lets `build` decide between a static single row and the
+/// marquee based on whether all chips fit within the available width.
+/// `expanded` is the user-driven multi-row Wrap that surfaces every chip
+/// for selection.
+enum _RailMode { automatic, expanded }
+
+/// Replacement for the original `_TrackSelector` that stops the chip list
+/// from eating two or more rows of the timeline.
+///
+/// Behavior:
+///   - When the full chip set fits on one row → static row, no animation.
+///   - When it overflows → "All" stays pinned at the left, the rest scroll
+///     leftward as a marquee.
+///   - Tapping the marquee region expands into a multi-row Wrap (week
+///     activity descending) for selection. Selecting a chip, idling for
+///     `motionRailExpandedIdleTimeout`, or the app returning to the
+///     foreground collapses it back to the marquee.
+///   - Tracks with posts in the last 24h pulse with a white glow; tracks
+///     with >= 5 posts in the last 7 days carry a steady track-colored
+///     halo. Both signals are gated by `MediaQuery.disableAnimationsOf`.
+class MarqueeTrackRail extends StatefulWidget {
+  final List<Track> tracks;
+  final List<Post> posts;
+  final Set<String> selectedTrackIds;
+  final bool allSelected;
+  final int shuffleSeed;
+  final ValueChanged<String> onToggleTrack;
+  final VoidCallback onToggleAll;
+  final VoidCallback onReshuffle;
+
+  const MarqueeTrackRail({
+    super.key,
+    required this.tracks,
+    required this.posts,
+    required this.selectedTrackIds,
+    required this.allSelected,
+    required this.shuffleSeed,
+    required this.onToggleTrack,
+    required this.onToggleAll,
+    required this.onReshuffle,
+  });
+
+  @override
+  State<MarqueeTrackRail> createState() => _MarqueeTrackRailState();
+}
+
+class _MarqueeTrackRailState extends State<MarqueeTrackRail>
+    with TickerProviderStateMixin, WidgetsBindingObserver {
+  late final AnimationController _marqueeController;
+  late final AnimationController _pulseController;
+  Timer? _expandTimer;
+  bool _hoverPaused = false;
+  _RailMode _mode = _RailMode.automatic;
+
+  /// Memoized chip-width estimates keyed by label text. Rebuilt only when
+  /// the label set changes between builds.
+  Map<String, double> _chipWidthCache = const {};
+
+  // Snapshot of the last marquee parameters we asked the controller to
+  // run with — used to avoid restarting the animation on every build.
+  double _currentScrollDistance = 0;
+  bool _wantsMarquee = false;
+  bool _lastDisableAnimations = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _marqueeController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 10),
+    );
+    // Start the pulse at its visible mid-point so reduced-motion users
+    // see the static glow without ever ticking. `build` toggles the
+    // repeat on/off based on `MediaQuery.disableAnimationsOf`.
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: motionPulsePeriod,
+      value: 0.5,
+    );
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _expandTimer?.cancel();
+    _marqueeController.dispose();
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    // Defer to next frame: didChangeAppLifecycleState fires outside the
+    // build phase, but parent rebuilds triggered by `onReshuffle` should
+    // not race the resume-paint that Flutter is about to schedule.
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      widget.onReshuffle();
+      if (_mode == _RailMode.expanded) _exitExpanded();
+    });
+  }
+
+  void _enterExpanded() {
+    if (_mode == _RailMode.expanded) {
+      _restartExpandTimer();
+      return;
+    }
+    setState(() => _mode = _RailMode.expanded);
+    _marqueeController.stop();
+    _restartExpandTimer();
+  }
+
+  void _exitExpanded() {
+    if (_mode != _RailMode.expanded) return;
+    _expandTimer?.cancel();
+    _expandTimer = null;
+    setState(() => _mode = _RailMode.automatic);
+  }
+
+  void _restartExpandTimer() {
+    _expandTimer?.cancel();
+    _expandTimer = Timer(motionRailExpandedIdleTimeout, () {
+      if (mounted) _exitExpanded();
+    });
+  }
+
+  void _onChipTap(String trackId) {
+    widget.onToggleTrack(trackId);
+    if (_mode == _RailMode.expanded) _exitExpanded();
+  }
+
+  void _onAllChipTap() {
+    widget.onToggleAll();
+    if (_mode == _RailMode.expanded) _exitExpanded();
+  }
+
+  void _onHoverEnter() {
+    if (_hoverPaused) return;
+    _hoverPaused = true;
+    if (_marqueeController.isAnimating) _marqueeController.stop();
+  }
+
+  void _onHoverExit() {
+    if (!_hoverPaused) return;
+    _hoverPaused = false;
+    if (_wantsMarquee && !_lastDisableAnimations) {
+      _marqueeController.repeat();
+    }
+  }
+
+  double _estimateChipWidth(String label, TextStyle style) {
+    final cached = _chipWidthCache[label];
+    if (cached != null) return cached;
+    final tp = TextPainter(
+      text: TextSpan(text: label, style: style),
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    )..layout();
+    // Match _chip's horizontal padding (8 px each side) + border allowance.
+    final width = tp.width + 18;
+    _chipWidthCache[label] = width;
+    return width;
+  }
+
+  void _schedulePulse(bool disableAnimations) {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (disableAnimations) {
+        if (_pulseController.isAnimating) _pulseController.stop();
+      } else {
+        if (!_pulseController.isAnimating) {
+          _pulseController.repeat(reverse: true);
+        }
+      }
+    });
+  }
+
+  void _scheduleMarquee({
+    required bool wantsMarquee,
+    required double scrollDistance,
+    required bool disableAnimations,
+  }) {
+    if (_wantsMarquee == wantsMarquee &&
+        (_currentScrollDistance - scrollDistance).abs() < 0.5 &&
+        _lastDisableAnimations == disableAnimations) {
+      return;
+    }
+    _wantsMarquee = wantsMarquee;
+    _currentScrollDistance = scrollDistance;
+    _lastDisableAnimations = disableAnimations;
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (!wantsMarquee || disableAnimations || _hoverPaused) {
+        if (_marqueeController.isAnimating) _marqueeController.stop();
+        return;
+      }
+      final durationMs = (scrollDistance / motionMarqueeSpeedDp * 1000)
+          .round()
+          .clamp(1000, 120000);
+      _marqueeController.duration = Duration(milliseconds: durationMs);
+      _marqueeController.repeat();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final disableAnimations = MediaQuery.disableAnimationsOf(context);
+    _schedulePulse(disableAnimations);
+    final l10n = context.l10n;
+    final activity = computeTrackActivity(widget.posts);
+
+    // Reset chip-width cache if the label set changed between builds.
+    final currentLabels = {l10n.all, for (final t in widget.tracks) t.name};
+    if (!_chipWidthCache.keys.toSet().containsAll(currentLabels) ||
+        _chipWidthCache.length > currentLabels.length * 2) {
+      _chipWidthCache = <String, double>{};
+    }
+
+    const chipStyle = TextStyle(fontSize: fontSizeSm - 1); // 11
+    final allChipWidth = _estimateChipWidth(l10n.all, chipStyle) + spaceSm;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final maxWidth = constraints.maxWidth;
+          double tracksWidth = 0;
+          for (final t in widget.tracks) {
+            tracksWidth += _estimateChipWidth(t.name, chipStyle) + spaceXs;
+          }
+          final overflows = (allChipWidth + tracksWidth) > maxWidth;
+
+          if (_mode == _RailMode.expanded) {
+            _scheduleMarquee(
+              wantsMarquee: false,
+              scrollDistance: 0,
+              disableAnimations: disableAnimations,
+            );
+            return _buildExpanded(activity, chipStyle);
+          }
+
+          if (!overflows) {
+            _scheduleMarquee(
+              wantsMarquee: false,
+              scrollDistance: 0,
+              disableAnimations: disableAnimations,
+            );
+            return _buildStatic(activity, chipStyle);
+          }
+
+          _scheduleMarquee(
+            wantsMarquee: true,
+            scrollDistance: tracksWidth,
+            disableAnimations: disableAnimations,
+          );
+          return _buildMarquee(
+            activity,
+            chipStyle,
+            allChipWidth: allChipWidth,
+            scrollDistance: tracksWidth,
+            disableAnimations: disableAnimations,
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildStatic(
+    Map<String, TrackActivity> activity,
+    TextStyle chipStyle,
+  ) {
+    // Single-row layout used when all chips fit. We still apply the
+    // shuffleSeed so the order is consistent with what marquee mode
+    // would have shown if the screen had been narrower.
+    final shuffled = widget.shuffleSeed == 0
+        ? widget.tracks
+        : shuffleTracks(widget.tracks, widget.shuffleSeed);
+    return Row(
+      children: [
+        _buildAllChip(chipStyle),
+        const SizedBox(width: spaceSm),
+        Expanded(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            // Manual horizontal scroll is still allowed as an escape hatch
+            // if the estimate slightly mis-predicts overflow.
+            physics: const ClampingScrollPhysics(),
+            child: Row(
+              children: [
+                for (final track in shuffled)
+                  Padding(
+                    padding: const EdgeInsets.only(right: spaceXs),
+                    child: _buildTrackChip(track, activity, chipStyle),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMarquee(
+    Map<String, TrackActivity> activity,
+    TextStyle chipStyle, {
+    required double allChipWidth,
+    required double scrollDistance,
+    required bool disableAnimations,
+  }) {
+    final shuffled = widget.shuffleSeed == 0
+        ? widget.tracks
+        : shuffleTracks(widget.tracks, widget.shuffleSeed);
+
+    Widget chipRow() => Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final track in shuffled)
+          Padding(
+            padding: const EdgeInsets.only(right: spaceXs),
+            child: _buildTrackChip(track, activity, chipStyle),
+          ),
+      ],
+    );
+
+    final marqueeContent = LayoutBuilder(
+      builder: (context, marqueeConstraints) {
+        final viewportWidth = marqueeConstraints.maxWidth;
+        return ClipRect(
+          child: AnimatedBuilder(
+            animation: _marqueeController,
+            builder: (context, _) {
+              final progress = disableAnimations
+                  ? 0.0
+                  : _marqueeController.value;
+              final offset = -progress * scrollDistance;
+              return SizedBox(
+                width: viewportWidth,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Positioned(left: offset, top: 0, child: chipRow()),
+                    // Wrapping copy keeps the strip seamless past the
+                    // viewport edge for any scroll distance.
+                    Positioned(
+                      left: offset + scrollDistance,
+                      top: 0,
+                      child: chipRow(),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+
+    Widget marqueeArea = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: _enterExpanded,
+      child: Tooltip(
+        message: context.l10n.trackRailExpandHint,
+        child: marqueeContent,
+      ),
+    );
+
+    if (kIsWeb) {
+      marqueeArea = MouseRegion(
+        onEnter: (_) => _onHoverEnter(),
+        onExit: (_) => _onHoverExit(),
+        child: marqueeArea,
+      );
+    }
+
+    return Row(
+      children: [
+        _buildAllChip(chipStyle),
+        const SizedBox(width: spaceSm),
+        Expanded(child: marqueeArea),
+      ],
+    );
+  }
+
+  Widget _buildExpanded(
+    Map<String, TrackActivity> activity,
+    TextStyle chipStyle,
+  ) {
+    final sorted = sortByWeekActivity(widget.tracks, activity);
+    return Wrap(
+      spacing: spaceXs,
+      runSpacing: spaceXxs,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(right: spaceSm),
+          child: _buildAllChip(chipStyle),
+        ),
+        for (final track in sorted) _buildTrackChip(track, activity, chipStyle),
+      ],
+    );
+  }
+
+  Widget _buildAllChip(TextStyle chipStyle) {
+    return _Chip(
+      label: context.l10n.all,
+      selected: widget.allSelected,
+      selectedColor: colorInteractive,
+      borderRadius: BorderRadius.circular(radiusSm),
+      onTap: _onAllChipTap,
+      textStyle: chipStyle,
+    );
+  }
+
+  Widget _buildTrackChip(
+    Track track,
+    Map<String, TrackActivity> activity,
+    TextStyle chipStyle,
+  ) {
+    final stats = activity[track.id] ?? TrackActivity.empty;
+    final selected = widget.selectedTrackIds.contains(track.id);
+    return _HighlightedChip(
+      pulseAnimation: _pulseController,
+      disableAnimations: _lastDisableAnimations,
+      activity: stats,
+      trackColor: track.displayColor,
+      child: _Chip(
+        label: track.name,
+        selected: selected,
+        selectedColor: track.displayColor,
+        onTap: () => _onChipTap(track.id),
+        textStyle: chipStyle,
+      ),
+    );
+  }
+}
+
+/// The base chip — visually equivalent to the original `_TrackSelector`
+/// inner chip. Kept as a stateless leaf so the highlight wrapper can sit
+/// outside it without touching its rendering.
+class _Chip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final Color selectedColor;
+  final VoidCallback onTap;
+  final TextStyle textStyle;
+  final BorderRadius? borderRadius;
+
+  const _Chip({
+    required this.label,
+    required this.selected,
+    required this.selectedColor,
+    required this.onTap,
+    required this.textStyle,
+    this.borderRadius,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          borderRadius: borderRadius ?? BorderRadius.circular(10),
+          color: selected ? selectedColor.withValues(alpha: 0.2) : null,
+          border: Border.all(color: selected ? selectedColor : colorBorder),
+        ),
+        child: Text(
+          label,
+          style: textStyle.copyWith(
+            color: selected ? selectedColor : colorInteractive,
+            fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Adds the freshness pulse + active halo on top of a `_Chip`.
+///
+/// The pulse is driven by an `AnimationController` owned by the parent
+/// rail (one controller for the entire rail instead of one-per-chip
+/// keeps the widget tree light and stays well below the `Ticker` cost
+/// of many simultaneous animations).
+class _HighlightedChip extends StatelessWidget {
+  final Animation<double> pulseAnimation;
+  final bool disableAnimations;
+  final TrackActivity activity;
+  final Color trackColor;
+  final Widget child;
+
+  const _HighlightedChip({
+    required this.pulseAnimation,
+    required this.disableAnimations,
+    required this.activity,
+    required this.trackColor,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isFresh = activity.isFresh;
+    final isActive = activity.isActive;
+    if (!isFresh && !isActive) return child;
+
+    return AnimatedBuilder(
+      animation: pulseAnimation,
+      builder: (context, _) {
+        // Reduced-motion: settle on the midpoint of the pulse so the
+        // glow is visible without animating.
+        final t = disableAnimations ? 0.5 : pulseAnimation.value;
+        final shadows = <BoxShadow>[
+          if (isActive)
+            BoxShadow(
+              color: trackColor.withValues(alpha: highlightActiveHaloAlpha),
+              blurRadius: highlightActiveHaloBlur,
+              spreadRadius: 0.5,
+            ),
+          if (isFresh)
+            BoxShadow(
+              color: Colors.white.withValues(
+                alpha:
+                    highlightFreshAlphaMin +
+                    (highlightFreshAlphaMax - highlightFreshAlphaMin) * t,
+              ),
+              blurRadius:
+                  highlightFreshBlurMin +
+                  (highlightFreshBlurMax - highlightFreshBlurMin) * t,
+            ),
+        ];
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(10),
+            boxShadow: shadows,
+          ),
+          child: child,
+        );
+      },
+    );
+  }
+}

--- a/frontend/lib/widgets/timeline/marquee_track_rail.dart
+++ b/frontend/lib/widgets/timeline/marquee_track_rail.dart
@@ -31,8 +31,10 @@ const double _marqueeViewportHeight = 36;
 ///   - When the full chip set fits on one row → static row, no animation.
 ///   - When it overflows → "All" stays pinned at the left, the rest scroll
 ///     leftward as a marquee.
-///   - Tapping the marquee region expands into a multi-row Wrap (week
-///     activity descending) for selection. Selecting a chip, idling for
+///   - Tapping the marquee region expands into a multi-row `Wrap` for
+///     selection. The expanded view reuses the same shuffled order as
+///     the marquee so chips do not visibly reflow when the user swaps
+///     between modes. Selecting a chip, idling for
 ///     `motionRailExpandedIdleTimeout`, or the app returning to the
 ///     foreground collapses it back to the marquee.
 ///   - Tracks with posts in the last 24h pulse with a white glow; tracks

--- a/frontend/lib/widgets/timeline/marquee_track_rail.dart
+++ b/frontend/lib/widgets/timeline/marquee_track_rail.dart
@@ -72,6 +72,14 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
   bool _hoverPaused = false;
   _RailMode _mode = _RailMode.automatic;
 
+  /// Wall-clock time of the last `AppLifecycleState.paused`, used to
+  /// debounce the resume-driven reshuffle. iOS / Android raise
+  /// `paused → resumed` for transient system events (notification
+  /// banners, biometric prompts, control center, etc.), so we only
+  /// treat a *meaningfully long* absence as a genuine "user came back
+  /// to the app" signal.
+  DateTime? _lastPausedAt;
+
   /// Memoized chip-width estimates keyed by label text. Rebuilt only when
   /// the label set changes between builds.
   Map<String, double> _chipWidthCache = const {};
@@ -128,7 +136,24 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused) {
+      _lastPausedAt = DateTime.now();
+      return;
+    }
     if (state != AppLifecycleState.resumed) return;
+    // Only fire on a meaningfully long absence — transient system
+    // events (notification banners, biometric prompts, control
+    // center, push notifications) raise paused → resumed within
+    // seconds and should NOT bump the shuffleSeed or collapse the
+    // expanded view (the user did not "return to the app" in their
+    // mental model).
+    final pausedAt = _lastPausedAt;
+    _lastPausedAt = null;
+    if (pausedAt == null ||
+        DateTime.now().difference(pausedAt) <
+            const Duration(seconds: 60)) {
+      return;
+    }
     // Defer to next frame: didChangeAppLifecycleState fires outside the
     // build phase, but parent rebuilds triggered by `onReshuffle` should
     // not race the resume-paint that Flutter is about to schedule.
@@ -248,10 +273,17 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
     });
   }
 
-  void _schedulePulse(bool disableAnimations) {
+  void _schedulePulse({
+    required bool disableAnimations,
+    required bool hasAnyHighlight,
+  }) {
     SchedulerBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      if (disableAnimations) {
+      // Stop the ticker whenever the pulse would be invisible — no
+      // tracks have a fresh / active highlight, or the user has
+      // reduced-motion enabled. Idle artists (common in Phase 0)
+      // would otherwise spin a vsync-rate ticker forever.
+      if (disableAnimations || !hasAnyHighlight) {
         if (_pulseController.isAnimating) _pulseController.stop();
       } else {
         if (!_pulseController.isAnimating) {
@@ -288,23 +320,36 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
       final durationMs = (scrollDistance / motionMarqueeSpeedDp * 1000)
           .round()
           .clamp(1000, 120000);
-      // Fully reset before repeat — when the controller had been
-      // stopped mid-cycle (expand → idle 10s → marquee), repeat from
-      // the leftover value caused the visual scroll to start at the
-      // wrong offset and could appear frozen until the wrap copy
-      // caught up.
-      _marqueeController.reset();
-      _marqueeController.duration = Duration(milliseconds: durationMs);
-      _marqueeController.repeat();
+      final currentDurationMs =
+          _marqueeController.duration?.inMilliseconds ?? -1;
+      final needsReset =
+          !_marqueeController.isAnimating || currentDurationMs != durationMs;
+      if (needsReset) {
+        // Reset only when something material changed (cold start,
+        // viewport resized, expand → idle 10s collapse). Refreshes
+        // that only swap the shuffle order keep the scroll mid-cycle
+        // so the rail does not visibly jump back to its head.
+        _marqueeController.reset();
+        _marqueeController.duration = Duration(milliseconds: durationMs);
+      }
+      if (!_marqueeController.isAnimating) {
+        _marqueeController.repeat();
+      }
     });
   }
 
   @override
   Widget build(BuildContext context) {
     final disableAnimations = MediaQuery.disableAnimationsOf(context);
-    _schedulePulse(disableAnimations);
     final l10n = context.l10n;
     final activity = computeTrackActivity(widget.posts);
+    final hasAnyHighlight = activity.values.any(
+      (a) => a.isFresh || a.isActive,
+    );
+    _schedulePulse(
+      disableAnimations: disableAnimations,
+      hasAnyHighlight: hasAnyHighlight,
+    );
 
     // Reset chip-width cache if the label set changed between builds.
     final currentLabels = {l10n.all, for (final t in widget.tracks) t.name};
@@ -372,12 +417,10 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
     Map<String, TrackActivity> activity,
     TextStyle chipStyle,
   ) {
-    // Single-row layout used when all chips fit. We still apply the
-    // shuffleSeed so the order is consistent with what marquee mode
-    // would have shown if the screen had been narrower.
-    final shuffled = widget.shuffleSeed == 0
-        ? widget.tracks
-        : shuffleTracks(widget.tracks, widget.shuffleSeed);
+    // Single-row layout used when all chips fit. Use the backend order
+    // directly — a static row is a stable selector, so reshuffling on
+    // every pull-to-refresh / resume would only hurt muscle memory.
+    // The marquee path is the only place that benefits from rotation.
     return Row(
       children: [
         _buildAllChip(chipStyle),
@@ -390,7 +433,7 @@ class _MarqueeTrackRailState extends State<MarqueeTrackRail>
             physics: const ClampingScrollPhysics(),
             child: Row(
               children: [
-                for (final track in shuffled)
+                for (final track in widget.tracks)
                   Padding(
                     padding: const EdgeInsets.only(right: spaceXs),
                     child: _buildTrackChip(track, activity, chipStyle),

--- a/frontend/test/utils/track_activity_test.dart
+++ b/frontend/test/utils/track_activity_test.dart
@@ -112,27 +112,4 @@ void main() {
       expect(shuffleTracks(const [], 1), isEmpty);
     });
   });
-
-  group('sortByWeekActivity', () {
-    test('orders by descending weekPostCount, name as tiebreaker', () {
-      final t1 = _track('t1', 'Apple');
-      final t2 = _track('t2', 'Banana');
-      final t3 = _track('t3', 'Cherry');
-      final t4 = _track('t4', 'Date');
-
-      final activity = {
-        't1': const TrackActivity(isFresh: false, weekPostCount: 2),
-        't2': const TrackActivity(isFresh: false, weekPostCount: 5),
-        't3': const TrackActivity(isFresh: false, weekPostCount: 2),
-        // t4: no entry → treated as 0 → last
-      };
-
-      final sorted = sortByWeekActivity([t1, t2, t3, t4], activity);
-      expect(sorted.map((t) => t.id), ['t2', 't1', 't3', 't4']);
-    });
-
-    test('empty input returns empty list', () {
-      expect(sortByWeekActivity(const [], const {}), isEmpty);
-    });
-  });
 }

--- a/frontend/test/utils/track_activity_test.dart
+++ b/frontend/test/utils/track_activity_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gleisner_web/models/post.dart';
+import 'package:gleisner_web/models/track.dart';
+import 'package:gleisner_web/utils/track_activity.dart';
+
+Post _post(String id, String? trackId, DateTime createdAt) => Post(
+  id: id,
+  mediaType: MediaType.thought,
+  importance: 0.5,
+  createdAt: createdAt,
+  updatedAt: createdAt,
+  author: const PostAuthor(id: 'u1', username: 'tester'),
+  trackId: trackId,
+);
+
+Track _track(String id, String name) =>
+    Track(id: id, name: name, color: '#888888', createdAt: DateTime(2026));
+
+void main() {
+  group('computeTrackActivity', () {
+    final now = DateTime.utc(2026, 5, 25, 12, 0, 0);
+
+    test('counts posts within the 7-day window', () {
+      final posts = [
+        _post('1', 't1', now.subtract(const Duration(days: 1))),
+        _post('2', 't1', now.subtract(const Duration(days: 6, hours: 23))),
+        _post('3', 't1', now.subtract(const Duration(days: 8))), // out
+        _post('4', 't2', now.subtract(const Duration(days: 2))),
+      ];
+      final activity = computeTrackActivity(posts, now: now);
+
+      expect(activity['t1']?.weekPostCount, 2);
+      expect(activity['t2']?.weekPostCount, 1);
+      // t3 absent from input → must be absent from map (caller treats as empty)
+      expect(activity.containsKey('t3'), isFalse);
+    });
+
+    test('marks tracks with posts in the last 24h as fresh', () {
+      final posts = [
+        _post('1', 't1', now.subtract(const Duration(hours: 1))),
+        _post('2', 't2', now.subtract(const Duration(hours: 25))),
+      ];
+      final activity = computeTrackActivity(posts, now: now);
+
+      expect(activity['t1']?.isFresh, isTrue);
+      expect(activity['t2']?.isFresh, isFalse);
+    });
+
+    test('weekPostCount >= 5 marks track as active (halo eligible)', () {
+      final posts = [
+        for (var i = 0; i < 5; i++)
+          _post('p$i', 't1', now.subtract(Duration(days: i))),
+        for (var i = 0; i < 4; i++)
+          _post('q$i', 't2', now.subtract(Duration(days: i))),
+      ];
+      final activity = computeTrackActivity(posts, now: now);
+
+      expect(activity['t1']?.isActive, isTrue);
+      expect(activity['t2']?.isActive, isFalse);
+    });
+
+    test('posts without trackId are ignored', () {
+      final posts = [
+        _post('1', null, now.subtract(const Duration(hours: 2))),
+        _post('2', 't1', now.subtract(const Duration(hours: 2))),
+      ];
+      final activity = computeTrackActivity(posts, now: now);
+
+      expect(activity.length, 1);
+      expect(activity['t1']?.weekPostCount, 1);
+    });
+
+    test('returns empty map when no posts fall in the window', () {
+      final posts = [_post('1', 't1', now.subtract(const Duration(days: 30)))];
+      expect(computeTrackActivity(posts, now: now), isEmpty);
+    });
+  });
+
+  group('shuffleTracks', () {
+    test('returns a new list (does not mutate input)', () {
+      final tracks = [_track('t1', 'A'), _track('t2', 'B'), _track('t3', 'C')];
+      final inputCopy = List<Track>.from(tracks);
+      final shuffled = shuffleTracks(tracks, 42);
+
+      expect(tracks, equals(inputCopy));
+      expect(shuffled, isNot(same(tracks)));
+      expect(shuffled.length, tracks.length);
+    });
+
+    test('same seed yields same order (deterministic)', () {
+      final tracks = [
+        _track('t1', 'A'),
+        _track('t2', 'B'),
+        _track('t3', 'C'),
+        _track('t4', 'D'),
+      ];
+      final a = shuffleTracks(tracks, 12345);
+      final b = shuffleTracks(tracks, 12345);
+      expect(a.map((t) => t.id), equals(b.map((t) => t.id)));
+    });
+
+    test('different seeds usually produce different orders', () {
+      final tracks = [for (var i = 0; i < 6; i++) _track('t$i', 'name$i')];
+      final a = shuffleTracks(tracks, 1);
+      final b = shuffleTracks(tracks, 2);
+      // With 6! = 720 permutations the seed-1 and seed-2 outputs being
+      // identical would be a strong signal of a broken Random.
+      expect(a.map((t) => t.id), isNot(equals(b.map((t) => t.id))));
+    });
+
+    test('empty input returns empty list', () {
+      expect(shuffleTracks(const [], 1), isEmpty);
+    });
+  });
+
+  group('sortByWeekActivity', () {
+    test('orders by descending weekPostCount, name as tiebreaker', () {
+      final t1 = _track('t1', 'Apple');
+      final t2 = _track('t2', 'Banana');
+      final t3 = _track('t3', 'Cherry');
+      final t4 = _track('t4', 'Date');
+
+      final activity = {
+        't1': const TrackActivity(isFresh: false, weekPostCount: 2),
+        't2': const TrackActivity(isFresh: false, weekPostCount: 5),
+        't3': const TrackActivity(isFresh: false, weekPostCount: 2),
+        // t4: no entry → treated as 0 → last
+      };
+
+      final sorted = sortByWeekActivity([t1, t2, t3, t4], activity);
+      expect(sorted.map((t) => t.id), ['t2', 't1', 't3', 't4']);
+    });
+
+    test('empty input returns empty list', () {
+      expect(sortByWeekActivity(const [], const {}), isEmpty);
+    });
+  });
+}

--- a/frontend/test/widgets/timeline/marquee_track_rail_test.dart
+++ b/frontend/test/widgets/timeline/marquee_track_rail_test.dart
@@ -1,0 +1,232 @@
+// Widget tests for the `MarqueeTrackRail` UI.
+//
+// These cover the user-facing contract — chip rendering, tap callbacks,
+// marquee → expand → marquee transitions, and the highlight pulse
+// suppression under `MediaQuery.disableAnimations`. The marquee scroll
+// animation itself is not asserted frame-by-frame (Flutter's test ticker
+// makes that brittle); we verify only that the controller is started /
+// stopped in the right modes.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gleisner_web/l10n/app_localizations.dart';
+import 'package:gleisner_web/models/post.dart';
+import 'package:gleisner_web/models/track.dart';
+import 'package:gleisner_web/widgets/timeline/marquee_track_rail.dart';
+
+Track _track(String id, String name, [String color = '#888888']) =>
+    Track(id: id, name: name, color: color, createdAt: DateTime(2026));
+
+Post _post(String id, String trackId, DateTime createdAt) => Post(
+  id: id,
+  mediaType: MediaType.thought,
+  importance: 0.5,
+  createdAt: createdAt,
+  updatedAt: createdAt,
+  author: const PostAuthor(id: 'u1', username: 'tester'),
+  trackId: trackId,
+);
+
+Widget _harness({
+  required List<Track> tracks,
+  required List<Post> posts,
+  Set<String>? selectedTrackIds,
+  bool allSelected = true,
+  int shuffleSeed = 12345,
+  double width = 360,
+  void Function(String)? onToggleTrack,
+  VoidCallback? onToggleAll,
+  VoidCallback? onReshuffle,
+  bool disableAnimations = false,
+}) {
+  return MaterialApp(
+    locale: const Locale('en'),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: MediaQuery(
+      data: MediaQueryData(
+        size: Size(width, 800),
+        disableAnimations: disableAnimations,
+      ),
+      child: Scaffold(
+        body: SizedBox(
+          width: width,
+          child: MarqueeTrackRail(
+            tracks: tracks,
+            posts: posts,
+            selectedTrackIds:
+                selectedTrackIds ?? tracks.map((t) => t.id).toSet(),
+            allSelected: allSelected,
+            shuffleSeed: shuffleSeed,
+            onToggleTrack: onToggleTrack ?? (_) {},
+            onToggleAll: onToggleAll ?? () {},
+            onReshuffle: onReshuffle ?? () {},
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('MarqueeTrackRail', () {
+    testWidgets('renders the "All" chip plus every track in static mode', (
+      tester,
+    ) async {
+      final tracks = [_track('t1', 'Music'), _track('t2', 'Art')];
+      await tester.pumpWidget(
+        _harness(tracks: tracks, posts: const [], width: 600),
+      );
+      await tester.pump();
+
+      expect(find.text('All'), findsOneWidget);
+      expect(find.text('Music'), findsOneWidget);
+      expect(find.text('Art'), findsOneWidget);
+    });
+
+    testWidgets('tap on the "All" chip fires onToggleAll', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _harness(
+          tracks: [_track('t1', 'A')],
+          posts: const [],
+          width: 600,
+          onToggleAll: () => taps++,
+        ),
+      );
+      await tester.pump();
+      await tester.tap(find.text('All'));
+      expect(taps, 1);
+    });
+
+    testWidgets('tap on a track chip fires onToggleTrack with the track id', (
+      tester,
+    ) async {
+      String? toggledId;
+      await tester.pumpWidget(
+        _harness(
+          tracks: [_track('t1', 'A'), _track('t2', 'B')],
+          posts: const [],
+          width: 600,
+          onToggleTrack: (id) => toggledId = id,
+        ),
+      );
+      await tester.pump();
+      await tester.tap(find.text('B'));
+      expect(toggledId, 't2');
+    });
+
+    testWidgets('overflow → marquee mode wraps tracks in a Tooltip area', (
+      tester,
+    ) async {
+      // 12 wide track labels at a narrow viewport guarantees overflow even
+      // before TextPainter measures the exact pixel widths.
+      final tracks = [
+        for (var i = 0; i < 12; i++) _track('t$i', 'LongTrackName$i'),
+      ];
+      await tester.pumpWidget(
+        _harness(tracks: tracks, posts: const [], width: 200),
+      );
+      await tester.pump();
+
+      expect(find.byType(Tooltip), findsWidgets);
+    });
+
+    testWidgets('tapping the marquee area expands and reveals all tracks', (
+      tester,
+    ) async {
+      final tracks = [
+        for (var i = 0; i < 12; i++) _track('t$i', 'LongTrackName$i'),
+      ];
+      await tester.pumpWidget(
+        _harness(tracks: tracks, posts: const [], width: 200),
+      );
+      await tester.pump();
+      // Before tap: marquee viewport may not have laid out every chip on
+      // screen depending on offset. After expand we assert all are present.
+      await tester.tap(find.byType(Tooltip).first);
+      await tester.pump();
+
+      for (var i = 0; i < 12; i++) {
+        expect(find.text('LongTrackName$i'), findsOneWidget);
+      }
+    });
+
+    testWidgets(
+      'tapping a chip in the expanded view collapses back to marquee',
+      (tester) async {
+        final tracks = [
+          for (var i = 0; i < 12; i++) _track('t$i', 'LongTrackName$i'),
+        ];
+        String? toggledId;
+        await tester.pumpWidget(
+          _harness(
+            tracks: tracks,
+            posts: const [],
+            width: 200,
+            onToggleTrack: (id) => toggledId = id,
+          ),
+        );
+        await tester.pump();
+        await tester.tap(find.byType(Tooltip).first);
+        await tester.pump();
+
+        await tester.tap(find.text('LongTrackName3'));
+        await tester.pump();
+
+        expect(toggledId, 't3');
+        // After collapse, the rail goes back to marquee. The Tooltip
+        // wrapper is the marquee-mode marker.
+        expect(find.byType(Tooltip), findsWidgets);
+      },
+    );
+
+    testWidgets('disableAnimations renders without throwing or hanging', (
+      tester,
+    ) async {
+      final tracks = [
+        for (var i = 0; i < 12; i++) _track('t$i', 'LongTrackName$i'),
+      ];
+      final posts = [
+        _post('p1', 't0', DateTime.now().subtract(const Duration(hours: 2))),
+      ];
+      await tester.pumpWidget(
+        _harness(
+          tracks: tracks,
+          posts: posts,
+          width: 200,
+          disableAnimations: true,
+        ),
+      );
+      // Without reduced-motion, pumpAndSettle on an infinite marquee
+      // would time out. Reduced-motion should let it complete because
+      // the marquee never starts.
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+      expect(find.byType(MarqueeTrackRail), findsOneWidget);
+    });
+
+    testWidgets('highlight wraps fresh tracks in a DecoratedBox with shadow', (
+      tester,
+    ) async {
+      final freshPost = _post(
+        'p1',
+        't1',
+        DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      await tester.pumpWidget(
+        _harness(
+          tracks: [_track('t1', 'A'), _track('t2', 'B')],
+          posts: [freshPost],
+          width: 600,
+          disableAnimations: true,
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      // The highlight wrapper injects a DecoratedBox above the chip. It
+      // does not exist when no track is highlighted, so its presence
+      // here is the signal that the fresh path fired.
+      expect(find.byType(DecoratedBox), findsWidgets);
+    });
+  });
+}

--- a/frontend/test/widgets/timeline/marquee_track_rail_test.dart
+++ b/frontend/test/widgets/timeline/marquee_track_rail_test.dart
@@ -208,28 +208,47 @@ void main() {
       expect(find.byType(MarqueeTrackRail), findsOneWidget);
     });
 
-    testWidgets('highlight wraps fresh tracks in a DecoratedBox with shadow', (
-      tester,
-    ) async {
-      final freshPost = _post(
-        'p1',
-        't1',
-        DateTime.now().subtract(const Duration(hours: 1)),
-      );
-      await tester.pumpWidget(
-        _harness(
-          tracks: [_track('t1', 'A'), _track('t2', 'B')],
-          posts: [freshPost],
-          width: 600,
-          disableAnimations: true,
-        ),
-      );
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+    testWidgets(
+      'fresh tracks get a non-empty boxShadow; non-fresh tracks do not',
+      (tester) async {
+        final freshPost = _post(
+          'p1',
+          't1',
+          DateTime.now().subtract(const Duration(hours: 1)),
+        );
+        await tester.pumpWidget(
+          _harness(
+            tracks: [_track('t1', 'A'), _track('t2', 'B')],
+            posts: [freshPost],
+            width: 600,
+            disableAnimations: true,
+          ),
+        );
+        await tester.pumpAndSettle(const Duration(seconds: 1));
 
-      // The highlight wrapper injects a DecoratedBox above the chip. It
-      // does not exist when no track is highlighted, so its presence
-      // here is the signal that the fresh path fired.
-      expect(find.byType(DecoratedBox), findsWidgets);
-    });
+        // `find.byType(DecoratedBox)` is too lax — the base `_Chip`
+        // also uses a DecoratedBox for its border, so the count is
+        // never zero. We need to look specifically at DecoratedBoxes
+        // that carry a non-empty `boxShadow`, which is the cue the
+        // `_HighlightedChip` wrapper paints behind a fresh / active
+        // chip. Exactly one chip is fresh (t1), so we expect exactly
+        // one matching plate.
+        final withShadow = tester
+            .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+            .where((d) {
+              final dec = d.decoration;
+              return dec is BoxDecoration &&
+                  dec.boxShadow != null &&
+                  dec.boxShadow!.isNotEmpty;
+            })
+            .toList();
+
+        expect(
+          withShadow,
+          hasLength(1),
+          reason: 'only t1 is fresh — only one highlighted plate expected',
+        );
+      },
+    );
   });
 }

--- a/frontend/test/widgets/timeline/marquee_track_rail_test.dart
+++ b/frontend/test/widgets/timeline/marquee_track_rail_test.dart
@@ -152,34 +152,37 @@ void main() {
       }
     });
 
-    testWidgets(
-      'tapping a chip in the expanded view collapses back to marquee',
-      (tester) async {
-        final tracks = [
-          for (var i = 0; i < 12; i++) _track('t$i', 'LongTrackName$i'),
-        ];
-        String? toggledId;
-        await tester.pumpWidget(
-          _harness(
-            tracks: tracks,
-            posts: const [],
-            width: 200,
-            onToggleTrack: (id) => toggledId = id,
-          ),
-        );
-        await tester.pump();
-        await tester.tap(find.byType(Tooltip).first);
-        await tester.pump();
+    testWidgets('tapping a chip in the expanded view stays in expanded mode '
+        '(so multiple tracks can be toggled before idle collapses)', (
+      tester,
+    ) async {
+      final tracks = [
+        for (var i = 0; i < 12; i++) _track('t$i', 'LongTrackName$i'),
+      ];
+      final toggled = <String>[];
+      await tester.pumpWidget(
+        _harness(
+          tracks: tracks,
+          posts: const [],
+          width: 200,
+          onToggleTrack: toggled.add,
+        ),
+      );
+      await tester.pump();
+      await tester.tap(find.byType(Tooltip).first);
+      await tester.pump();
 
-        await tester.tap(find.text('LongTrackName3'));
-        await tester.pump();
+      await tester.tap(find.text('LongTrackName3'));
+      await tester.pump();
+      await tester.tap(find.text('LongTrackName5'));
+      await tester.pump();
 
-        expect(toggledId, 't3');
-        // After collapse, the rail goes back to marquee. The Tooltip
-        // wrapper is the marquee-mode marker.
-        expect(find.byType(Tooltip), findsWidgets);
-      },
-    );
+      expect(toggled, ['t3', 't5']);
+      // All chips still visible — rail did not collapse back to marquee.
+      for (var i = 0; i < 12; i++) {
+        expect(find.text('LongTrackName$i'), findsOneWidget);
+      }
+    });
 
     testWidgets('disableAnimations renders without throwing or hanging', (
       tester,


### PR DESCRIPTION
## Summary

- Replaces the two-row `Wrap`-based track filter at the top of the timeline (and the public artist page) with a single-row marquee that pins **All** at the left and scrolls the rest of the chips when they overflow.
- Tapping the marquee region expands into a multi-row `Wrap` that reuses the same shuffled order as the marquee. Idling 8 s (5 s after manual QA), selecting any chip in expanded mode, pull-to-refresh, or app foreground (debounced — only on absences > 60 s) collapse and reshuffle.
- Tracks with at least one post in the last 24 h **pulse with a white glow**; tracks with ≥ 5 posts in the last 7 days carry a **steady track-colored halo**. The pulse uses a per-chip phase offset so neighbors don't synchronize. Both signals honor `MediaQuery.disableAnimations`.
- Frontend-only — no backend or schema changes. Activity is aggregated from `TimelineState.posts` via a pure function with full unit coverage.

## Behavior

| Mode | When | Layout | Animation |
|------|------|--------|-----------|
| `static` | All chips fit on one row | Single horizontal row, **backend order preserved** | Highlights only (no marquee) |
| `marquee` | Chips overflow | "All" pinned + remainder scrolls leftward at 40 dp/s, **shuffled per load** | Marquee + highlights |
| `expanded` | User tapped the marquee | Multi-row `Wrap`, **same shuffled order as marquee** | Highlights only |

- Tab return between StatefulShellRoute tabs is **not** wired to reshuffle in this PR — see #442 (deferred from Phase 0 to avoid `listenManual` cross-tab issues).
- Activity aggregation currently reads from the paginated post slice in `TimelineState`. With Phase 0 data volume the slice is the whole timeline; the long-term fix is tracked in #443.

## Design decisions captured during QA

- **Expanded view does not sort by week activity.** The original spec was "week-activity descending" but manual QA found the reorder between marquee and expanded modes felt disruptive. Resolved by reusing the marquee's shuffled order in expanded mode. The originally implemented `sortByWeekActivity` helper was retired in commit `0103023`.
- **Static row preserves backend order.** Desktop / wide viewports do not benefit from per-load shuffling (it just breaks muscle memory), so `_buildStatic` ignores `shuffleSeed`.
- **App-foreground reshuffle is debounced.** `paused → resumed` round-trips shorter than 60 s (notification banner, biometric prompt, control center) skip the reshuffle.
- **Marquee position is preserved across reshuffles.** Only resets when the computed scroll duration actually changes, so refreshes that only rotate the order don't visibly jump.
- **Pulse ticker idles when nothing is highlighted.** The ticker only runs when at least one track has a fresh / active state.

## Test plan

- [x] `flutter test --platform chrome` — all tests green (17 new across `track_activity_test.dart` + `marquee_track_rail_test.dart`).
- [x] `dart analyze lib/` — clean.
- [x] `dart format --set-exit-if-changed` on the changed files — clean.
- [x] Manual smoke on web (Chrome desktop + DevTools mobile emulation): own timeline with many tracks → marquee; tap → expand; tap chip → toggles selection, stays expanded; 5 s idle → collapse to marquee.
- [x] Manual smoke with reduced-motion: pulse + marquee both static.
- [ ] Manual smoke on iOS Safari (post-merge).

## Follow-ups

- #442 — wire reshuffle into StatefulShellRoute tab returns.
- #443 — paginated-aware activity aggregation.
- Auto-review residual: Important I6 (mirror test on the highlight shadow) and Nice items N1-N7 — see PR comment for the full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)