### PR TITLE
chore: gitignore .claude/auto-review-log/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ build/
 # Claude Code worktrees & temporary plans
 .claude/worktrees/
 .claude/plans/
+.claude/auto-review-log/


### PR DESCRIPTION
## 概要

`/auto-review-loop` スキルが生成するローカルレビューログ `.claude/auto-review-log/` を `.gitignore` に追加し、追跡対象から除外する。

## 背景

PR #444 のレビュー時に `.claude/auto-review-log/feature_marquee-track-rail-20260525T174326/iter-1.md` がローカル生成され、yatima 側で submodule の untracked content として検出されていた。`.claude/worktrees/` `.claude/plans/` と同じくローカルの作業痕跡であり、コミットする性質のものではない。

## 変更

- `.gitignore` に `.claude/auto-review-log/` を 1 行追加

## 影響

- なし（ignore 追加のみ、コード変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)